### PR TITLE
feat: outils de fader OSC avec pagination

### DIFF
--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -36,6 +36,11 @@ export const oscMappings = {
     select: '/eos/preset/select',
     info: '/eos/get/preset'
   },
+  faders: {
+    base: '/eos/fader',
+    bankCreate: '/eos/fader/bank/create',
+    bankPage: '/eos/fader/bank/page'
+  },
   submasters: {
     base: '/eos/sub',
     info: '/eos/get/submaster'

--- a/src/tools/faders/__tests__/faders.test.ts
+++ b/src/tools/faders/__tests__/faders.test.ts
@@ -1,0 +1,110 @@
+import type { OscMessage } from '../../../services/osc/index';
+import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { oscMappings } from '../../../services/osc/mappings';
+import {
+  __resetFaderBankCacheForTests,
+  eosFaderBankCreateTool,
+  eosFaderSetLevelTool,
+  eosFaderLoadTool,
+  eosFaderUnloadTool,
+  eosFaderPageTool
+} from '../index';
+
+class FakeOscService implements OscGateway {
+  public readonly sentMessages: OscMessage[] = [];
+
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  public send(message: OscMessage): void {
+    this.sentMessages.push(message);
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+}
+
+const runTool = async (tool: any, args: unknown): Promise<any> => {
+  const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
+  return handler(args, {});
+};
+
+describe('fader tools', () => {
+  let service: FakeOscService;
+
+  beforeEach(() => {
+    service = new FakeOscService();
+    const client = new OscClient(service, { defaultTimeoutMs: 50 });
+    setOscClient(client);
+    __resetFaderBankCacheForTests();
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it('cree un bank et initialise le cache', async () => {
+    await runTool(eosFaderBankCreateTool, { bank_index: 2, fader_count: 12, page_number: 3 });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const message = service.sentMessages[0];
+    expect(message).toMatchObject({ address: oscMappings.faders.bankCreate });
+
+    const payloadArg = message.args?.[0];
+    expect(payloadArg).toMatchObject({ type: 's' });
+
+    const payload = JSON.parse(String(payloadArg?.value));
+    expect(payload).toEqual({ bank: 2, faders: 12, page: 3 });
+  });
+
+  it('normalise les niveaux et respecte la page courante', async () => {
+    await runTool(eosFaderBankCreateTool, { bank_index: 1, fader_count: 10, page_number: 2 });
+    service.sentMessages.length = 0;
+
+    await runTool(eosFaderSetLevelTool, { bank_index: 1, fader_index: 4, level: '50%' });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const message = service.sentMessages[0];
+    expect(message.address).toBe(`${oscMappings.faders.base}/1/2/4`);
+    expect(message.args?.[0]).toMatchObject({ type: 'f', value: 0.5 });
+  });
+
+  it('maintient la pagination pour load et unload', async () => {
+    await runTool(eosFaderBankCreateTool, { bank_index: 3, fader_count: 6, page_number: 0 });
+    await runTool(eosFaderPageTool, { bank_index: 3, delta: 2 });
+    await runTool(eosFaderPageTool, { bank_index: 3, delta: 1 });
+
+    const pageResult = await runTool(eosFaderPageTool, { bank_index: 3, delta: -2 });
+    const pageData = (pageResult.content as any[]).find((item) => item.type === 'object');
+    expect(pageData.data).toMatchObject({ page: 1 });
+
+    service.sentMessages.length = 0;
+
+    await runTool(eosFaderSetLevelTool, { bank_index: 3, fader_index: 1, level: 0.75 });
+    await runTool(eosFaderLoadTool, { bank_index: 3, fader_index: 1 });
+    await runTool(eosFaderUnloadTool, { bank_index: 3, fader_index: 1 });
+
+    expect(service.sentMessages).toHaveLength(3);
+    expect(service.sentMessages[0].address).toBe(`${oscMappings.faders.base}/3/1/1`);
+    expect(service.sentMessages[0].args?.[0]).toMatchObject({ type: 'f', value: 0.75 });
+    expect(service.sentMessages[1].address).toBe(`${oscMappings.faders.base}/3/1/1/load`);
+    expect(service.sentMessages[2].address).toBe(`${oscMappings.faders.base}/3/1/1/unload`);
+  });
+
+  it('initialise un bank par defaut lors de la pagination', async () => {
+    const result = await runTool(eosFaderPageTool, { bank_index: 7, delta: 1 });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const message = service.sentMessages[0];
+    expect(message.address).toBe(oscMappings.faders.bankPage);
+
+    const payload = JSON.parse(String(message.args?.[0]?.value));
+    expect(payload).toEqual({ bank: 7, delta: 1 });
+
+    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    expect(objectContent.data).toMatchObject({ previousPage: 0, page: 1 });
+  });
+});

--- a/src/tools/faders/index.ts
+++ b/src/tools/faders/index.ts
@@ -1,0 +1,390 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import type { OscMessageArgument } from '../../services/osc/index.js';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types.js';
+
+interface FaderBankState {
+  page: number;
+  faderCount: number;
+}
+
+const LEVEL_KEYWORDS: Record<string, number> = {
+  full: 1,
+  out: 0
+};
+
+const bankStateCache = new Map<number, FaderBankState>();
+
+export function __resetFaderBankCacheForTests(): void {
+  bankStateCache.clear();
+}
+
+const targetOptionsSchema = {
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+} satisfies ZodRawShape;
+
+const bankIndexSchema = z
+  .number()
+  .int()
+  .min(0)
+  .describe('Index du bank de faders (0 = Main, 1 = Mains, etc.).');
+
+const faderIndexSchema = z
+  .number()
+  .int()
+  .min(1)
+  .describe('Position du fader dans le bank (1-n).');
+
+const levelValueSchema = z.union([z.number(), z.string().min(1)]);
+
+const bankCreateInputSchema = {
+  bank_index: bankIndexSchema,
+  fader_count: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .describe('Nombre de faders a creer dans le bank.'),
+  page_number: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe('Numero de page initial (0 par defaut).'),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const setLevelInputSchema = {
+  bank_index: bankIndexSchema,
+  fader_index: faderIndexSchema,
+  level: levelValueSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const loadInputSchema = {
+  bank_index: bankIndexSchema,
+  fader_index: faderIndexSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const pageInputSchema = {
+  bank_index: bankIndexSchema,
+  delta: z.number().int(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+function extractTargetOptions(options: { targetAddress?: string; targetPort?: number }): {
+  targetAddress?: string;
+  targetPort?: number;
+} {
+  const target: { targetAddress?: string; targetPort?: number } = {};
+  if (options.targetAddress) {
+    target.targetAddress = options.targetAddress;
+  }
+  if (typeof options.targetPort === 'number') {
+    target.targetPort = options.targetPort;
+  }
+  return target;
+}
+
+function annotate(osc: string): Record<string, unknown> {
+  return {
+    mapping: {
+      osc
+    }
+  };
+}
+
+function buildJsonArgs(payload: Record<string, unknown>): OscMessageArgument[] {
+  return [
+    {
+      type: 's' as const,
+      value: JSON.stringify(payload)
+    }
+  ];
+}
+
+function buildFloatArgs(value: number): OscMessageArgument[] {
+  return [
+    {
+      type: 'f',
+      value
+    }
+  ];
+}
+
+function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+  return {
+    content: [
+      { type: 'text', text },
+      { type: 'object', data }
+    ]
+  } as ToolExecutionResult;
+}
+
+function toNumber(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const withoutPercent = trimmed.endsWith('%') ? trimmed.slice(0, -1) : trimmed;
+  const normalised = withoutPercent.replace(',', '.');
+  const parsed = Number.parseFloat(normalised);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function resolveLevelValue(value: number | string): number {
+  let numeric: number | null = null;
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error('Le niveau doit etre un nombre fini.');
+    }
+    numeric = value;
+  } else {
+    const lowered = value.trim().toLowerCase();
+    if (lowered in LEVEL_KEYWORDS) {
+      numeric = LEVEL_KEYWORDS[lowered];
+    } else {
+      numeric = toNumber(value);
+    }
+  }
+
+  if (numeric == null) {
+    throw new Error("Impossible d'interpreter la valeur de niveau.");
+  }
+
+  if (numeric > 1) {
+    if (numeric > 100) {
+      throw new Error('Le niveau ne peut pas exceder 100%.');
+    }
+    numeric = numeric / 100;
+  }
+
+  if (numeric < 0 || numeric > 1) {
+    throw new Error('Le niveau doit etre compris entre 0 et 1 (ou 0% et 100%).');
+  }
+
+  return numeric;
+}
+
+function getBankState(bankIndex: number): FaderBankState {
+  const existing = bankStateCache.get(bankIndex);
+  if (existing) {
+    return existing;
+  }
+  const state: FaderBankState = { page: 0, faderCount: 0 };
+  bankStateCache.set(bankIndex, state);
+  return state;
+}
+
+function setBankState(bankIndex: number, state: FaderBankState): void {
+  bankStateCache.set(bankIndex, state);
+}
+
+function formatPercent(level: number): string {
+  const percent = level * 100;
+  return Number.isInteger(percent) ? `${percent}%` : `${percent.toFixed(1)}%`;
+}
+
+export const eosFaderBankCreateTool: ToolDefinition<typeof bankCreateInputSchema> = {
+  name: 'eos_fader_bank_create',
+  config: {
+    title: 'Creation de bank de faders',
+    description: 'Cree un bank de faders OSC avec pagination optionnelle.',
+    inputSchema: bankCreateInputSchema,
+    annotations: annotate(oscMappings.faders.bankCreate)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(bankCreateInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const payload: Record<string, unknown> = {
+      bank: options.bank_index,
+      faders: options.fader_count
+    };
+
+    const page = options.page_number ?? 0;
+    if (options.page_number != null) {
+      payload.page = page;
+    }
+
+    client.sendMessage(
+      oscMappings.faders.bankCreate,
+      buildJsonArgs(payload),
+      extractTargetOptions(options)
+    );
+
+    setBankState(options.bank_index, { page, faderCount: options.fader_count });
+
+    return createResult(`Bank ${options.bank_index} initialise avec ${options.fader_count} faders (page ${page}).`, {
+      action: 'fader_bank_create',
+      bank: options.bank_index,
+      faders: options.fader_count,
+      page,
+      request: payload,
+      osc: {
+        address: oscMappings.faders.bankCreate,
+        args: payload
+      }
+    });
+  }
+};
+
+export const eosFaderSetLevelTool: ToolDefinition<typeof setLevelInputSchema> = {
+  name: 'eos_fader_set_level',
+  config: {
+    title: 'Reglage de niveau de fader',
+    description: 'Definit le niveau (0-1 ou 0-100%) du fader cible.',
+    inputSchema: setLevelInputSchema,
+    annotations: annotate(`${oscMappings.faders.base}/{bank}/{page}/{fader}`)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(setLevelInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const state = getBankState(options.bank_index);
+    const level = resolveLevelValue(options.level);
+    const address = `${oscMappings.faders.base}/${options.bank_index}/${state.page}/${options.fader_index}`;
+
+    client.sendMessage(address, buildFloatArgs(level), extractTargetOptions(options));
+
+    return createResult(
+      `Fader ${options.bank_index}.${state.page}.${options.fader_index} regle a ${formatPercent(level)}.`,
+      {
+        action: 'fader_set_level',
+        bank: options.bank_index,
+        page: state.page,
+        fader: options.fader_index,
+        level,
+        osc: {
+          address,
+          args: [{ type: 'f', value: level }]
+        }
+      }
+    );
+  }
+};
+
+export const eosFaderLoadTool: ToolDefinition<typeof loadInputSchema> = {
+  name: 'eos_fader_load',
+  config: {
+    title: 'Chargement de fader',
+    description: 'Charge le contenu courant sur le fader specifie.',
+    inputSchema: loadInputSchema,
+    annotations: annotate(`${oscMappings.faders.base}/{bank}/{page}/{fader}/load`)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(loadInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const state = getBankState(options.bank_index);
+    const address = `${oscMappings.faders.base}/${options.bank_index}/${state.page}/${options.fader_index}/load`;
+
+    client.sendMessage(address, [], extractTargetOptions(options));
+
+    return createResult(
+      `Fader ${options.bank_index}.${state.page}.${options.fader_index} charge.`,
+      {
+        action: 'fader_load',
+        bank: options.bank_index,
+        page: state.page,
+        fader: options.fader_index,
+        osc: {
+          address,
+          args: []
+        }
+      }
+    );
+  }
+};
+
+export const eosFaderUnloadTool: ToolDefinition<typeof loadInputSchema> = {
+  name: 'eos_fader_unload',
+  config: {
+    title: 'Dechargement de fader',
+    description: 'Decharge le contenu du fader specifie.',
+    inputSchema: loadInputSchema,
+    annotations: annotate(`${oscMappings.faders.base}/{bank}/{page}/{fader}/unload`)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(loadInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const state = getBankState(options.bank_index);
+    const address = `${oscMappings.faders.base}/${options.bank_index}/${state.page}/${options.fader_index}/unload`;
+
+    client.sendMessage(address, [], extractTargetOptions(options));
+
+    return createResult(
+      `Fader ${options.bank_index}.${state.page}.${options.fader_index} decharge.`,
+      {
+        action: 'fader_unload',
+        bank: options.bank_index,
+        page: state.page,
+        fader: options.fader_index,
+        osc: {
+          address,
+          args: []
+        }
+      }
+    );
+  }
+};
+
+export const eosFaderPageTool: ToolDefinition<typeof pageInputSchema> = {
+  name: 'eos_fader_page',
+  config: {
+    title: 'Navigation de bank de faders',
+    description: 'Change de page dans le bank en ajoutant le delta specifie.',
+    inputSchema: pageInputSchema,
+    annotations: annotate(oscMappings.faders.bankPage)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(pageInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const state = getBankState(options.bank_index);
+    const previousPage = state.page;
+    const payload = {
+      bank: options.bank_index,
+      delta: options.delta
+    };
+
+    client.sendMessage(
+      oscMappings.faders.bankPage,
+      buildJsonArgs(payload),
+      extractTargetOptions(options)
+    );
+
+    const nextPage = Math.max(0, previousPage + options.delta);
+    state.page = nextPage;
+
+    return createResult(
+      `Bank ${options.bank_index}: passage de la page ${previousPage} a ${nextPage}.`,
+      {
+        action: 'fader_bank_page',
+        bank: options.bank_index,
+        previousPage,
+        page: nextPage,
+        request: payload,
+        osc: {
+          address: oscMappings.faders.bankPage,
+          args: payload
+        }
+      }
+    );
+  }
+};
+
+const faderTools = [
+  eosFaderBankCreateTool,
+  eosFaderSetLevelTool,
+  eosFaderLoadTool,
+  eosFaderUnloadTool,
+  eosFaderPageTool
+];
+
+export default faderTools;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -10,6 +10,7 @@ import cueTools from './cues/index.js';
 import paletteTools from './palettes/index.js';
 import presetTools from './presets/index.js';
 import submasterTools from './submasters/index.js';
+import faderTools from './faders/index.js';
 import type { ToolDefinition } from './types.js';
 
 export const toolDefinitions: ToolDefinition[] = [
@@ -24,7 +25,8 @@ export const toolDefinitions: ToolDefinition[] = [
   ...cueTools,
   ...paletteTools,
   ...presetTools,
-  ...submasterTools
+  ...submasterTools,
+  ...faderTools
 ];
 
 export default toolDefinitions;


### PR DESCRIPTION
## Summary
- ajoute des outils OSC pour gerer les banks de faders avec cache de pagination et conversion de niveaux
- enregistre le nouveau module faders et expose les mappings OSC correspondants
- couvre les cas multi-pages via des tests unitaires

## Testing
- npm test -- faders

------
https://chatgpt.com/codex/tasks/task_e_68f542e32ec4832a93e6141ad43db29b