### PR TITLE
Add palette control tools

### DIFF
--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -12,6 +12,25 @@ export const oscMappings = {
     info: '/eos/group/info',
     list: '/eos/group/list'
   },
+  palettes: {
+    info: '/eos/get/palette',
+    intensity: {
+      fire: '/eos/ip/fire',
+      info: '/eos/get/ip'
+    },
+    focus: {
+      fire: '/eos/fp/fire',
+      info: '/eos/get/fp'
+    },
+    color: {
+      fire: '/eos/cp/fire',
+      info: '/eos/get/cp'
+    },
+    beam: {
+      fire: '/eos/bp/fire',
+      info: '/eos/get/bp'
+    }
+  },
   cues: {
     fire: '/eos/cue/fire',
     go: '/eos/cue/go',

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,6 +7,7 @@ import channelTools from './channels/index.js';
 import groupTools from './groups/index.js';
 import pingTool from './ping.js';
 import cueTools from './cues/index.js';
+import paletteTools from './palettes/index.js';
 import type { ToolDefinition } from './types.js';
 
 export const toolDefinitions: ToolDefinition[] = [
@@ -18,7 +19,8 @@ export const toolDefinitions: ToolDefinition[] = [
   ...commandTools,
   ...channelTools,
   ...groupTools,
-  ...cueTools
+  ...cueTools,
+  ...paletteTools
 ];
 
 export default toolDefinitions;

--- a/src/tools/palettes/__tests__/palettes.test.ts
+++ b/src/tools/palettes/__tests__/palettes.test.ts
@@ -1,0 +1,131 @@
+import type { OscMessage } from '../../../services/osc/index';
+import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { oscMappings } from '../../../services/osc/mappings';
+import {
+  eosBeamPaletteFireTool,
+  eosColorPaletteFireTool,
+  eosFocusPaletteFireTool,
+  eosIntensityPaletteFireTool,
+  eosPaletteGetInfoTool
+} from '../index';
+
+type ToolHandler = (args: unknown, extra?: unknown) => Promise<any>;
+
+class FakeOscService implements OscGateway {
+  public readonly sentMessages: OscMessage[] = [];
+
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  public send(message: OscMessage): void {
+    this.sentMessages.push(message);
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public emit(message: OscMessage): void {
+    this.listeners.forEach((listener) => listener(message));
+  }
+}
+
+describe('palette tools', () => {
+  let service: FakeOscService;
+
+  const runTool = async (tool: any, args: unknown): Promise<any> => {
+    const handler = tool.handler as ToolHandler;
+    return handler(args, {});
+  };
+
+  beforeEach(() => {
+    service = new FakeOscService();
+    const client = new OscClient(service, { defaultTimeoutMs: 50 });
+    setOscClient(client);
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it('envoie un message json lors du declenchement dune palette', async () => {
+    await runTool(eosColorPaletteFireTool, { palette_number: 42 });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const [message] = service.sentMessages;
+    expect(message.address).toBe(oscMappings.palettes.color.fire);
+    expect(message.args).toHaveLength(1);
+    const payload = JSON.parse(String(message.args?.[0]?.value ?? '{}'));
+    expect(payload).toMatchObject({ palette: 42 });
+  });
+
+  it('normalise les informations de palette et les canaux par type', async () => {
+    const promise = runTool(eosPaletteGetInfoTool, { palette_type: 'fp', palette_number: 12 });
+
+    queueMicrotask(() => {
+      const responsePayload = {
+        status: 'ok',
+        palette: {
+          number: '12',
+          label: 'Position Scene',
+          absolute: 'true',
+          locked: 0,
+          channels: [12, '5', { channel: 3 }, { number: '7' }],
+          'by-type channels': {
+            intensity: ['1', '2'],
+            focus: [{ channel: 12 }, { channel: '15' }],
+            color: ['7'],
+            bp: [40, '41'],
+            extra: ['50']
+          }
+        }
+      };
+
+      service.emit({
+        address: oscMappings.palettes.focus.info,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify(responsePayload)
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+
+    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    expect(objectContent).toBeDefined();
+
+    const paletteInfo = objectContent.data.palette;
+    expect(paletteInfo.paletteType).toBe('fp');
+    expect(paletteInfo.paletteNumber).toBe(12);
+    expect(paletteInfo.label).toBe('Position Scene');
+    expect(paletteInfo.absolute).toBe(true);
+    expect(paletteInfo.locked).toBe(false);
+    expect(paletteInfo.channels).toEqual([1, 2, 3, 5, 7, 12, 15, 40, 41, 50]);
+    expect(paletteInfo.byTypeChannels).toEqual({
+      intensity: [1, 2],
+      focus: [12, 15],
+      color: [7],
+      beam: [40, 41],
+      extra: [50]
+    });
+  });
+
+  it('declenche chaque type de palette avec le bon mapping', async () => {
+    await runTool(eosIntensityPaletteFireTool, { palette_number: 1 });
+    await runTool(eosFocusPaletteFireTool, { palette_number: 2 });
+    await runTool(eosBeamPaletteFireTool, { palette_number: 3 });
+
+    expect(service.sentMessages).toHaveLength(3);
+    const addresses = service.sentMessages.map((message) => message.address);
+    expect(addresses).toEqual([
+      oscMappings.palettes.intensity.fire,
+      oscMappings.palettes.focus.fire,
+      oscMappings.palettes.beam.fire
+    ]);
+  });
+});

--- a/src/tools/palettes/index.ts
+++ b/src/tools/palettes/index.ts
@@ -1,0 +1,481 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
+import type { OscMessageArgument } from '../../services/osc/index';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+
+const targetOptionsSchema = {
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+} satisfies ZodRawShape;
+
+const paletteNumberSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(99999)
+  .describe('Numero de palette (1-99999)');
+
+const paletteTypeSchema = z
+  .enum(['ip', 'fp', 'cp', 'bp'])
+  .describe("Type de palette: 'ip' (intensite), 'fp' (focus), 'cp' (couleur), 'bp' (beam)");
+
+type PaletteType = z.infer<typeof paletteTypeSchema>;
+
+interface PaletteInfo {
+  paletteType: PaletteType;
+  paletteNumber: number;
+  label: string | null;
+  absolute: boolean;
+  locked: boolean;
+  channels: number[];
+  byTypeChannels: Record<string, number[]>;
+}
+
+const paletteTypeLabels: Record<PaletteType, string> = {
+  ip: 'intensite',
+  fp: 'focus',
+  cp: 'couleur',
+  bp: 'beam'
+};
+
+const paletteTypeTitles: Record<PaletteType, string> = {
+  ip: 'Palette Intensite',
+  fp: 'Palette Focus',
+  cp: 'Palette Couleur',
+  bp: 'Palette Beam'
+};
+
+const paletteFireInputSchema = {
+  palette_number: paletteNumberSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const paletteGetInfoInputSchema = {
+  palette_type: paletteTypeSchema,
+  palette_number: paletteNumberSchema,
+  fields: z.array(z.string().min(1)).optional(),
+  timeoutMs: z.number().int().min(50).optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+function buildJsonArgs(payload: Record<string, unknown>): OscMessageArgument[] {
+  return [
+    {
+      type: 's' as const,
+      value: JSON.stringify(payload)
+    }
+  ];
+}
+
+function extractTargetOptions(options: { targetAddress?: string; targetPort?: number }): {
+  targetAddress?: string;
+  targetPort?: number;
+} {
+  const target: { targetAddress?: string; targetPort?: number } = {};
+  if (options.targetAddress) {
+    target.targetAddress = options.targetAddress;
+  }
+  if (typeof options.targetPort === 'number') {
+    target.targetPort = options.targetPort;
+  }
+  return target;
+}
+
+function annotate(osc: string): Record<string, unknown> {
+  return {
+    mapping: {
+      osc
+    }
+  };
+}
+
+function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+  return {
+    content: [
+      { type: 'text', text },
+      { type: 'object', data }
+    ]
+  } as ToolExecutionResult;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null && !Array.isArray(value);
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return null;
+    }
+    const normalised = trimmed.replace(',', '.');
+    const parsed = Number.parseFloat(normalised.replace(/[^0-9.+-]/g, ''));
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function asFiniteInteger(value: unknown): number | null {
+  const numeric = asFiniteNumber(value);
+  if (numeric == null) {
+    return null;
+  }
+  const truncated = Math.trunc(numeric);
+  return Number.isFinite(truncated) ? truncated : null;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+}
+
+function normaliseBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  if (typeof value === 'string') {
+    const lowered = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on', 'enabled', 'abs'].includes(lowered)) {
+      return true;
+    }
+    if (['0', 'false', 'no', 'off', 'disabled'].includes(lowered)) {
+      return false;
+    }
+  }
+  return false;
+}
+
+function normaliseByTypeKey(key: string): string | null {
+  const trimmed = key.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const lowered = trimmed.toLowerCase();
+  const aliases: Record<string, string> = {
+    intensity: 'intensity',
+    intensite: 'intensity',
+    ip: 'intensity',
+    focus: 'focus',
+    position: 'focus',
+    fp: 'focus',
+    color: 'color',
+    colour: 'color',
+    cp: 'color',
+    beam: 'beam',
+    form: 'beam',
+    bp: 'beam'
+  };
+  const alias = aliases[lowered];
+  const base = alias ?? lowered;
+  return base.replace(/[^a-z0-9]+/g, '_');
+}
+
+function collectChannelNumbers(value: unknown, seen = new Set<unknown>()): number[] {
+  const result = new Set<number>();
+
+  function visit(candidate: unknown): void {
+    if (candidate == null) {
+      return;
+    }
+    if (Array.isArray(candidate)) {
+      candidate.forEach((item) => visit(item));
+      return;
+    }
+    if (isRecord(candidate)) {
+      if (seen.has(candidate)) {
+        return;
+      }
+      seen.add(candidate);
+      if ('channel' in candidate) {
+        const channel = asFiniteInteger(candidate.channel);
+        if (channel != null && channel > 0) {
+          result.add(channel);
+        }
+      }
+      if ('number' in candidate) {
+        const channel = asFiniteInteger(candidate.number);
+        if (channel != null && channel > 0) {
+          result.add(channel);
+        }
+      }
+      if ('id' in candidate) {
+        const channel = asFiniteInteger(candidate.id);
+        if (channel != null && channel > 0) {
+          result.add(channel);
+        }
+      }
+      if ('target' in candidate) {
+        const channel = asFiniteInteger(candidate.target);
+        if (channel != null && channel > 0) {
+          result.add(channel);
+        }
+      }
+      for (const key of Object.keys(candidate)) {
+        if (key.toLowerCase().includes('channel')) {
+          visit(candidate[key]);
+        }
+      }
+      return;
+    }
+    const numeric = asFiniteInteger(candidate);
+    if (numeric != null && numeric > 0) {
+      result.add(numeric);
+    }
+  }
+
+  visit(value);
+  return Array.from(result).sort((a, b) => a - b);
+}
+
+function mapByTypeChannels(value: unknown): Record<string, number[]> {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const entries: Record<string, number[]> = {};
+  for (const [key, channels] of Object.entries(value)) {
+    const normalisedKey = normaliseByTypeKey(key);
+    if (!normalisedKey) {
+      continue;
+    }
+    const list = collectChannelNumbers(channels);
+    if (list.length > 0) {
+      entries[normalisedKey] = list;
+    }
+  }
+  return entries;
+}
+
+function mapPaletteInfo(raw: unknown, fallback: { type: PaletteType; number: number }): PaletteInfo {
+  const root = isRecord(raw) ? raw : {};
+  const container = isRecord(root.palette) ? (root.palette as Record<string, unknown>) : root;
+
+  const paletteNumber =
+    asFiniteInteger(container.palette) ??
+    asFiniteInteger(container.number) ??
+    asFiniteInteger(container.id) ??
+    asFiniteInteger(root.palette_number) ??
+    fallback.number;
+
+  const label =
+    asString(container.label) ??
+    asString(container.name) ??
+    asString(root.label) ??
+    null;
+
+  const absolute = normaliseBoolean(
+    container.absolute ?? container.abs ?? container.absolute_flag ?? container.absolute_mode ?? root.absolute
+  );
+  const locked = normaliseBoolean(container.locked ?? container.lock ?? container.is_locked ?? root.locked);
+
+  const directChannels = collectChannelNumbers(
+    container.channels ??
+      container.members ??
+      container.channel_list ??
+      container.channel ??
+      root.channels ??
+      root.members
+  );
+
+  const byTypeSource =
+    (container as Record<string, unknown>)['by-type channels'] ??
+    container.by_type_channels ??
+    container.channels_by_type ??
+    container.byTypeChannels ??
+    root.by_type_channels ??
+    root.channels_by_type ??
+    null;
+
+  const byTypeChannels = mapByTypeChannels(byTypeSource);
+  const combinedChannels = new Set<number>(directChannels);
+  Object.values(byTypeChannels).forEach((list) => {
+    list.forEach((channel) => combinedChannels.add(channel));
+  });
+
+  return {
+    paletteType: fallback.type,
+    paletteNumber,
+    label,
+    absolute,
+    locked,
+    channels: Array.from(combinedChannels).sort((a, b) => a - b),
+    byTypeChannels
+  };
+}
+
+function formatPaletteDescription(info: PaletteInfo): string {
+  const typeTitle = paletteTypeTitles[info.paletteType];
+  const label = info.label ? `\"${info.label}\"` : 'sans label';
+  const mode = info.absolute ? 'absolue' : 'relative';
+  const lockState = info.locked ? 'verrouillee' : 'modifiable';
+  const channels = info.channels.length > 0 ? info.channels.join(', ') : 'aucun canal';
+  return `${typeTitle} ${info.paletteNumber} ${label} (${mode}, ${lockState}, canaux: ${channels})`;
+}
+
+interface PaletteFireConfig {
+  type: PaletteType;
+  name: string;
+  title: string;
+  description: string;
+  mapping: string;
+}
+
+function createPaletteFireTool({ type, name, title, description, mapping }: PaletteFireConfig): ToolDefinition<
+  typeof paletteFireInputSchema
+> {
+  return {
+    name,
+    config: {
+      title,
+      description,
+      inputSchema: paletteFireInputSchema,
+      annotations: annotate(mapping)
+    },
+    handler: async (args) => {
+      const schema = z.object(paletteFireInputSchema).strict();
+      const options = schema.parse(args ?? {});
+      const client = getOscClient();
+      const payload = {
+        palette: options.palette_number
+      };
+
+      client.sendMessage(mapping, buildJsonArgs(payload), extractTargetOptions(options));
+
+      return createResult(`Palette ${paletteTypeLabels[type]} ${options.palette_number} declenchee`, {
+        action: 'palette_fire',
+        palette_type: type,
+        palette_number: options.palette_number,
+        osc: {
+          address: mapping,
+          args: payload
+        }
+      });
+    }
+  } satisfies ToolDefinition<typeof paletteFireInputSchema>;
+}
+
+function getInfoMappingForType(type: PaletteType): string {
+  switch (type) {
+    case 'ip':
+      return oscMappings.palettes.intensity.info;
+    case 'fp':
+      return oscMappings.palettes.focus.info;
+    case 'cp':
+      return oscMappings.palettes.color.info;
+    case 'bp':
+      return oscMappings.palettes.beam.info;
+    default:
+      return oscMappings.palettes.intensity.info;
+  }
+}
+
+export const eosIntensityPaletteFireTool = createPaletteFireTool({
+  type: 'ip',
+  name: 'eos_intensity_palette_fire',
+  title: "Declenchement de palette d'intensite",
+  description: "Declenche une palette d'intensite sur la console Eos.",
+  mapping: oscMappings.palettes.intensity.fire
+});
+
+export const eosFocusPaletteFireTool = createPaletteFireTool({
+  type: 'fp',
+  name: 'eos_focus_palette_fire',
+  title: 'Declenchement de palette de focus',
+  description: 'Declenche une palette de focus sur la console Eos.',
+  mapping: oscMappings.palettes.focus.fire
+});
+
+export const eosColorPaletteFireTool = createPaletteFireTool({
+  type: 'cp',
+  name: 'eos_color_palette_fire',
+  title: 'Declenchement de palette de couleur',
+  description: 'Declenche une palette de couleur sur la console Eos.',
+  mapping: oscMappings.palettes.color.fire
+});
+
+export const eosBeamPaletteFireTool = createPaletteFireTool({
+  type: 'bp',
+  name: 'eos_beam_palette_fire',
+  title: 'Declenchement de palette de beam',
+  description: 'Declenche une palette de beam sur la console Eos.',
+  mapping: oscMappings.palettes.beam.fire
+});
+
+export const eosPaletteGetInfoTool: ToolDefinition<typeof paletteGetInfoInputSchema> = {
+  name: 'eos_palette_get_info',
+  config: {
+    title: 'Informations de palette',
+    description: 'Recupere les informations detaillees pour une palette donnee.',
+    inputSchema: paletteGetInfoInputSchema,
+    annotations: annotate(oscMappings.palettes.info)
+  },
+  handler: async (args) => {
+    const schema = z.object(paletteGetInfoInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const mapping = getInfoMappingForType(options.palette_type);
+    const payload: Record<string, unknown> = {
+      palette: options.palette_number,
+      type: options.palette_type
+    };
+    if (options.fields?.length) {
+      payload.fields = options.fields;
+    }
+
+    const response: OscJsonResponse = await client.requestJson(mapping, {
+      payload,
+      timeoutMs: options.timeoutMs,
+      ...extractTargetOptions(options)
+    });
+
+    const info = mapPaletteInfo(response.data, {
+      type: options.palette_type,
+      number: options.palette_number
+    });
+
+    const text = formatPaletteDescription(info);
+
+    const result: ToolExecutionResult = {
+      content: [
+        { type: 'text', text },
+        {
+          type: 'object',
+          data: {
+            action: 'palette_get_info',
+            status: response.status,
+            request: payload,
+            palette: info,
+            osc: {
+              address: mapping,
+              response: response.payload
+            }
+          }
+        }
+      ]
+    } as ToolExecutionResult;
+
+    return result;
+  }
+};
+
+const paletteTools = [
+  eosIntensityPaletteFireTool,
+  eosFocusPaletteFireTool,
+  eosColorPaletteFireTool,
+  eosBeamPaletteFireTool,
+  eosPaletteGetInfoTool
+];
+
+export default paletteTools;


### PR DESCRIPTION
## Summary
- add OSC mappings for the various palette OSC endpoints
- implement palette fire and info tools with shared validation and response mapping
- cover palette behaviour with unit tests using mocked OSC clients

## Testing
- npm test -- palettes

------
https://chatgpt.com/codex/tasks/task_e_68f52ae9ea94832a9585d327b343698c