### PR TITLE
Add OSC client utilities for EOS connection tools

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createOscServiceFromEnv, OscService } from '../services/osc/index.js';
+import { initializeOscClient } from '../services/osc/client.js';
 import { toolDefinitions } from '../tools/index.js';
 import type {
   ToolDefinition,
@@ -78,6 +79,7 @@ interface BootstrapContext {
 async function bootstrap(): Promise<BootstrapContext> {
   const tcpPort = Number.parseInt(process.env.MCP_TCP_PORT ?? '3032', 10);
   const oscService = createOscServiceFromEnv();
+  initializeOscClient(oscService);
 
   const server = new McpServer({
     name: 'eos-mcp-server',

--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -1,0 +1,141 @@
+import { OscClient, type ConnectResult } from '../client';
+import type { OscGateway } from '../client';
+import type { OscMessage } from '../index';
+
+describe('OscClient', () => {
+  class FakeOscService implements OscGateway {
+    public readonly sentMessages: OscMessage[] = [];
+
+    private readonly listeners = new Set<(message: OscMessage) => void>();
+
+    public send(message: OscMessage, _targetAddress?: string, _targetPort?: number): void {
+      this.sentMessages.push(message);
+    }
+
+    public onMessage(listener: (message: OscMessage) => void): () => void {
+      this.listeners.add(listener);
+      return () => {
+        this.listeners.delete(listener);
+      };
+    }
+
+    public emit(message: OscMessage): void {
+      this.listeners.forEach((listener) => listener(message));
+    }
+  }
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('realise un handshake et selectionne le protocole prefere', async () => {
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    const connectPromise = client.connect({ preferredProtocols: ['udp', 'tcp'] });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: '/eos/handshake/reply',
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify({ version: '3.2.0', protocols: ['udp', 'tcp'] })
+          }
+        ]
+      });
+
+      setTimeout(() => {
+        service.emit({
+          address: '/eos/protocol/select/reply',
+          args: [{ type: 's', value: 'ok' }]
+        });
+      }, 0);
+    });
+
+    const result = await connectPromise;
+
+    expect(result.status).toBe('ok');
+    expect(result.version).toBe('3.2.0');
+    expect(result.selectedProtocol).toBe('udp');
+    expect(result.protocolStatus).toBe('ok');
+    expect(service.sentMessages.map((message) => message.address)).toEqual([
+      '/eos/handshake',
+      '/eos/protocol/select'
+    ]);
+  });
+
+  it("retourne un statut timeout lorsque la console ne repond pas au handshake", async () => {
+    jest.useFakeTimers();
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    const promise = client.connect({ handshakeTimeoutMs: 10 });
+
+    jest.advanceTimersByTime(11);
+
+    await expect(promise).resolves.toMatchObject<Partial<ConnectResult>>({
+      status: 'timeout',
+      availableProtocols: [],
+      version: null
+    });
+  });
+
+  it('retourne le statut du ping et l\'echo', async () => {
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    const pingPromise = client.ping({ message: 'hello' });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: '/eos/ping/reply',
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify({ status: 'ok', echo: 'hello' })
+          }
+        ]
+      });
+    });
+
+    const result = await pingPromise;
+
+    expect(result.status).toBe('ok');
+    expect(result.echo).toBe('hello');
+    expect(result.roundtripMs).not.toBeNull();
+    expect(service.sentMessages[0]?.address).toBe('/eos/ping');
+  });
+
+  it('indique un timeout sur le ping lorsque la console ne repond pas', async () => {
+    jest.useFakeTimers();
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    const promise = client.ping({ timeoutMs: 5 });
+
+    jest.advanceTimersByTime(6);
+
+    await expect(promise).resolves.toMatchObject({ status: 'timeout' });
+  });
+
+  it('confirme la souscription OSC', async () => {
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    const subscribePromise = client.subscribe({ path: '/eos/out/ping', rateHz: 5 });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: '/eos/subscribe/reply',
+        args: [{ type: 's', value: 'ok' }]
+      });
+    });
+
+    const result = await subscribePromise;
+
+    expect(result.status).toBe('ok');
+    expect(result.path).toBe('/eos/out/ping');
+    expect(service.sentMessages[0]?.address).toBe('/eos/subscribe');
+  });
+});

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -1,0 +1,483 @@
+import type { OscMessage, OscService } from './index.js';
+
+const HANDSHAKE_REQUEST = '/eos/handshake';
+const HANDSHAKE_REPLY = '/eos/handshake/reply';
+const PROTOCOL_SELECT_REQUEST = '/eos/protocol/select';
+const PROTOCOL_SELECT_REPLY = '/eos/protocol/select/reply';
+const PING_REQUEST = '/eos/ping';
+const PING_REPLY = '/eos/ping/reply';
+const RESET_REQUEST = '/eos/reset';
+const RESET_REPLY = '/eos/reset/reply';
+const SUBSCRIBE_REQUEST = '/eos/subscribe';
+const SUBSCRIBE_REPLY = '/eos/subscribe/reply';
+
+const DEFAULT_OPERATION_TIMEOUT_MS = 1500;
+const DEFAULT_HANDSHAKE_TIMEOUT_MS = 2000;
+
+type PredicateResult<T> = T | null;
+
+export type StepStatus = 'ok' | 'timeout' | 'error' | 'skipped';
+
+export class OscTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OscTimeoutError';
+  }
+}
+
+export interface OscGateway {
+  send(message: OscMessage, targetAddress?: string, targetPort?: number): void;
+  onMessage(listener: (message: OscMessage) => void): () => void;
+}
+
+export interface OscClientConfig {
+  defaultTimeoutMs?: number;
+  handshakeTimeoutMs?: number;
+  protocolTimeoutMs?: number;
+}
+
+export interface TargetOptions {
+  targetAddress?: string;
+  targetPort?: number;
+}
+
+export interface ConnectOptions extends TargetOptions {
+  preferredProtocols?: string[];
+  handshakeTimeoutMs?: number;
+  protocolTimeoutMs?: number;
+  clientId?: string;
+}
+
+interface HandshakeData {
+  version: string | null;
+  protocols: string[];
+  raw: unknown;
+}
+
+export interface ConnectResult {
+  status: StepStatus;
+  version: string | null;
+  availableProtocols: string[];
+  selectedProtocol: string | null;
+  protocolStatus: StepStatus;
+  handshakePayload: unknown;
+  protocolResponse?: unknown;
+  error?: string;
+}
+
+export interface PingOptions extends TargetOptions {
+  message?: string;
+  timeoutMs?: number;
+}
+
+export interface PingResult {
+  status: StepStatus;
+  roundtripMs: number | null;
+  echo: string | null;
+  payload: unknown;
+  error?: string;
+}
+
+export interface ResetOptions extends TargetOptions {
+  full?: boolean;
+  timeoutMs?: number;
+}
+
+export interface ResetResult {
+  status: StepStatus;
+  payload: unknown;
+  error?: string;
+}
+
+export interface SubscribeOptions extends TargetOptions {
+  path: string;
+  enable?: boolean;
+  rateHz?: number;
+  timeoutMs?: number;
+}
+
+export interface SubscribeResult {
+  status: StepStatus;
+  path: string;
+  payload: unknown;
+  error?: string;
+}
+
+export class OscClient {
+  constructor(private readonly gateway: OscGateway, private readonly config: OscClientConfig = {}) {}
+
+  public async connect(options: ConnectOptions = {}): Promise<ConnectResult> {
+    const handshakeTimeout =
+      options.handshakeTimeoutMs ?? this.config.handshakeTimeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
+    const protocolTimeout =
+      options.protocolTimeoutMs ?? this.config.protocolTimeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS;
+
+    try {
+      const handshake = await this.performHandshake(options, handshakeTimeout);
+      const protocolResult = await this.selectProtocol(handshake, options, protocolTimeout);
+
+      return {
+        status: 'ok',
+        version: handshake.version,
+        availableProtocols: handshake.protocols,
+        selectedProtocol: protocolResult.selectedProtocol,
+        protocolStatus: protocolResult.status,
+        handshakePayload: handshake.raw,
+        protocolResponse: protocolResult.payload
+      };
+    } catch (error) {
+      if (error instanceof OscTimeoutError) {
+        return {
+          status: 'timeout',
+          version: null,
+          availableProtocols: [],
+          selectedProtocol: null,
+          protocolStatus: 'skipped',
+          handshakePayload: null,
+          error: error.message
+        };
+      }
+      throw error;
+    }
+  }
+
+  public async ping(options: PingOptions = {}): Promise<PingResult> {
+    const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS;
+    const message: OscMessage = {
+      address: PING_REQUEST,
+      args: []
+    };
+
+    if (options.message) {
+      message.args?.push({ type: 's', value: options.message });
+    }
+
+    const startedAt = Date.now();
+    this.send(message, options);
+
+    try {
+      const response = await this.waitForResponse(
+        (incoming) => (incoming.address === PING_REPLY ? incoming : null),
+        timeoutMs,
+        'Aucune reponse ping recu avant expiration'
+      );
+
+      const payload = this.extractPayload(response);
+      return {
+        status: 'ok',
+        roundtripMs: Date.now() - startedAt,
+        echo: this.extractEcho(payload),
+        payload
+      };
+    } catch (error) {
+      if (error instanceof OscTimeoutError) {
+        return {
+          status: 'timeout',
+          roundtripMs: null,
+          echo: null,
+          payload: null,
+          error: error.message
+        };
+      }
+      throw error;
+    }
+  }
+
+  public async reset(options: ResetOptions = {}): Promise<ResetResult> {
+    const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS;
+    const message: OscMessage = {
+      address: RESET_REQUEST,
+      args: [{ type: 'i', value: options.full ? 1 : 0 }]
+    };
+
+    this.send(message, options);
+
+    try {
+      const response = await this.waitForResponse(
+        (incoming) => (incoming.address === RESET_REPLY ? incoming : null),
+        timeoutMs,
+        'Aucune confirmation de reset recu avant expiration'
+      );
+      const payload = this.extractPayload(response);
+      return {
+        status: this.normaliseStatus(payload),
+        payload
+      };
+    } catch (error) {
+      if (error instanceof OscTimeoutError) {
+        return {
+          status: 'timeout',
+          payload: null,
+          error: error.message
+        };
+      }
+      throw error;
+    }
+  }
+
+  public async subscribe(options: SubscribeOptions): Promise<SubscribeResult> {
+    const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS;
+    const args = [
+      { type: 's', value: options.path },
+      { type: 'i', value: options.enable === false ? 0 : 1 }
+    ];
+
+    if (typeof options.rateHz === 'number') {
+      args.push({ type: 'f', value: options.rateHz });
+    }
+
+    this.send(
+      {
+        address: SUBSCRIBE_REQUEST,
+        args
+      },
+      options
+    );
+
+    try {
+      const response = await this.waitForResponse(
+        (incoming) => (incoming.address === SUBSCRIBE_REPLY ? incoming : null),
+        timeoutMs,
+        'Aucune confirmation de souscription recue avant expiration'
+      );
+      const payload = this.extractPayload(response);
+      return {
+        status: this.normaliseStatus(payload),
+        path: options.path,
+        payload
+      };
+    } catch (error) {
+      if (error instanceof OscTimeoutError) {
+        return {
+          status: 'timeout',
+          path: options.path,
+          payload: null,
+          error: error.message
+        };
+      }
+      throw error;
+    }
+  }
+
+  private send(message: OscMessage, options: TargetOptions): void {
+    this.gateway.send(message, options.targetAddress, options.targetPort);
+  }
+
+  private async performHandshake(options: ConnectOptions, timeout: number): Promise<HandshakeData> {
+    const args = [
+      { type: 's', value: options.clientId ?? 'mcp' }
+    ];
+
+    if (options.preferredProtocols?.length) {
+      args.push({ type: 's', value: JSON.stringify({ preferredProtocols: options.preferredProtocols }) });
+    }
+
+    this.send(
+      {
+        address: HANDSHAKE_REQUEST,
+        args
+      },
+      options
+    );
+
+    const response = await this.waitForResponse(
+      (incoming) => (incoming.address === HANDSHAKE_REPLY ? incoming : null),
+      timeout,
+      'Aucune reponse de handshake recue avant expiration'
+    );
+
+    return this.parseHandshakeResponse(response);
+  }
+
+  private async selectProtocol(
+    handshake: HandshakeData,
+    options: ConnectOptions,
+    timeout: number
+  ): Promise<{ status: StepStatus; selectedProtocol: string | null; payload?: unknown }> {
+    const protocols = handshake.protocols;
+    if (protocols.length === 0) {
+      return { status: 'skipped', selectedProtocol: null };
+    }
+
+    const candidates = options.preferredProtocols?.length ? options.preferredProtocols : protocols;
+    const selection = candidates.find((protocol) => protocols.includes(protocol));
+    if (!selection) {
+      return { status: 'skipped', selectedProtocol: null };
+    }
+
+    this.send(
+      {
+        address: PROTOCOL_SELECT_REQUEST,
+        args: [{ type: 's', value: selection }]
+      },
+      options
+    );
+
+    try {
+      const response = await this.waitForResponse(
+        (incoming) => (incoming.address === PROTOCOL_SELECT_REPLY ? incoming : null),
+        timeout,
+        'Aucune confirmation de protocole recue avant expiration'
+      );
+      const payload = this.extractPayload(response);
+      const status = this.normaliseStatus(payload);
+      return {
+        status,
+        selectedProtocol: selection,
+        payload
+      };
+    } catch (error) {
+      if (error instanceof OscTimeoutError) {
+        return {
+          status: 'timeout',
+          selectedProtocol: selection
+        };
+      }
+      throw error;
+    }
+  }
+
+  private parseHandshakeResponse(message: OscMessage): HandshakeData {
+    const payload = this.extractPayload(message);
+    let version: string | null = null;
+    let protocols: string[] = [];
+
+    if (payload && typeof payload === 'object') {
+      const maybeVersion = (payload as { version?: unknown }).version;
+      if (typeof maybeVersion === 'string') {
+        version = maybeVersion;
+      }
+
+      const maybeProtocols = (payload as { protocols?: unknown }).protocols;
+      if (Array.isArray(maybeProtocols)) {
+        protocols = maybeProtocols.filter((item): item is string => typeof item === 'string');
+      }
+    } else if (typeof payload === 'string') {
+      version = payload;
+    }
+
+    if (!version) {
+      const firstString = message.args?.find((arg) => typeof arg.value === 'string');
+      if (firstString && typeof firstString.value === 'string') {
+        version = firstString.value;
+      }
+    }
+
+    if (protocols.length === 0 && message.args) {
+      protocols = message.args
+        .map((arg) => arg.value)
+        .filter((value): value is string => typeof value === 'string')
+        .filter((value) => value.startsWith('proto:'))
+        .map((value) => value.replace('proto:', ''));
+    }
+
+    return {
+      version,
+      protocols,
+      raw: payload ?? message
+    };
+  }
+
+  private extractPayload(message: OscMessage): unknown {
+    const firstArg = message.args?.[0]?.value;
+    if (typeof firstArg === 'string') {
+      try {
+        return JSON.parse(firstArg);
+      } catch (error) {
+        return firstArg;
+      }
+    }
+    return firstArg ?? null;
+  }
+
+  private extractEcho(payload: unknown): string | null {
+    if (typeof payload === 'string') {
+      return payload;
+    }
+
+    if (payload && typeof payload === 'object') {
+      const maybeEcho = (payload as { echo?: unknown }).echo;
+      if (typeof maybeEcho === 'string') {
+        return maybeEcho;
+      }
+    }
+
+    return null;
+  }
+
+  private normaliseStatus(payload: unknown): StepStatus {
+    if (payload && typeof payload === 'object') {
+      const maybeStatus = (payload as { status?: unknown }).status;
+      if (typeof maybeStatus === 'string') {
+        return this.fromStatusString(maybeStatus);
+      }
+    }
+
+    if (typeof payload === 'string') {
+      return this.fromStatusString(payload);
+    }
+
+    return 'ok';
+  }
+
+  private fromStatusString(value: string): StepStatus {
+    const normalised = value.trim().toLowerCase();
+    if (normalised.includes('error') || normalised.includes('fail')) {
+      return 'error';
+    }
+
+    if (normalised.includes('timeout')) {
+      return 'timeout';
+    }
+
+    if (normalised.includes('skip')) {
+      return 'skipped';
+    }
+
+    return 'ok';
+  }
+
+  private async waitForResponse<T extends OscMessage>(
+    matcher: (message: OscMessage) => PredicateResult<T>,
+    timeoutMs: number,
+    timeoutMessage: string
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const dispose = this.gateway.onMessage((message: OscMessage) => {
+        const matched = matcher(message);
+        if (matched) {
+          cleanup();
+          resolve(matched);
+        }
+      });
+
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new OscTimeoutError(timeoutMessage));
+      }, timeoutMs);
+
+      const cleanup = (): void => {
+        clearTimeout(timer);
+        dispose();
+      };
+    });
+  }
+}
+
+let sharedClient: OscClient | null = null;
+
+export function initializeOscClient(service: OscService, config: OscClientConfig = {}): OscClient {
+  sharedClient = new OscClient(service, config);
+  return sharedClient;
+}
+
+export function setOscClient(client: OscClient | null): void {
+  sharedClient = client;
+}
+
+export function getOscClient(): OscClient {
+  if (!sharedClient) {
+    throw new Error('Le client OSC n\'est pas initialise. Appelez initializeOscClient avant d\'utiliser les outils.');
+  }
+  return sharedClient;
+}

--- a/src/tools/connection/eos_connect.ts
+++ b/src/tools/connection/eos_connect.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import { getOscClient } from '../../services/osc/client.js';
+import type { ToolDefinition } from '../types.js';
+
+const inputSchema = {
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional(),
+  preferredProtocols: z.array(z.string().min(1)).min(1).optional(),
+  handshakeTimeoutMs: z.number().int().positive().optional(),
+  protocolTimeoutMs: z.number().int().positive().optional(),
+  clientId: z.string().min(1).optional()
+};
+
+export const eosConnectTool: ToolDefinition<typeof inputSchema> = {
+  name: 'eos_connect',
+  config: {
+    title: 'Connexion OSC EOS',
+    description: 'Initie un handshake OSC avec la console EOS, choisit un protocole et retourne la version detectee.',
+    inputSchema
+  },
+  handler: async (args) => {
+    const schema = z.object(inputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const result = await client.connect(options);
+
+    const summaryParts = [
+      `Handshake: ${result.status}`,
+      `Protocoles disponibles: ${result.availableProtocols.length > 0 ? result.availableProtocols.join(', ') : 'aucun'}`,
+      `Protocole selectionne: ${result.selectedProtocol ?? 'non defini'} (${result.protocolStatus})`,
+      `Version detectee: ${result.version ?? 'inconnue'}`
+    ];
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: summaryParts.join('\n')
+        },
+        {
+          type: 'object',
+          data: result
+        }
+      ]
+    };
+  }
+};
+
+export default eosConnectTool;

--- a/src/tools/connection/eos_ping.ts
+++ b/src/tools/connection/eos_ping.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+import { getOscClient } from '../../services/osc/client.js';
+import type { ToolDefinition } from '../types.js';
+
+const inputSchema = {
+  message: z.string().min(1).optional(),
+  timeoutMs: z.number().int().positive().optional(),
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+};
+
+export const eosPingTool: ToolDefinition<typeof inputSchema> = {
+  name: 'eos_ping',
+  config: {
+    title: 'Ping OSC EOS',
+    description: 'Envoie un ping OSC a la console EOS et retourne le statut.',
+    inputSchema
+  },
+  handler: async (args) => {
+    const schema = z.object(inputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const result = await client.ping(options);
+
+    const lines = [
+      `Ping: ${result.status}`,
+      `Delai aller-retour: ${result.roundtripMs ?? 'n/a'} ms`,
+      `Echo: ${result.echo ?? 'aucun'}`
+    ];
+
+    if (result.error) {
+      lines.push(`Erreur: ${result.error}`);
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: lines.join('\n')
+        },
+        {
+          type: 'object',
+          data: result
+        }
+      ]
+    };
+  }
+};
+
+export default eosPingTool;

--- a/src/tools/connection/eos_reset.ts
+++ b/src/tools/connection/eos_reset.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import { getOscClient } from '../../services/osc/client.js';
+import type { ToolDefinition } from '../types.js';
+
+const inputSchema = {
+  full: z.boolean().optional(),
+  timeoutMs: z.number().int().positive().optional(),
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+};
+
+export const eosResetTool: ToolDefinition<typeof inputSchema> = {
+  name: 'eos_reset',
+  config: {
+    title: 'Reset OSC EOS',
+    description: 'Envoie une commande de reset a la console EOS.',
+    inputSchema
+  },
+  handler: async (args) => {
+    const schema = z.object(inputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const result = await client.reset(options);
+
+    const lines = [`Reset: ${result.status}`];
+    if (options.full) {
+      lines.push('Mode: complet');
+    } else {
+      lines.push('Mode: partiel');
+    }
+
+    if (result.error) {
+      lines.push(`Erreur: ${result.error}`);
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: lines.join('\n')
+        },
+        {
+          type: 'object',
+          data: result
+        }
+      ]
+    };
+  }
+};
+
+export default eosResetTool;

--- a/src/tools/connection/eos_subscribe.ts
+++ b/src/tools/connection/eos_subscribe.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import { getOscClient } from '../../services/osc/client.js';
+import type { ToolDefinition } from '../types.js';
+
+const inputSchema = {
+  path: z.string().min(1),
+  enable: z.boolean().optional(),
+  rateHz: z.number().positive().optional(),
+  timeoutMs: z.number().int().positive().optional(),
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+};
+
+export const eosSubscribeTool: ToolDefinition<typeof inputSchema> = {
+  name: 'eos_subscribe',
+  config: {
+    title: 'Souscription OSC EOS',
+    description: 'Active ou desactive une souscription OSC sur la console EOS.',
+    inputSchema
+  },
+  handler: async (args) => {
+    const schema = z.object(inputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const result = await client.subscribe(options);
+
+    const lines = [
+      `Souscription: ${result.status}`,
+      `Chemin: ${result.path}`
+    ];
+
+    if (typeof options.rateHz === 'number') {
+      lines.push(`Frequence: ${options.rateHz} Hz`);
+    }
+
+    if (options.enable === false) {
+      lines.push('Action: desactivation');
+    } else {
+      lines.push('Action: activation');
+    }
+
+    if (result.error) {
+      lines.push(`Erreur: ${result.error}`);
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: lines.join('\n')
+        },
+        {
+          type: 'object',
+          data: result
+        }
+      ]
+    };
+  }
+};
+
+export default eosSubscribeTool;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,16 @@
+import eosConnectTool from './connection/eos_connect.js';
+import eosPingTool from './connection/eos_ping.js';
+import eosResetTool from './connection/eos_reset.js';
+import eosSubscribeTool from './connection/eos_subscribe.js';
 import pingTool from './ping.js';
 import type { ToolDefinition } from './types.js';
 
-export const toolDefinitions: ToolDefinition[] = [pingTool];
+export const toolDefinitions: ToolDefinition[] = [
+  pingTool,
+  eosConnectTool,
+  eosPingTool,
+  eosResetTool,
+  eosSubscribeTool
+];
 
 export default toolDefinitions;


### PR DESCRIPTION
## Summary
- add an OSC client abstraction with handshake, protocol negotiation, and timeout handling
- expose EOS connection tools (connect, ping, reset, subscribe) with Zod input validation
- update the OSC service bootstrap and cover the client with mocked OSC interaction tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f51709f1f4832a866844384e648e78