### PR TITLE
Add EOS command tools and command-line support

### DIFF
--- a/src/tools/commands/__tests__/command_tools.test.ts
+++ b/src/tools/commands/__tests__/command_tools.test.ts
@@ -1,0 +1,136 @@
+import type { OscMessage } from '../../../services/osc/index';
+import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import {
+  eosCommandTool,
+  eosNewCommandTool,
+  eosCommandWithSubstitutionTool,
+  eosGetCommandLineTool
+} from '../command_tools';
+
+describe('command tools', () => {
+  class FakeOscService implements OscGateway {
+    public readonly sentMessages: OscMessage[] = [];
+
+    private readonly listeners = new Set<(message: OscMessage) => void>();
+
+    public send(message: OscMessage, _targetAddress?: string, _targetPort?: number): void {
+      this.sentMessages.push(message);
+    }
+
+    public onMessage(listener: (message: OscMessage) => void): () => void {
+      this.listeners.add(listener);
+      return () => {
+        this.listeners.delete(listener);
+      };
+    }
+
+    public emit(message: OscMessage): void {
+      this.listeners.forEach((listener) => listener(message));
+    }
+  }
+
+  let service: FakeOscService;
+
+  const runTool = async (tool: any, args: unknown): Promise<any> => {
+    const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
+    return handler(args, {});
+  };
+
+  beforeEach(() => {
+    service = new FakeOscService();
+    const client = new OscClient(service, { defaultTimeoutMs: 50 });
+    setOscClient(client);
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it('envoie une commande en respectant le terminateur', async () => {
+    const result = await runTool(eosCommandTool, { command: 'Chan 1', terminateWithEnter: true, user: 2 });
+
+    expect(service.sentMessages).toHaveLength(1);
+    expect(service.sentMessages[0]).toMatchObject({
+      address: '/eos/cmd',
+      args: [
+        { type: 's', value: 'Chan 1#' },
+        { type: 'i', value: 2 }
+      ]
+    });
+
+    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    expect(objectContent).toBeDefined();
+  });
+
+  it('applique la substitution et efface la ligne pour eos_new_command', async () => {
+    await runTool(eosNewCommandTool, {
+      command: 'Group %1 At %2',
+      substitutions: [5, 'Full'],
+      clearLine: true,
+      terminateWithEnter: true
+    });
+
+    expect(service.sentMessages).toHaveLength(1);
+    expect(service.sentMessages[0]).toMatchObject({
+      address: '/eos/newcmd',
+      args: [
+        { type: 's', value: 'Group 5 At Full#' }
+      ]
+    });
+  });
+
+  it('peut envoyer un new_command sans effacement prealable', async () => {
+    await runTool(eosNewCommandTool, {
+      command: 'Chan %1 At 50',
+      substitutions: [1],
+      clearLine: false
+    });
+
+    expect(service.sentMessages).toHaveLength(1);
+    expect(service.sentMessages[0]?.address).toBe('/eos/cmd');
+  });
+
+  it('envoie une commande via gabarit avec substitutions numerotees', async () => {
+    await runTool(eosCommandWithSubstitutionTool, {
+      template: 'Cue %1/%2 Go',
+      values: [1, 2],
+      terminateWithEnter: true
+    });
+
+    expect(service.sentMessages).toHaveLength(1);
+    expect(service.sentMessages[0]).toMatchObject({
+      address: '/eos/cmd',
+      args: [
+        { type: 's', value: 'Cue 1/2 Go#' }
+      ]
+    });
+  });
+
+  it('recupere la ligne de commande et decode le numero utilisateur', async () => {
+    const promise = runTool(eosGetCommandLineTool, { user: 4 });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: '/eos/get/cmd_line',
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify({ text: 'Chan 1 At 50', user: 'User 4' })
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+
+    expect(objectContent).toBeDefined();
+    expect((objectContent as { type: string; data: unknown }).data).toMatchObject({
+      status: 'ok',
+      text: 'Chan 1 At 50',
+      user: 4
+    });
+
+    expect(service.sentMessages[0]).toMatchObject({ address: '/eos/get/cmd_line' });
+  });
+});

--- a/src/tools/commands/command_tools.ts
+++ b/src/tools/commands/command_tools.ts
@@ -1,0 +1,240 @@
+import { z } from 'zod';
+import { getOscClient, type CommandLineState } from '../../services/osc/client';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+
+type SubstitutionValue = string | number | boolean;
+
+const targetOptionsSchema = {
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+};
+
+const substitutionsSchema = z.array(z.union([z.string(), z.number(), z.boolean()])).optional();
+
+const mappingAnnotations = (osc: string, cli: string): Record<string, unknown> => ({
+  mapping: {
+    osc,
+    cli
+  }
+});
+
+function ensureTerminator(command: string, terminate?: boolean): string {
+  if (!terminate) {
+    return command;
+  }
+
+  return command.endsWith('#') ? command : `${command}#`;
+}
+
+function applySubstitutions(template: string, values: SubstitutionValue[] = []): string {
+  const normalisedValues = values.map((value) => String(value));
+  return template.replace(/%(%|\d+)/g, (match, group) => {
+    if (group === '%') {
+      return '%';
+    }
+
+    const index = Number.parseInt(group, 10);
+    if (Number.isNaN(index) || index < 1) {
+      return '';
+    }
+
+    const replacement = normalisedValues[index - 1];
+    return replacement ?? '';
+  });
+}
+
+function buildOscDescriptor(command: string, user?: number | null): Record<string, unknown> {
+  const args: Array<{ type: string; value: string | number }> = [{ type: 's', value: command }];
+  if (typeof user === 'number' && Number.isFinite(user)) {
+    args.push({ type: 'i', value: Math.trunc(user) });
+  }
+  return { args };
+}
+
+function formatSendResult(command: string, user: number | null, oscAddress: string): ToolExecutionResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Commande envoyee sur ${oscAddress}: ${command}`
+      },
+      {
+        type: 'object',
+        data: {
+          command,
+          user,
+          osc: {
+            address: oscAddress,
+            ...buildOscDescriptor(command, user)
+          },
+          cli: {
+            text: command
+          }
+        }
+      }
+    ]
+  } as ToolExecutionResult;
+}
+
+function formatCommandLineState(result: CommandLineState): ToolExecutionResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: result.status === 'ok'
+          ? `Ligne de commande utilisateur ${result.user ?? 'global'}: ${result.text}`
+          : `Lecture de la ligne de commande indisponible (${result.status})`
+      },
+      {
+        type: 'object',
+        data: result
+      }
+    ]
+  } as ToolExecutionResult;
+}
+
+const commandInputSchema = {
+  command: z.string().min(1, 'La commande ne peut pas etre vide'),
+  terminateWithEnter: z.boolean().optional(),
+  user: z.number().int().min(0).optional(),
+  ...targetOptionsSchema
+};
+
+export const eosCommandTool: ToolDefinition<typeof commandInputSchema> = {
+  name: 'eos_command',
+  config: {
+    title: 'Commande EOS',
+    description: 'Envoie du texte sur la ligne de commande existante de la console.',
+    inputSchema: commandInputSchema,
+    annotations: mappingAnnotations('/eos/cmd', 'command_line')
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(commandInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const command = ensureTerminator(options.command, options.terminateWithEnter);
+
+    client.sendCommand(command, {
+      user: options.user,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort
+    });
+
+    return formatSendResult(command, options.user ?? null, '/eos/cmd');
+  }
+};
+
+const newCommandInputSchema = {
+  command: z.string().min(1, 'La commande ne peut pas etre vide'),
+  substitutions: substitutionsSchema,
+  terminateWithEnter: z.boolean().optional(),
+  clearLine: z.boolean().optional(),
+  user: z.number().int().min(0).optional(),
+  ...targetOptionsSchema
+};
+
+export const eosNewCommandTool: ToolDefinition<typeof newCommandInputSchema> = {
+  name: 'eos_new_command',
+  config: {
+    title: 'Nouvelle commande EOS',
+    description: 'Efface optionnellement la ligne de commande puis envoie le texte fourni.',
+    inputSchema: newCommandInputSchema,
+    annotations: mappingAnnotations('/eos/newcmd', 'command_line_new')
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(newCommandInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const substituted = applySubstitutions(options.command, options.substitutions ?? []);
+    const command = ensureTerminator(substituted, options.terminateWithEnter);
+    const shouldClear = options.clearLine !== false;
+
+    if (shouldClear) {
+      client.sendNewCommand(command, {
+        user: options.user,
+        targetAddress: options.targetAddress,
+        targetPort: options.targetPort
+      });
+      return formatSendResult(command, options.user ?? null, '/eos/newcmd');
+    }
+
+    client.sendCommand(command, {
+      user: options.user,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort
+    });
+
+    return formatSendResult(command, options.user ?? null, '/eos/cmd');
+  }
+};
+
+const substitutionCommandInputSchema = {
+  template: z.string().min(1, 'Le gabarit ne peut pas etre vide'),
+  values: substitutionsSchema,
+  terminateWithEnter: z.boolean().optional(),
+  user: z.number().int().min(0).optional(),
+  ...targetOptionsSchema
+};
+
+export const eosCommandWithSubstitutionTool: ToolDefinition<typeof substitutionCommandInputSchema> = {
+  name: 'eos_command_with_substitution',
+  config: {
+    title: 'Commande avec substitution',
+    description: 'Applique des substitutions %1, %2, ... puis envoie la commande.',
+    inputSchema: substitutionCommandInputSchema,
+    annotations: mappingAnnotations('/eos/cmd', 'command_line_template')
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(substitutionCommandInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const substituted = applySubstitutions(options.template, options.values ?? []);
+    const command = ensureTerminator(substituted, options.terminateWithEnter);
+
+    client.sendCommand(command, {
+      user: options.user,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort
+    });
+
+    return formatSendResult(command, options.user ?? null, '/eos/cmd');
+  }
+};
+
+const commandLineInputSchema = {
+  user: z.number().int().min(0).optional(),
+  timeoutMs: z.number().int().positive().optional(),
+  ...targetOptionsSchema
+};
+
+export const eosGetCommandLineTool: ToolDefinition<typeof commandLineInputSchema> = {
+  name: 'eos_get_command_line',
+  config: {
+    title: 'Lecture de la ligne de commande EOS',
+    description: 'Recupere le contenu courant de la ligne de commande via OSC Get.',
+    inputSchema: commandLineInputSchema,
+    annotations: mappingAnnotations('/eos/get/cmd_line', 'command_line_query')
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(commandLineInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const result = await client.getCommandLine({
+      user: options.user,
+      timeoutMs: options.timeoutMs,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort
+    });
+
+    return formatCommandLineState(result);
+  }
+};
+
+export const commandTools = [
+  eosCommandTool,
+  eosNewCommandTool,
+  eosCommandWithSubstitutionTool,
+  eosGetCommandLineTool
+] as ToolDefinition[];
+
+export default commandTools;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,6 +2,7 @@ import eosConnectTool from './connection/eos_connect.js';
 import eosPingTool from './connection/eos_ping.js';
 import eosResetTool from './connection/eos_reset.js';
 import eosSubscribeTool from './connection/eos_subscribe.js';
+import commandTools from './commands/command_tools.js';
 import pingTool from './ping.js';
 import type { ToolDefinition } from './types.js';
 
@@ -10,7 +11,8 @@ export const toolDefinitions: ToolDefinition[] = [
   eosConnectTool,
   eosPingTool,
   eosResetTool,
-  eosSubscribeTool
+  eosSubscribeTool,
+  ...commandTools
 ];
 
 export default toolDefinitions;


### PR DESCRIPTION
## Summary
- add command-oriented tool definitions with OSC/CLI mapping and substitution support
- extend the OSC client with command send/get helpers and command-line decoding
- cover command conversions with simulated OSC fixtures and integrate the tools in the registry

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f519fb4790832a917d85dec7f8bb50