### PR TITLE
Add cue control tools with structured state parsing

### DIFF
--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -11,6 +11,19 @@ export const oscMappings = {
     level: '/eos/group/level',
     info: '/eos/group/info',
     list: '/eos/group/list'
+  },
+  cues: {
+    fire: '/eos/cue/fire',
+    go: '/eos/cue/go',
+    stopBack: '/eos/cue/stop/back',
+    select: '/eos/cue/select',
+    info: '/eos/get/cue',
+    list: '/eos/get/cuelist',
+    cuelistInfo: '/eos/get/cuelist/info',
+    bankCreate: '/eos/cuelist/bank/create',
+    bankPage: '/eos/cuelist/bank/page',
+    active: '/eos/get/active/cue',
+    pending: '/eos/get/pending/cue'
   }
 } as const;
 

--- a/src/tools/cues/__tests__/cues.test.ts
+++ b/src/tools/cues/__tests__/cues.test.ts
@@ -1,0 +1,146 @@
+import type { OscMessage } from '../../../services/osc/index';
+import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { oscMappings } from '../../../services/osc/mappings';
+import {
+  eosCueGoTool,
+  eosCueStopBackTool,
+  eosGetActiveCueTool
+} from '../index';
+
+type ToolHandler = (args: unknown, extra?: unknown) => Promise<any>;
+
+class FakeOscService implements OscGateway {
+  public readonly sentMessages: OscMessage[] = [];
+
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  public send(message: OscMessage): void {
+    this.sentMessages.push(message);
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public emit(message: OscMessage): void {
+    this.listeners.forEach((listener) => listener(message));
+  }
+}
+
+describe('cue tools', () => {
+  let service: FakeOscService;
+
+  const runTool = async (tool: any, args: unknown): Promise<any> => {
+    const handler = tool.handler as ToolHandler;
+    return handler(args, {});
+  };
+
+  beforeEach(() => {
+    service = new FakeOscService();
+    const client = new OscClient(service, { defaultTimeoutMs: 50 });
+    setOscClient(client);
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it('enchaine un go puis un stop back sur la meme liste', async () => {
+    await runTool(eosCueGoTool, { cuelist_number: 5 });
+    await runTool(eosCueStopBackTool, { cuelist_number: 5, back: true });
+
+    expect(service.sentMessages).toHaveLength(2);
+
+    const goMessage = service.sentMessages[0];
+    expect(goMessage.address).toBe(oscMappings.cues.go);
+    const goPayload = JSON.parse(String(goMessage?.args?.[0]?.value ?? '{}'));
+    expect(goPayload).toMatchObject({ cuelist: 5 });
+
+    const stopMessage = service.sentMessages[1];
+    expect(stopMessage.address).toBe(oscMappings.cues.stopBack);
+    const stopPayload = JSON.parse(String(stopMessage?.args?.[0]?.value ?? '{}'));
+    expect(stopPayload).toMatchObject({ cuelist: 5, back: true });
+  });
+
+  it('normalise les donnees renvoyees par get_active_cue', async () => {
+    const promise = runTool(eosGetActiveCueTool, { cuelist_number: 1 });
+
+    queueMicrotask(() => {
+      const payload = {
+        status: 'ok',
+        cue: {
+          cuelist: 1,
+          cue: '2',
+          cue_part: 1,
+          label: 'Transition',
+          timings: {
+            up: '5.0',
+            down: '10.0',
+            focus: '2.5'
+          },
+          flags: {
+            mark: 1,
+            block: 0,
+            assert: true,
+            solo: 'false',
+            timecode: 'yes'
+          },
+          link: '2.5',
+          follow: '3.5',
+          hang: '00:02',
+          loop: 0,
+          notes: 'Example'
+        },
+        duration: '45',
+        progress: '50%',
+        remaining: '00:30'
+      };
+
+      service.emit({
+        address: oscMappings.cues.active,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify(payload)
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    expect(objectContent).toBeDefined();
+
+    const cueState = objectContent.data.cue;
+    expect(cueState.details.identifier).toEqual({
+      cuelistNumber: 1,
+      cueNumber: '2',
+      cuePart: 1
+    });
+    expect(cueState.details.timings).toMatchObject({
+      up: 5,
+      down: 10,
+      focus: 2.5
+    });
+    expect(cueState.details.flags).toMatchObject({
+      mark: true,
+      block: false,
+      assert: true,
+      solo: false,
+      timecode: true
+    });
+    expect(cueState.details.links).toMatchObject({
+      link: '2.5',
+      follow: 3.5,
+      hang: 2,
+      loop: 0
+    });
+    expect(cueState.details.notes).toBe('Example');
+    expect(cueState.durationSeconds).toBe(45);
+    expect(cueState.progressPercent).toBe(50);
+    expect(cueState.remainingSeconds).toBe(30);
+  });
+});

--- a/src/tools/cues/common.ts
+++ b/src/tools/cues/common.ts
@@ -1,0 +1,153 @@
+import { z, type ZodRawShape } from 'zod';
+import type { OscMessageArgument } from '../../services/osc/index.js';
+import type { ToolExecutionResult } from '../types';
+import type { CueIdentifier } from './types';
+
+export const targetOptionsSchema = {
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+} satisfies ZodRawShape;
+
+export const cuelistNumberSchema = z.number().int().min(1).max(99999);
+
+export const cueNumberSchema = z.union([z.string().min(1), z.number()]);
+
+export const cuePartSchema = z.number().int().min(0).max(99);
+
+export interface CueCommandOptions {
+  cuelist_number?: number | null;
+  cue_number?: string | number | null;
+  cue_part?: number | null;
+}
+
+export function buildJsonArgs(payload: Record<string, unknown>): OscMessageArgument[] {
+  return [
+    {
+      type: 's' as const,
+      value: JSON.stringify(payload)
+    }
+  ];
+}
+
+export function extractTargetOptions<T extends { targetAddress?: string; targetPort?: number }>(
+  options: T
+): { targetAddress?: string; targetPort?: number } {
+  const target: { targetAddress?: string; targetPort?: number } = {};
+  if (options.targetAddress) {
+    target.targetAddress = options.targetAddress;
+  }
+  if (typeof options.targetPort === 'number') {
+    target.targetPort = options.targetPort;
+  }
+  return target;
+}
+
+function normaliseCueNumberValue(value: string | number | null | undefined): string | null {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+    return String(value);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  return null;
+}
+
+function normaliseCuePartValue(value: number | null | undefined): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const truncated = Math.trunc(value);
+    return truncated >= 0 ? truncated : null;
+  }
+  return null;
+}
+
+export function createCueIdentifierFromOptions(options: CueCommandOptions): CueIdentifier {
+  const cuelistNumber =
+    typeof options.cuelist_number === 'number' && Number.isFinite(options.cuelist_number)
+      ? Math.trunc(options.cuelist_number)
+      : null;
+
+  const cueNumber = normaliseCueNumberValue(options.cue_number);
+  const cuePart = normaliseCuePartValue(options.cue_part);
+
+  return {
+    cuelistNumber,
+    cueNumber,
+    cuePart
+  };
+}
+
+export function buildCueCommandPayload(
+  identifier: CueIdentifier,
+  options: { defaultPart?: number | null } = {}
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+
+  if (identifier.cuelistNumber != null) {
+    payload.cuelist = identifier.cuelistNumber;
+    payload.list = identifier.cuelistNumber;
+    payload.cuelist_number = identifier.cuelistNumber;
+  }
+
+  if (identifier.cueNumber != null) {
+    payload.cue = identifier.cueNumber;
+    payload.cue_number = identifier.cueNumber;
+    payload.number = identifier.cueNumber;
+  }
+
+  const part = identifier.cuePart ?? options.defaultPart ?? null;
+  if (part != null) {
+    payload.part = part;
+    payload.cue_part = part;
+  }
+
+  return payload;
+}
+
+export function formatCueDescription(identifier: CueIdentifier): string {
+  const parts: string[] = [];
+  if (identifier.cuelistNumber != null) {
+    parts.push(`liste ${identifier.cuelistNumber}`);
+  }
+  if (identifier.cueNumber != null) {
+    const suffix = identifier.cuePart != null && identifier.cuePart !== 0 ? `.${identifier.cuePart}` : '';
+    parts.push(`cue ${identifier.cueNumber}${suffix}`);
+  }
+  if (parts.length === 0) {
+    return 'cue';
+  }
+  return parts.join(' ');
+}
+
+export function createCueCommandResult(
+  action: string,
+  identifier: CueIdentifier,
+  payload: Record<string, unknown>,
+  oscAddress: string,
+  extra: Record<string, unknown> = {}
+): ToolExecutionResult {
+  const text = `Commande ${action} envoyee pour ${formatCueDescription(identifier)}.`;
+  return {
+    content: [
+      { type: 'text', text },
+      {
+        type: 'object',
+        data: {
+          action,
+          identifier,
+          request: payload,
+          osc: {
+            address: oscAddress,
+            args: payload
+          },
+          ...extra
+        }
+      }
+    ]
+  } as ToolExecutionResult;
+}

--- a/src/tools/cues/cuelist_bank_create.ts
+++ b/src/tools/cues/cuelist_bank_create.ts
@@ -1,0 +1,85 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+import {
+  buildCueCommandPayload,
+  buildJsonArgs,
+  createCueIdentifierFromOptions,
+  cuelistNumberSchema,
+  extractTargetOptions,
+  formatCueDescription,
+  targetOptionsSchema
+} from './common';
+
+const bankCreateInputSchema = {
+  bank_index: z.number().int().min(0),
+  cuelist_number: cuelistNumberSchema,
+  num_prev_cues: z.number().int().min(0),
+  num_pending_cues: z.number().int().min(0),
+  offset: z.number().int().optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+export const eosCuelistBankCreateTool: ToolDefinition<typeof bankCreateInputSchema> = {
+  name: 'eos_cuelist_bank_create',
+  config: {
+    title: 'Creation de bank de cuelist',
+    description: 'Configure un bank OSC pour surveiller une liste de cues.',
+    inputSchema: bankCreateInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.cues.bankCreate
+      }
+    }
+  },
+  handler: async (args) => {
+    const schema = z.object(bankCreateInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const identifier = createCueIdentifierFromOptions(options);
+    const payload = {
+      ...buildCueCommandPayload({
+        cuelistNumber: identifier.cuelistNumber,
+        cueNumber: null,
+        cuePart: null
+      }),
+      bank: options.bank_index,
+      previous: options.num_prev_cues,
+      pending: options.num_pending_cues
+    } as Record<string, unknown>;
+
+    if (typeof options.offset === 'number') {
+      payload.offset = Math.trunc(options.offset);
+    }
+
+    client.sendMessage(oscMappings.cues.bankCreate, buildJsonArgs(payload), extractTargetOptions(options));
+
+    const text = `Bank ${options.bank_index} assigne a ${formatCueDescription({
+      ...identifier,
+      cueNumber: null,
+      cuePart: null
+    })}`;
+
+    const result: ToolExecutionResult = {
+      content: [
+        { type: 'text', text },
+        {
+          type: 'object',
+          data: {
+            action: 'cuelist_bank_create',
+            request: payload,
+            osc: {
+              address: oscMappings.cues.bankCreate,
+              args: payload
+            }
+          }
+        }
+      ]
+    } as ToolExecutionResult;
+
+    return result;
+  }
+};
+
+export default eosCuelistBankCreateTool;

--- a/src/tools/cues/cuelist_bank_page.ts
+++ b/src/tools/cues/cuelist_bank_page.ts
@@ -1,0 +1,59 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+import { buildJsonArgs, extractTargetOptions, targetOptionsSchema } from './common';
+
+const bankPageInputSchema = {
+  bank_index: z.number().int().min(0),
+  delta: z.number().int(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+export const eosCuelistBankPageTool: ToolDefinition<typeof bankPageInputSchema> = {
+  name: 'eos_cuelist_bank_page',
+  config: {
+    title: 'Navigation de bank de cuelist',
+    description: 'Change de page dans un bank de cues en ajoutant le delta specifie.',
+    inputSchema: bankPageInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.cues.bankPage
+      }
+    }
+  },
+  handler: async (args) => {
+    const schema = z.object(bankPageInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const payload = {
+      bank: options.bank_index,
+      delta: options.delta
+    };
+
+    client.sendMessage(oscMappings.cues.bankPage, buildJsonArgs(payload), extractTargetOptions(options));
+
+    const text = `Bank ${options.bank_index}: changement de page (${options.delta >= 0 ? '+' : ''}${options.delta})`;
+
+    const result: ToolExecutionResult = {
+      content: [
+        { type: 'text', text },
+        {
+          type: 'object',
+          data: {
+            action: 'cuelist_bank_page',
+            request: payload,
+            osc: {
+              address: oscMappings.cues.bankPage,
+              args: payload
+            }
+          }
+        }
+      ]
+    } as ToolExecutionResult;
+
+    return result;
+  }
+};
+
+export default eosCuelistBankPageTool;

--- a/src/tools/cues/cuelist_get_info.ts
+++ b/src/tools/cues/cuelist_get_info.ts
@@ -1,0 +1,76 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+import {
+  buildCueCommandPayload,
+  createCueIdentifierFromOptions,
+  cuelistNumberSchema,
+  extractTargetOptions,
+  formatCueDescription,
+  targetOptionsSchema
+} from './common';
+import { mapCuelistInfo } from './mappers';
+
+const cuelistInfoInputSchema = {
+  cuelist_number: cuelistNumberSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+export const eosCuelistGetInfoTool: ToolDefinition<typeof cuelistInfoInputSchema> = {
+  name: 'eos_cuelist_get_info',
+  config: {
+    title: 'Informations de cuelist',
+    description: 'Recupere les attributs d\'une liste de cues (modes, flags...).',
+    inputSchema: cuelistInfoInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.cues.cuelistInfo
+      }
+    }
+  },
+  handler: async (args) => {
+    const schema = z.object(cuelistInfoInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const identifier = createCueIdentifierFromOptions(options);
+    const payload = buildCueCommandPayload({
+      cuelistNumber: identifier.cuelistNumber,
+      cueNumber: null,
+      cuePart: null
+    });
+
+    const response = await client.requestJson(oscMappings.cues.cuelistInfo, {
+      payload,
+      ...extractTargetOptions(options)
+    });
+
+    const info = mapCuelistInfo(response.data, identifier);
+
+    const listLabel = formatCueDescription({ ...identifier, cueNumber: null, cuePart: null });
+    const text = `${listLabel}: ${info.label ?? 'sans label'}`;
+
+    const result: ToolExecutionResult = {
+      content: [
+        { type: 'text', text },
+        {
+          type: 'object',
+          data: {
+            action: 'cuelist_get_info',
+            status: response.status,
+            request: payload,
+            cuelist: info,
+            osc: {
+              address: oscMappings.cues.cuelistInfo,
+              response: response.payload
+            }
+          }
+        }
+      ]
+    } as ToolExecutionResult;
+
+    return result;
+  }
+};
+
+export default eosCuelistGetInfoTool;

--- a/src/tools/cues/fire.ts
+++ b/src/tools/cues/fire.ts
@@ -1,0 +1,65 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition } from '../types';
+import {
+  buildCueCommandPayload,
+  buildJsonArgs,
+  createCueCommandResult,
+  createCueIdentifierFromOptions,
+  cueNumberSchema,
+  cuePartSchema,
+  cuelistNumberSchema,
+  extractTargetOptions,
+  formatCueDescription,
+  targetOptionsSchema
+} from './common';
+import type { CueIdentifier } from './types';
+
+const fireInputSchema = {
+  cuelist_number: cuelistNumberSchema,
+  cue_number: cueNumberSchema,
+  cue_part: cuePartSchema.optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+export const eosCueFireTool: ToolDefinition<typeof fireInputSchema> = {
+  name: 'eos_cue_fire',
+  config: {
+    title: 'Declenchement de cue',
+    description: 'Declenche immediatement une cue specifique dans une liste donnee.',
+    inputSchema: fireInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.cues.fire
+      }
+    }
+  },
+  handler: async (args) => {
+    const schema = z.object(fireInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const baseIdentifier = createCueIdentifierFromOptions(options);
+    const identifier: CueIdentifier = {
+      cuelistNumber: baseIdentifier.cuelistNumber,
+      cueNumber: baseIdentifier.cueNumber,
+      cuePart: baseIdentifier.cuePart ?? 0
+    };
+
+    const payload = buildCueCommandPayload(identifier, { defaultPart: 0 });
+
+    client.sendMessage(oscMappings.cues.fire, buildJsonArgs(payload), extractTargetOptions(options));
+
+    return createCueCommandResult(
+      'cue_fire',
+      identifier,
+      payload,
+      oscMappings.cues.fire,
+      {
+        summary: `Declenchement de ${formatCueDescription(identifier)}`
+      }
+    );
+  }
+};
+
+export default eosCueFireTool;

--- a/src/tools/cues/get_active_cue.ts
+++ b/src/tools/cues/get_active_cue.ts
@@ -1,0 +1,80 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+import {
+  buildCueCommandPayload,
+  createCueIdentifierFromOptions,
+  cuelistNumberSchema,
+  extractTargetOptions,
+  formatCueDescription,
+  targetOptionsSchema
+} from './common';
+import { mapCuePlaybackState } from './mappers';
+import type { CueIdentifier } from './types';
+
+const getActiveCueInputSchema = {
+  cuelist_number: cuelistNumberSchema.optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+function formatActiveText(identifier: CueIdentifier, progress: number | null): string {
+  const progressText = progress != null ? `${Math.round(progress)}%` : 'progression inconnue';
+  return `Cue active ${formatCueDescription(identifier)} (${progressText})`;
+}
+
+export const eosGetActiveCueTool: ToolDefinition<typeof getActiveCueInputSchema> = {
+  name: 'eos_get_active_cue',
+  config: {
+    title: 'Cue active',
+    description: 'Recupere la cue actuellement en lecture sur la liste specifiee (ou principale).',
+    inputSchema: getActiveCueInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.cues.active
+      }
+    }
+  },
+  handler: async (args) => {
+    const schema = z.object(getActiveCueInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const identifier = createCueIdentifierFromOptions(options);
+    const payload = buildCueCommandPayload({
+      cuelistNumber: identifier.cuelistNumber,
+      cueNumber: null,
+      cuePart: null
+    });
+
+    const response = await client.requestJson(oscMappings.cues.active, {
+      payload,
+      ...extractTargetOptions(options)
+    });
+
+    const state = mapCuePlaybackState(response.data, identifier);
+    const text = formatActiveText(state.details.identifier, state.progressPercent);
+
+    const result: ToolExecutionResult = {
+      content: [
+        { type: 'text', text },
+        {
+          type: 'object',
+          data: {
+            action: 'get_active_cue',
+            status: response.status,
+            request: payload,
+            cue: state,
+            osc: {
+              address: oscMappings.cues.active,
+              response: response.payload
+            }
+          }
+        }
+      ]
+    } as ToolExecutionResult;
+
+    return result;
+  }
+};
+
+export default eosGetActiveCueTool;

--- a/src/tools/cues/get_info.ts
+++ b/src/tools/cues/get_info.ts
@@ -1,0 +1,93 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+import {
+  buildCueCommandPayload,
+  createCueIdentifierFromOptions,
+  cueNumberSchema,
+  cuePartSchema,
+  cuelistNumberSchema,
+  extractTargetOptions,
+  formatCueDescription,
+  targetOptionsSchema
+} from './common';
+import { mapCueDetails } from './mappers';
+import type { CueDetails, CueIdentifier } from './types';
+
+const getInfoInputSchema = {
+  cuelist_number: cuelistNumberSchema,
+  cue_number: cueNumberSchema,
+  cue_part: cuePartSchema.optional(),
+  fields: z.array(z.string().min(1)).optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+function formatCueInfoText(details: CueDetails): string {
+  const label = details.label ? `"${details.label}"` : 'sans label';
+  const up = details.timings.up != null ? `${details.timings.up}s` : '—';
+  const down = details.timings.down != null ? `${details.timings.down}s` : '—';
+  return `Cue ${formatCueDescription(details.identifier)} ${label} (Up ${up} / Down ${down})`;
+}
+
+export const eosCueGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
+  name: 'eos_cue_get_info',
+  config: {
+    title: 'Informations de cue',
+    description: 'Recupere les informations detaillees d\'une cue (timings, flags, notes...).',
+    inputSchema: getInfoInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.cues.info
+      }
+    }
+  },
+  handler: async (args) => {
+    const schema = z.object(getInfoInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const baseIdentifier = createCueIdentifierFromOptions(options);
+    const identifier: CueIdentifier = {
+      cuelistNumber: baseIdentifier.cuelistNumber,
+      cueNumber: baseIdentifier.cueNumber,
+      cuePart: baseIdentifier.cuePart ?? 0
+    };
+
+    const payload = buildCueCommandPayload(identifier, { defaultPart: 0 });
+    if (options.fields?.length) {
+      payload.fields = options.fields;
+    }
+
+    const response = await client.requestJson(oscMappings.cues.info, {
+      payload,
+      ...extractTargetOptions(options)
+    });
+
+    const details = mapCueDetails(response.data, identifier);
+
+    const text = formatCueInfoText(details);
+
+    const result: ToolExecutionResult = {
+      content: [
+        { type: 'text', text },
+        {
+          type: 'object',
+          data: {
+            action: 'cue_get_info',
+            status: response.status,
+            request: payload,
+            cue: details,
+            osc: {
+              address: oscMappings.cues.info,
+              response: response.payload
+            }
+          }
+        }
+      ]
+    } as ToolExecutionResult;
+
+    return result;
+  }
+};
+
+export default eosCueGetInfoTool;

--- a/src/tools/cues/get_pending_cue.ts
+++ b/src/tools/cues/get_pending_cue.ts
@@ -1,0 +1,74 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+import {
+  buildCueCommandPayload,
+  createCueIdentifierFromOptions,
+  cuelistNumberSchema,
+  extractTargetOptions,
+  formatCueDescription,
+  targetOptionsSchema
+} from './common';
+import { mapCuePlaybackState } from './mappers';
+
+const getPendingCueInputSchema = {
+  cuelist_number: cuelistNumberSchema.optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+export const eosGetPendingCueTool: ToolDefinition<typeof getPendingCueInputSchema> = {
+  name: 'eos_get_pending_cue',
+  config: {
+    title: 'Cue en attente',
+    description: 'Recupere la prochaine cue en attente sur la liste specifiee (ou principale).',
+    inputSchema: getPendingCueInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.cues.pending
+      }
+    }
+  },
+  handler: async (args) => {
+    const schema = z.object(getPendingCueInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const identifier = createCueIdentifierFromOptions(options);
+    const payload = buildCueCommandPayload({
+      cuelistNumber: identifier.cuelistNumber,
+      cueNumber: null,
+      cuePart: null
+    });
+
+    const response = await client.requestJson(oscMappings.cues.pending, {
+      payload,
+      ...extractTargetOptions(options)
+    });
+
+    const state = mapCuePlaybackState(response.data, identifier);
+    const text = `Cue en attente ${formatCueDescription(state.details.identifier)} (${state.details.label ?? 'sans label'})`;
+
+    const result: ToolExecutionResult = {
+      content: [
+        { type: 'text', text },
+        {
+          type: 'object',
+          data: {
+            action: 'get_pending_cue',
+            status: response.status,
+            request: payload,
+            cue: state,
+            osc: {
+              address: oscMappings.cues.pending,
+              response: response.payload
+            }
+          }
+        }
+      ]
+    } as ToolExecutionResult;
+
+    return result;
+  }
+};
+
+export default eosGetPendingCueTool;

--- a/src/tools/cues/go.ts
+++ b/src/tools/cues/go.ts
@@ -1,0 +1,58 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition } from '../types';
+import {
+  buildCueCommandPayload,
+  buildJsonArgs,
+  createCueCommandResult,
+  createCueIdentifierFromOptions,
+  cueNumberSchema,
+  cuePartSchema,
+  cuelistNumberSchema,
+  extractTargetOptions,
+  formatCueDescription,
+  targetOptionsSchema
+} from './common';
+
+const goInputSchema = {
+  cuelist_number: cuelistNumberSchema,
+  cue_number: cueNumberSchema.optional(),
+  cue_part: cuePartSchema.optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+export const eosCueGoTool: ToolDefinition<typeof goInputSchema> = {
+  name: 'eos_cue_go',
+  config: {
+    title: 'GO sur liste de cues',
+    description: 'Declenche un GO sur la liste de cues cible, optionnellement vers une cue precise.',
+    inputSchema: goInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.cues.go
+      }
+    }
+  },
+  handler: async (args) => {
+    const schema = z.object(goInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const identifier = createCueIdentifierFromOptions(options);
+    const payload = buildCueCommandPayload(identifier);
+
+    client.sendMessage(oscMappings.cues.go, buildJsonArgs(payload), extractTargetOptions(options));
+
+    return createCueCommandResult(
+      'cue_go',
+      identifier,
+      payload,
+      oscMappings.cues.go,
+      {
+        summary: `GO envoye sur ${formatCueDescription(identifier)}`
+      }
+    );
+  }
+};
+
+export default eosCueGoTool;

--- a/src/tools/cues/index.ts
+++ b/src/tools/cues/index.ts
@@ -1,0 +1,41 @@
+import eosCueFireTool from './fire';
+import eosCueGoTool from './go';
+import eosCueStopBackTool from './stop_back';
+import eosCueSelectTool from './select';
+import eosCueGetInfoTool from './get_info';
+import eosCueListAllTool from './list_all';
+import eosCuelistGetInfoTool from './cuelist_get_info';
+import eosCuelistBankCreateTool from './cuelist_bank_create';
+import eosCuelistBankPageTool from './cuelist_bank_page';
+import eosGetActiveCueTool from './get_active_cue';
+import eosGetPendingCueTool from './get_pending_cue';
+
+export const cueTools = [
+  eosCueFireTool,
+  eosCueGoTool,
+  eosCueStopBackTool,
+  eosCueSelectTool,
+  eosCueGetInfoTool,
+  eosCueListAllTool,
+  eosCuelistGetInfoTool,
+  eosCuelistBankCreateTool,
+  eosCuelistBankPageTool,
+  eosGetActiveCueTool,
+  eosGetPendingCueTool
+];
+
+export default cueTools;
+
+export {
+  eosCueFireTool,
+  eosCueGoTool,
+  eosCueStopBackTool,
+  eosCueSelectTool,
+  eosCueGetInfoTool,
+  eosCueListAllTool,
+  eosCuelistGetInfoTool,
+  eosCuelistBankCreateTool,
+  eosCuelistBankPageTool,
+  eosGetActiveCueTool,
+  eosGetPendingCueTool
+};

--- a/src/tools/cues/list_all.ts
+++ b/src/tools/cues/list_all.ts
@@ -1,0 +1,76 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+import {
+  buildCueCommandPayload,
+  createCueIdentifierFromOptions,
+  cuelistNumberSchema,
+  extractTargetOptions,
+  formatCueDescription,
+  targetOptionsSchema
+} from './common';
+import { mapCueList } from './mappers';
+
+const listAllInputSchema = {
+  cuelist_number: cuelistNumberSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+export const eosCueListAllTool: ToolDefinition<typeof listAllInputSchema> = {
+  name: 'eos_cue_list_all',
+  config: {
+    title: 'Liste des cues',
+    description: 'Recupere toutes les cues d\'une liste avec leurs labels.',
+    inputSchema: listAllInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.cues.list
+      }
+    }
+  },
+  handler: async (args) => {
+    const schema = z.object(listAllInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const identifier = createCueIdentifierFromOptions(options);
+    const payload = buildCueCommandPayload({
+      cuelistNumber: identifier.cuelistNumber,
+      cueNumber: null,
+      cuePart: null
+    });
+
+    const response = await client.requestJson(oscMappings.cues.list, {
+      payload,
+      ...extractTargetOptions(options)
+    });
+
+    const cues = mapCueList(response.data, identifier);
+
+    const listLabel = formatCueDescription({ ...identifier, cueNumber: null, cuePart: null });
+    const text = `${listLabel}: ${cues.length} cue(s).`;
+
+    const result: ToolExecutionResult = {
+      content: [
+        { type: 'text', text },
+        {
+          type: 'object',
+          data: {
+            action: 'cue_list_all',
+            status: response.status,
+            request: payload,
+            cues,
+            osc: {
+              address: oscMappings.cues.list,
+              response: response.payload
+            }
+          }
+        }
+      ]
+    } as ToolExecutionResult;
+
+    return result;
+  }
+};
+
+export default eosCueListAllTool;

--- a/src/tools/cues/mappers.ts
+++ b/src/tools/cues/mappers.ts
@@ -1,0 +1,321 @@
+import type {
+  CueDetails,
+  CueFlags,
+  CueIdentifier,
+  CueLinks,
+  CueListEntry,
+  CuePlaybackState,
+  CueTimings,
+  CuelistInfo
+} from './types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null && !Array.isArray(value);
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return null;
+    }
+    const normalised = trimmed.replace(',', '.');
+    const parsed = Number.parseFloat(normalised.replace(/[^0-9.+-:]/g, ''));
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (isRecord(value)) {
+    const candidate =
+      value.seconds ?? value.secs ?? value.duration ?? value.value ?? value.time ?? value.total ?? value.amount;
+    return asFiniteNumber(candidate);
+  }
+  return null;
+}
+
+function asFiniteInteger(value: unknown): number | null {
+  const numeric = asFiniteNumber(value);
+  if (numeric == null) {
+    return null;
+  }
+  const truncated = Math.trunc(numeric);
+  return Number.isFinite(truncated) ? truncated : null;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+}
+
+function normaliseBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  if (typeof value === 'string') {
+    const normalised = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on', 'enabled'].includes(normalised)) {
+      return true;
+    }
+    if (['0', 'false', 'no', 'off', 'disabled'].includes(normalised)) {
+      return false;
+    }
+  }
+  return false;
+}
+
+function parseDuration(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return null;
+    }
+    const lower = trimmed.toLowerCase();
+    if (lower.includes(':')) {
+      const parts = lower
+        .split(':')
+        .map((part) => part.trim())
+        .map((part) => part.replace(',', '.'))
+        .map((part) => Number.parseFloat(part));
+      if (parts.every((part) => Number.isFinite(part))) {
+        if (parts.length === 3) {
+          return parts[0]! * 3600 + parts[1]! * 60 + parts[2]!;
+        }
+        if (parts.length === 2) {
+          return parts[0]! * 60 + parts[1]!;
+        }
+        if (parts.length === 1) {
+          return parts[0]!;
+        }
+      }
+    }
+    const cleaned = lower.replace(/[^0-9.+-]/g, '');
+    const parsed = Number.parseFloat(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (isRecord(value)) {
+    const candidate =
+      value.seconds ??
+      value.secs ??
+      value.duration ??
+      value.time ??
+      value.total ??
+      value.length ??
+      value.value ??
+      value.amount;
+    return parseDuration(candidate);
+  }
+  return null;
+}
+
+function parsePercentage(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value <= 1 ? value * 100 : value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return null;
+    }
+    const withoutPercent = trimmed.endsWith('%') ? trimmed.slice(0, -1) : trimmed;
+    const numeric = Number.parseFloat(withoutPercent.replace(',', '.'));
+    if (!Number.isFinite(numeric)) {
+      return null;
+    }
+    return numeric <= 1 ? numeric * 100 : numeric;
+  }
+  if (isRecord(value)) {
+    const candidate = value.progress ?? value.percent ?? value.percentage ?? value.value;
+    return parsePercentage(candidate);
+  }
+  return null;
+}
+
+function resolveIdentifier(raw: Record<string, unknown>, fallback: Partial<CueIdentifier>): CueIdentifier {
+  const cuelistNumber =
+    asFiniteInteger(raw.cuelist) ??
+    asFiniteInteger(raw.list) ??
+    asFiniteInteger(raw.cuelist_number) ??
+    asFiniteInteger(raw.playback) ??
+    fallback.cuelistNumber ??
+    null;
+
+  const cueNumberCandidate =
+    asString(raw.cue) ??
+    asString(raw.cue_number) ??
+    asString(raw.number) ??
+    asString(raw.id) ??
+    asString(raw.target) ??
+    fallback.cueNumber ??
+    null;
+
+  const cuePart =
+    asFiniteInteger(raw.cue_part) ??
+    asFiniteInteger(raw.part) ??
+    asFiniteInteger(raw.part_number) ??
+    fallback.cuePart ??
+    null;
+
+  return {
+    cuelistNumber,
+    cueNumber: cueNumberCandidate,
+    cuePart
+  };
+}
+
+function extractTimingContainer(raw: Record<string, unknown>): Record<string, unknown> {
+  if (isRecord(raw.timings)) {
+    return raw.timings as Record<string, unknown>;
+  }
+  if (isRecord(raw.time)) {
+    return raw.time as Record<string, unknown>;
+  }
+  if (isRecord(raw.timing)) {
+    return raw.timing as Record<string, unknown>;
+  }
+  return raw;
+}
+
+function mapCueTimings(raw: Record<string, unknown>): CueTimings {
+  const container = extractTimingContainer(raw);
+  return {
+    up: parseDuration(container.up ?? container.fade_up ?? container.in ?? container.uptime),
+    down: parseDuration(container.down ?? container.fade_down ?? container.out ?? container.downtime),
+    focus: parseDuration(container.focus ?? container.focus_time ?? container.focusfade),
+    color: parseDuration(container.color ?? container.color_time ?? container.colorfade),
+    beam: parseDuration(container.beam ?? container.beam_time ?? container.beamfade)
+  };
+}
+
+function mapCueFlags(raw: Record<string, unknown>): CueFlags {
+  const flagsSource = isRecord(raw.flags) ? (raw.flags as Record<string, unknown>) : raw;
+  return {
+    mark: normaliseBoolean(flagsSource.mark ?? flagsSource.marked),
+    block: normaliseBoolean(flagsSource.block ?? flagsSource.blocked),
+    assert: normaliseBoolean(flagsSource.assert ?? flagsSource.asserted),
+    solo: normaliseBoolean(flagsSource.solo ?? flagsSource.solo_mode),
+    timecode: normaliseBoolean(flagsSource.timecode ?? flagsSource.tc ?? flagsSource.time_code)
+  };
+}
+
+function mapCueLinks(raw: Record<string, unknown>): CueLinks {
+  return {
+    link: asString(raw.link ?? raw.linked_to ?? raw.jump ?? raw.autofollow),
+    follow: parseDuration(raw.follow ?? raw.follow_time ?? raw.auto_follow),
+    hang: parseDuration(raw.hang ?? raw.hang_time ?? raw.auto_hang),
+    loop: parseDuration(raw.loop ?? raw.loop_time ?? raw.auto_loop)
+  };
+}
+
+function identifierKey(identifier: CueIdentifier): string {
+  const list = identifier.cuelistNumber != null ? String(identifier.cuelistNumber) : 'null';
+  const cue = identifier.cueNumber ?? 'null';
+  const part = identifier.cuePart != null ? String(identifier.cuePart) : 'null';
+  return `${list}:${cue}:${part}`;
+}
+
+export function mapCueDetails(raw: unknown, fallback: Partial<CueIdentifier> = {}): CueDetails {
+  const source = isRecord(raw) ? raw : {};
+  const identifier = resolveIdentifier(source, fallback);
+  const label = asString(source.label ?? source.name ?? source.title ?? source.description) ?? null;
+  const curve = asString(source.curve ?? source.timing_curve ?? source.fade_curve ?? source.rate) ?? null;
+  const timings = mapCueTimings(source);
+  const flags = mapCueFlags(source);
+  const links = mapCueLinks(source);
+  const notes = asString(source.notes ?? source.note ?? source.comment ?? source.remarks) ?? null;
+
+  return {
+    identifier,
+    label,
+    timings,
+    curve,
+    flags,
+    links,
+    notes
+  };
+}
+
+export function mapCueList(raw: unknown, fallback: Partial<CueIdentifier> = {}): CueListEntry[] {
+  const source = isRecord(raw) ? raw : {};
+  const list = Array.isArray(source.cues)
+    ? source.cues
+    : Array.isArray(source.cuelist)
+      ? source.cuelist
+      : Array.isArray(source.items)
+        ? source.items
+        : Array.isArray(raw)
+          ? (raw as unknown[])
+          : [];
+
+  const entries = list
+    .map((item) => mapCueDetails(item, fallback))
+    .map((details) => ({ identifier: details.identifier, label: details.label }));
+
+  const unique = new Map<string, CueListEntry>();
+  for (const entry of entries) {
+    const key = identifierKey(entry.identifier);
+    if (!unique.has(key)) {
+      unique.set(key, entry);
+    }
+  }
+
+  return Array.from(unique.values());
+}
+
+export function mapCuelistInfo(raw: unknown, fallback: Partial<CueIdentifier> = {}): CuelistInfo {
+  const source = isRecord(raw) ? raw : {};
+  const identifier = resolveIdentifier(source, fallback);
+  const label = asString(source.label ?? source.name ?? source.title) ?? null;
+  const playbackMode =
+    asString(source.playback_mode ?? source.mode ?? source.play_mode ?? source.playback) ?? null;
+  const faderMode = asString(source.fader_mode ?? source.fader ?? source.slider_mode) ?? null;
+
+  const flagsSource = isRecord(source.flags) ? (source.flags as Record<string, unknown>) : source;
+
+  const info: CuelistInfo = {
+    cuelistNumber: identifier.cuelistNumber,
+    label,
+    playbackMode,
+    faderMode,
+    flags: {
+      independent: normaliseBoolean(flagsSource.independent),
+      htp: normaliseBoolean(flagsSource.htp ?? flagsSource.hightakesprecedence),
+      assert: normaliseBoolean(flagsSource.assert),
+      block: normaliseBoolean(flagsSource.block),
+      background: normaliseBoolean(flagsSource.background ?? flagsSource.background_enable),
+      soloMode: asString(flagsSource.solo_mode ?? flagsSource.solo ?? flagsSource.soloMode) ?? null
+    }
+  };
+
+  return info;
+}
+
+export function mapCuePlaybackState(raw: unknown, fallback: Partial<CueIdentifier> = {}): CuePlaybackState {
+  const source = isRecord(raw) ? raw : {};
+  const cueSource = isRecord(source.cue) ? (source.cue as Record<string, unknown>) : source;
+  const details = mapCueDetails(cueSource, fallback);
+
+  const duration = parseDuration(source.duration ?? cueSource.duration ?? source.total ?? cueSource.total_time);
+  const remaining = parseDuration(source.remaining ?? source.time_remaining ?? cueSource.remaining);
+  const progress =
+    parsePercentage(source.progress ?? source.percent ?? source.percentage ?? cueSource.progress ?? cueSource.percent);
+
+  return {
+    details,
+    durationSeconds: duration,
+    progressPercent: progress,
+    remainingSeconds: remaining
+  };
+}

--- a/src/tools/cues/select.ts
+++ b/src/tools/cues/select.ts
@@ -1,0 +1,58 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition } from '../types';
+import {
+  buildCueCommandPayload,
+  buildJsonArgs,
+  createCueCommandResult,
+  createCueIdentifierFromOptions,
+  cueNumberSchema,
+  cuePartSchema,
+  cuelistNumberSchema,
+  extractTargetOptions,
+  formatCueDescription,
+  targetOptionsSchema
+} from './common';
+
+const selectInputSchema = {
+  cuelist_number: cuelistNumberSchema,
+  cue_number: cueNumberSchema,
+  cue_part: cuePartSchema.optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+export const eosCueSelectTool: ToolDefinition<typeof selectInputSchema> = {
+  name: 'eos_cue_select',
+  config: {
+    title: 'Selection de cue',
+    description: 'Selectionne une cue dans la liste sans la declencher.',
+    inputSchema: selectInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.cues.select
+      }
+    }
+  },
+  handler: async (args) => {
+    const schema = z.object(selectInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const identifier = createCueIdentifierFromOptions(options);
+    const payload = buildCueCommandPayload(identifier, { defaultPart: 0 });
+
+    client.sendMessage(oscMappings.cues.select, buildJsonArgs(payload), extractTargetOptions(options));
+
+    return createCueCommandResult(
+      'cue_select',
+      identifier,
+      payload,
+      oscMappings.cues.select,
+      {
+        summary: `Selection de ${formatCueDescription(identifier)}`
+      }
+    );
+  }
+};
+
+export default eosCueSelectTool;

--- a/src/tools/cues/types.ts
+++ b/src/tools/cues/types.ts
@@ -1,0 +1,65 @@
+export interface CueIdentifier {
+  cuelistNumber: number | null;
+  cueNumber: string | null;
+  cuePart: number | null;
+}
+
+export interface CueTimings {
+  up: number | null;
+  down: number | null;
+  focus: number | null;
+  color: number | null;
+  beam: number | null;
+}
+
+export interface CueFlags {
+  mark: boolean;
+  block: boolean;
+  assert: boolean;
+  solo: boolean;
+  timecode: boolean;
+}
+
+export interface CueLinks {
+  link: string | null;
+  follow: number | null;
+  hang: number | null;
+  loop: number | null;
+}
+
+export interface CueDetails {
+  identifier: CueIdentifier;
+  label: string | null;
+  timings: CueTimings;
+  curve: string | null;
+  flags: CueFlags;
+  links: CueLinks;
+  notes: string | null;
+}
+
+export interface CueListEntry {
+  identifier: CueIdentifier;
+  label: string | null;
+}
+
+export interface CuelistInfo {
+  cuelistNumber: number | null;
+  label: string | null;
+  playbackMode: string | null;
+  faderMode: string | null;
+  flags: {
+    independent: boolean;
+    htp: boolean;
+    assert: boolean;
+    block: boolean;
+    background: boolean;
+    soloMode: string | null;
+  };
+}
+
+export interface CuePlaybackState {
+  details: CueDetails;
+  durationSeconds: number | null;
+  progressPercent: number | null;
+  remainingSeconds: number | null;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@ import commandTools from './commands/command_tools.js';
 import channelTools from './channels/index.js';
 import groupTools from './groups/index.js';
 import pingTool from './ping.js';
+import cueTools from './cues/index.js';
 import type { ToolDefinition } from './types.js';
 
 export const toolDefinitions: ToolDefinition[] = [
@@ -16,7 +17,8 @@ export const toolDefinitions: ToolDefinition[] = [
   eosSubscribeTool,
   ...commandTools,
   ...channelTools,
-  ...groupTools
+  ...groupTools,
+  ...cueTools
 ];
 
 export default toolDefinitions;


### PR DESCRIPTION
## Summary
- add a full set of cue tools (fire, go, stop/back, select, info, list, bank, state) with shared helpers
- normalise cue payloads into dedicated TypeScript types and mappers for timings, flags and links
- register the cue tools, extend OSC mappings, and cover scenarios with go/stop and get_active_cue tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f52664168c832aa4068e83686ca791