### PR TITLE
Add parameter control tools with normalization

### DIFF
--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -46,6 +46,15 @@ export const oscMappings = {
     stop: '/eos/effect/stop',
     info: '/eos/get/effect'
   },
+  parameters: {
+    wheelTick: '/eos/param/wheel/tick',
+    wheelRate: '/eos/param/wheel/rate',
+    colorHs: '/eos/param/color/hs',
+    colorRgb: '/eos/param/color/rgb',
+    positionXY: '/eos/param/position/xy',
+    positionXYZ: '/eos/param/position/xyz',
+    activeWheels: '/eos/get/active/wheels'
+  },
   faders: {
     base: '/eos/fader',
     bankCreate: '/eos/fader/bank/create',

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import submasterTools from './submasters/index.js';
 import faderTools from './faders/index.js';
 import macroTools from './macros/index.js';
 import effectTools from './effects/index.js';
+import parameterTools from './parameters/index.js';
 import type { ToolDefinition } from './types.js';
 
 export const toolDefinitions: ToolDefinition[] = [
@@ -30,7 +31,8 @@ export const toolDefinitions: ToolDefinition[] = [
   ...submasterTools,
   ...faderTools,
   ...macroTools,
-  ...effectTools
+  ...effectTools,
+  ...parameterTools
 ];
 
 export default toolDefinitions;

--- a/src/tools/parameters/__tests__/parameters.test.ts
+++ b/src/tools/parameters/__tests__/parameters.test.ts
@@ -1,0 +1,183 @@
+import type { OscMessage } from '../../../services/osc/index';
+import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { oscMappings } from '../../../services/osc/mappings';
+import {
+  eosGetActiveWheelsTool,
+  eosSetColorHsTool,
+  eosSetColorRgbTool,
+  eosSetPanTiltXYTool,
+  eosSetXYZPositionTool,
+  eosWheelSwitchContinuousTool,
+  eosWheelTickTool
+} from '../index';
+
+type ToolHandler = (args: unknown, extra?: unknown) => Promise<any>;
+
+class FakeOscService implements OscGateway {
+  public readonly sentMessages: OscMessage[] = [];
+
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  public send(message: OscMessage): void {
+    this.sentMessages.push(message);
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public emit(message: OscMessage): void {
+    this.listeners.forEach((listener) => listener(message));
+  }
+}
+
+describe('parameter tools', () => {
+  let service: FakeOscService;
+
+  const runTool = async (tool: any, args: unknown): Promise<any> => {
+    const handler = tool.handler as ToolHandler;
+    return handler(args, {});
+  };
+
+  beforeEach(() => {
+    service = new FakeOscService();
+    const client = new OscClient(service, { defaultTimeoutMs: 50 });
+    setOscClient(client);
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it('normalise les ticks avant denvoyer une rotation de roue', async () => {
+    await runTool(eosWheelTickTool, { parameter_name: 'Pan ', ticks: ' 2,7 ', mode: 'fine' });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const [message] = service.sentMessages;
+    expect(message.address).toBe(oscMappings.parameters.wheelTick);
+    expect(message.args).toHaveLength(1);
+    const payload = JSON.parse(String(message.args?.[0]?.value ?? '{}'));
+    expect(payload).toEqual({ parameter: 'Pan', ticks: 3, mode: 'fine' });
+  });
+
+  it('normalise le taux continu et limite la valeur', async () => {
+    await runTool(eosWheelSwitchContinuousTool, { parameter_name: 'Tilt', rate: ' 120% ' });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const payload = JSON.parse(String(service.sentMessages[0].args?.[0]?.value ?? '{}'));
+    expect(payload.rate).toBe(1);
+  });
+
+  it('convertit les valeurs HS avec arrondis corrects', async () => {
+    await runTool(eosSetColorHsTool, { hue: '180deg', saturation: '62,5%' });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const payload = JSON.parse(String(service.sentMessages[0].args?.[0]?.value ?? '{}'));
+    expect(payload.hue).toBe(180);
+    expect(payload.saturation).toBeCloseTo(62.5, 3);
+  });
+
+  it('normalise les composantes RGB et positions XY', async () => {
+    await runTool(eosSetColorRgbTool, { red: '80%', green: '0,5', blue: 1.2 });
+    await runTool(eosSetPanTiltXYTool, { x: '75%', y: '1.5' });
+
+    expect(service.sentMessages).toHaveLength(2);
+    const rgbPayload = JSON.parse(String(service.sentMessages[0].args?.[0]?.value ?? '{}'));
+    expect(rgbPayload).toEqual({ red: 0.8, green: 0.5, blue: 1 });
+
+    const xyPayload = JSON.parse(String(service.sentMessages[1].args?.[0]?.value ?? '{}'));
+    expect(xyPayload).toEqual({ x: 0.75, y: 1 });
+  });
+
+  it('convertit les coordonnees XYZ en conservant les decimales', async () => {
+    await runTool(eosSetXYZPositionTool, { x: '2,5m', y: '-1.234', z: '0.7777' });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const payload = JSON.parse(String(service.sentMessages[0].args?.[0]?.value ?? '{}'));
+    expect(payload).toEqual({ x: 2.5, y: -1.234, z: 0.778 });
+  });
+
+  it('normalise la reponse des encodeurs actifs', async () => {
+    const promise = runTool(eosGetActiveWheelsTool, {});
+
+    queueMicrotask(() => {
+      const payload = {
+        status: 'ok',
+        wheels: [
+          {
+            index: '1',
+            parameter: 'Pan',
+            label: 'Pan',
+            display_value: 'Pan 50%',
+            value: '0.5',
+            coarse: '50%',
+            fine: 0.52,
+            unit: '%'
+          },
+          {
+            wheel_index: '2',
+            parameter_name: 'Tilt',
+            display: 'Tilt 30°',
+            raw_value: '30',
+            fine_value: '3000%',
+            units: 'deg'
+          },
+          {
+            slot: 3,
+            name: 'Color',
+            percent: '75%'
+          }
+        ]
+      };
+
+      service.emit({
+        address: oscMappings.parameters.activeWheels,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify(payload)
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    expect(objectContent?.data.status).toBe('ok');
+    expect(objectContent?.data.wheels).toEqual([
+      {
+        wheelIndex: 1,
+        parameter: 'Pan',
+        label: 'Pan',
+        display: 'Pan 50%',
+        units: '%',
+        rawValue: 0.5,
+        coarseValue: 0.5,
+        fineValue: 0.52
+      },
+      {
+        wheelIndex: 2,
+        parameter: 'Tilt',
+        label: null,
+        display: 'Tilt 30°',
+        units: 'deg',
+        rawValue: 30,
+        coarseValue: null,
+        fineValue: 30
+      },
+      {
+        wheelIndex: 3,
+        parameter: 'Color',
+        label: null,
+        display: null,
+        units: null,
+        rawValue: 0.75,
+        coarseValue: null,
+        fineValue: null
+      }
+    ]);
+  });
+});

--- a/src/tools/parameters/index.ts
+++ b/src/tools/parameters/index.ts
@@ -1,0 +1,609 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
+import type { OscMessageArgument } from '../../services/osc/index';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types.js';
+
+const targetOptionsSchema = {
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+} satisfies ZodRawShape;
+
+const numericInputSchema = z.union([z.number(), z.string().min(1)]);
+
+function buildJsonArgs(payload: Record<string, unknown>): OscMessageArgument[] {
+  return [
+    {
+      type: 's' as const,
+      value: JSON.stringify(payload)
+    }
+  ];
+}
+
+function extractTargetOptions(options: { targetAddress?: string; targetPort?: number }): {
+  targetAddress?: string;
+  targetPort?: number;
+} {
+  const target: { targetAddress?: string; targetPort?: number } = {};
+  if (options.targetAddress) {
+    target.targetAddress = options.targetAddress;
+  }
+  if (typeof options.targetPort === 'number') {
+    target.targetPort = options.targetPort;
+  }
+  return target;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null && !Array.isArray(value);
+}
+
+function roundTo(value: number, precision: number): number {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+function parseNumeric(value: unknown): { value: number; hadPercent: boolean } | null {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+    return { value, hadPercent: false };
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return null;
+    }
+
+    let hadPercent = false;
+    let cleaned = trimmed;
+
+    if (cleaned.endsWith('%')) {
+      hadPercent = true;
+      cleaned = cleaned.slice(0, -1);
+    }
+
+    cleaned = cleaned.replace(/,/g, '.');
+    cleaned = cleaned.replace(/\u00b0|deg|degrees/gi, '');
+    cleaned = cleaned.replace(/[^0-9.+-]/g, '');
+
+    if (cleaned.length === 0) {
+      return null;
+    }
+
+    const parsed = Number.parseFloat(cleaned);
+    if (!Number.isFinite(parsed)) {
+      return null;
+    }
+
+    return { value: parsed, hadPercent };
+  }
+
+  return null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function normaliseTicks(value: unknown): number {
+  const numeric = parseNumeric(value);
+  if (numeric == null) {
+    throw new Error('Impossible de normaliser le nombre de ticks.');
+  }
+
+  return Math.round(numeric.value);
+}
+
+function normaliseRate(value: unknown): number {
+  const numeric = parseNumeric(value);
+  if (numeric == null) {
+    throw new Error("Impossible d'interpreter le taux continue.");
+  }
+
+  let rate = numeric.value;
+
+  const shouldConvertToPercent =
+    numeric.hadPercent ||
+    (Math.abs(rate) > 1 && Math.abs(rate) <= 100 && Number.isInteger(rate));
+
+  if (shouldConvertToPercent) {
+    rate /= 100;
+  }
+
+  rate = clamp(rate, -1, 1);
+  return roundTo(rate, 3);
+}
+
+function normaliseHue(value: unknown): number {
+  const numeric = parseNumeric(value);
+  if (numeric == null) {
+    throw new Error("Impossible d'interpreter la teinte (hue).");
+  }
+
+  const hue = clamp(numeric.value, 0, 360);
+  return roundTo(hue, 2);
+}
+
+function normalisePercentage(value: unknown, label: string): number {
+  const numeric = parseNumeric(value);
+  if (numeric == null) {
+    throw new Error(`Impossible d'interpreter ${label}.`);
+  }
+
+  let resolved = numeric.value;
+  const shouldConvertToPercent =
+    numeric.hadPercent || (resolved > 1 && resolved <= 100 && Number.isInteger(resolved));
+
+  if (shouldConvertToPercent) {
+    resolved /= 100;
+  }
+
+  resolved = clamp(resolved, 0, 1);
+  return roundTo(resolved, 4);
+}
+
+function normaliseCoordinate(value: unknown, label: string): number {
+  const numeric = parseNumeric(value);
+  if (numeric == null) {
+    throw new Error(`Impossible d'interpreter la coordonnee ${label}.`);
+  }
+
+  return roundTo(numeric.value, 3);
+}
+
+function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+  return {
+    content: [
+      { type: 'text', text },
+      { type: 'object', data }
+    ]
+  } as ToolExecutionResult;
+}
+
+function annotate(osc: string): Record<string, unknown> {
+  return {
+    mapping: {
+      osc
+    }
+  };
+}
+
+function normaliseParameterName(name: unknown): string {
+  if (typeof name !== 'string') {
+    throw new Error("Le nom du parametre doit etre une chaine de caracteres.");
+  }
+
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Le nom du parametre ne peut pas etre vide.');
+  }
+
+  return trimmed;
+}
+
+function toStringOrNull(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+}
+
+interface ActiveWheelInfo {
+  wheelIndex: number;
+  parameter: string;
+  label: string | null;
+  display: string | null;
+  rawValue: number | null;
+  coarseValue: number | null;
+  fineValue: number | null;
+  units: string | null;
+}
+
+function parseWheelNumeric(source: Record<string, unknown>, keys: string[]): number | null {
+  for (const key of keys) {
+    if (key in source) {
+      const numeric = parseNumeric(source[key]);
+      if (numeric) {
+        const base = numeric.hadPercent ? numeric.value / 100 : numeric.value;
+        if (Number.isFinite(base)) {
+          return roundTo(base, 4);
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function parseWheelIndex(source: Record<string, unknown>): number | null {
+  const numeric = parseWheelNumeric(source, ['wheel', 'wheel_index', 'index', 'slot', 'id', 'encoder']);
+  return numeric != null ? Math.trunc(numeric) : null;
+}
+
+function parseWheelParameter(source: Record<string, unknown>): string | null {
+  const candidates = ['parameter', 'parameter_name', 'name', 'param'];
+  for (const key of candidates) {
+    if (key in source) {
+      const value = toStringOrNull(source[key]);
+      if (value) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function normaliseActiveWheel(raw: unknown): ActiveWheelInfo | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+
+  const wheelIndex = parseWheelIndex(raw);
+  const parameter = parseWheelParameter(raw);
+
+  if (wheelIndex == null || parameter == null) {
+    return null;
+  }
+
+  const label =
+    toStringOrNull(raw.label) ??
+    toStringOrNull(raw.display_label) ??
+    toStringOrNull(raw.parameter_label) ??
+    null;
+
+  const display =
+    toStringOrNull(raw.display) ??
+    toStringOrNull(raw.display_value) ??
+    toStringOrNull(raw.displayValue) ??
+    null;
+
+  const units =
+    toStringOrNull(raw.unit) ??
+    toStringOrNull(raw.units) ??
+    toStringOrNull(raw.display_units) ??
+    null;
+
+  const rawValue = parseWheelNumeric(raw, ['value', 'raw', 'raw_value', 'rawValue', 'percent']);
+  const coarseValue = parseWheelNumeric(raw, ['coarse', 'coarse_value', 'coarseValue']);
+  const fineValue = parseWheelNumeric(raw, ['fine', 'fine_value', 'fineValue']);
+
+  return {
+    wheelIndex,
+    parameter,
+    label,
+    display,
+    units,
+    rawValue,
+    coarseValue,
+    fineValue
+  };
+}
+
+function extractActiveWheels(payload: unknown): ActiveWheelInfo[] {
+  if (!isRecord(payload)) {
+    return [];
+  }
+
+  const sourceList = Array.isArray(payload.wheels)
+    ? payload.wheels
+    : Array.isArray(payload.parameters)
+      ? payload.parameters
+      : [];
+
+  return sourceList
+    .map((item) => normaliseActiveWheel(item))
+    .filter((item): item is ActiveWheelInfo => item != null)
+    .sort((a, b) => a.wheelIndex - b.wheelIndex);
+}
+
+const wheelTickInputSchema = {
+  parameter_name: z.string().min(1),
+  ticks: numericInputSchema,
+  mode: z.enum(['coarse', 'fine']).optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const wheelRateInputSchema = {
+  parameter_name: z.string().min(1),
+  rate: numericInputSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const colorHsInputSchema = {
+  hue: numericInputSchema,
+  saturation: numericInputSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const colorRgbInputSchema = {
+  red: numericInputSchema,
+  green: numericInputSchema,
+  blue: numericInputSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const panTiltInputSchema = {
+  x: numericInputSchema,
+  y: numericInputSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const xyzInputSchema = {
+  x: numericInputSchema,
+  y: numericInputSchema,
+  z: numericInputSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const getActiveWheelsSchema = {
+  timeoutMs: z.number().int().min(50).optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+export const eosWheelTickTool: ToolDefinition<typeof wheelTickInputSchema> = {
+  name: 'eos_wheel_tick',
+  config: {
+    title: "Rotation d'encodeur",
+    description: "Simule une rotation d'encodeur pour un parametre donne.",
+    inputSchema: wheelTickInputSchema,
+    annotations: annotate(oscMappings.parameters.wheelTick)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(wheelTickInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const parameter = normaliseParameterName(options.parameter_name);
+    const ticks = normaliseTicks(options.ticks);
+    const mode = options.mode ?? 'coarse';
+
+    const payload = {
+      parameter,
+      ticks,
+      mode
+    };
+
+    client.sendMessage(
+      oscMappings.parameters.wheelTick,
+      buildJsonArgs(payload),
+      extractTargetOptions(options)
+    );
+
+    return createResult(`Rotation ${mode} de ${ticks} ticks sur ${parameter}`, {
+      parameter,
+      ticks,
+      mode,
+      osc: {
+        address: oscMappings.parameters.wheelTick,
+        args: payload
+      }
+    });
+  }
+};
+
+export const eosWheelSwitchContinuousTool: ToolDefinition<typeof wheelRateInputSchema> = {
+  name: 'eos_switch_continuous',
+  config: {
+    title: 'Mouvement continu',
+    description: "Active un mouvement continu d'encodeur sur un parametre.",
+    inputSchema: wheelRateInputSchema,
+    annotations: annotate(oscMappings.parameters.wheelRate)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(wheelRateInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const parameter = normaliseParameterName(options.parameter_name);
+    const rate = normaliseRate(options.rate);
+
+    const payload = {
+      parameter,
+      rate
+    };
+
+    client.sendMessage(
+      oscMappings.parameters.wheelRate,
+      buildJsonArgs(payload),
+      extractTargetOptions(options)
+    );
+
+    return createResult(`Mouvement continu ${rate} sur ${parameter}`, {
+      parameter,
+      rate,
+      osc: {
+        address: oscMappings.parameters.wheelRate,
+        args: payload
+      }
+    });
+  }
+};
+
+export const eosSetColorHsTool: ToolDefinition<typeof colorHsInputSchema> = {
+  name: 'eos_set_color_hs',
+  config: {
+    title: 'Couleur HS',
+    description: 'Definit une couleur via Hue/Saturation.',
+    inputSchema: colorHsInputSchema,
+    annotations: annotate(oscMappings.parameters.colorHs)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(colorHsInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+
+    const payload = {
+      hue: normaliseHue(options.hue),
+      saturation: normalisePercentage(options.saturation, 'la saturation') * 100
+    };
+
+    client.sendMessage(
+      oscMappings.parameters.colorHs,
+      buildJsonArgs(payload),
+      extractTargetOptions(options)
+    );
+
+    return createResult(`Couleur HS definie (H=${payload.hue}°, S=${roundTo(payload.saturation, 2)}%)`, {
+      hue: payload.hue,
+      saturation: roundTo(payload.saturation, 2),
+      osc: {
+        address: oscMappings.parameters.colorHs,
+        args: payload
+      }
+    });
+  }
+};
+
+export const eosSetColorRgbTool: ToolDefinition<typeof colorRgbInputSchema> = {
+  name: 'eos_set_color_rgb',
+  config: {
+    title: 'Couleur RGB',
+    description: 'Definit une couleur via valeurs RGB (0-1).',
+    inputSchema: colorRgbInputSchema,
+    annotations: annotate(oscMappings.parameters.colorRgb)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(colorRgbInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+
+    const payload = {
+      red: normalisePercentage(options.red, 'le rouge'),
+      green: normalisePercentage(options.green, 'le vert'),
+      blue: normalisePercentage(options.blue, 'le bleu')
+    };
+
+    client.sendMessage(
+      oscMappings.parameters.colorRgb,
+      buildJsonArgs(payload),
+      extractTargetOptions(options)
+    );
+
+    return createResult(`Couleur RGB definie (${payload.red}, ${payload.green}, ${payload.blue})`, {
+      ...payload,
+      osc: {
+        address: oscMappings.parameters.colorRgb,
+        args: payload
+      }
+    });
+  }
+};
+
+export const eosSetPanTiltXYTool: ToolDefinition<typeof panTiltInputSchema> = {
+  name: 'eos_set_pantilt_xy',
+  config: {
+    title: 'Position Pan/Tilt XY',
+    description: 'Definit une position normalisee sur le plan XY (0-1).',
+    inputSchema: panTiltInputSchema,
+    annotations: annotate(oscMappings.parameters.positionXY)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(panTiltInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+
+    const payload = {
+      x: normalisePercentage(options.x, 'x'),
+      y: normalisePercentage(options.y, 'y')
+    };
+
+    client.sendMessage(
+      oscMappings.parameters.positionXY,
+      buildJsonArgs(payload),
+      extractTargetOptions(options)
+    );
+
+    return createResult(`Position XY definie (${payload.x}, ${payload.y})`, {
+      ...payload,
+      osc: {
+        address: oscMappings.parameters.positionXY,
+        args: payload
+      }
+    });
+  }
+};
+
+export const eosSetXYZPositionTool: ToolDefinition<typeof xyzInputSchema> = {
+  name: 'eos_set_xyz_position',
+  config: {
+    title: 'Position XYZ',
+    description: 'Definit une position XYZ en metres.',
+    inputSchema: xyzInputSchema,
+    annotations: annotate(oscMappings.parameters.positionXYZ)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(xyzInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+
+    const payload = {
+      x: normaliseCoordinate(options.x, 'x'),
+      y: normaliseCoordinate(options.y, 'y'),
+      z: normaliseCoordinate(options.z, 'z')
+    };
+
+    client.sendMessage(
+      oscMappings.parameters.positionXYZ,
+      buildJsonArgs(payload),
+      extractTargetOptions(options)
+    );
+
+    return createResult(`Position XYZ definie (${payload.x}, ${payload.y}, ${payload.z})`, {
+      ...payload,
+      osc: {
+        address: oscMappings.parameters.positionXYZ,
+        args: payload
+      }
+    });
+  }
+};
+
+export const eosGetActiveWheelsTool: ToolDefinition<typeof getActiveWheelsSchema> = {
+  name: 'eos_get_active_wheels',
+  config: {
+    title: 'Encodeurs actifs',
+    description: 'Recupere et normalise la liste des encodeurs actifs.',
+    inputSchema: getActiveWheelsSchema,
+    annotations: annotate(oscMappings.parameters.activeWheels)
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(getActiveWheelsSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+
+    const response: OscJsonResponse = await client.requestJson(oscMappings.parameters.activeWheels, {
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort,
+      timeoutMs: options.timeoutMs
+    });
+
+    const wheels = extractActiveWheels(response.data);
+
+    return createResult(`Encodeurs actifs (${wheels.length})`, {
+      status: response.status,
+      wheels,
+      osc: {
+        request: oscMappings.parameters.activeWheels,
+        response: response.payload
+      }
+    });
+  }
+};
+
+const parameterTools = [
+  eosWheelTickTool,
+  eosWheelSwitchContinuousTool,
+  eosSetColorHsTool,
+  eosSetColorRgbTool,
+  eosSetPanTiltXYTool,
+  eosSetXYZPositionTool,
+  eosGetActiveWheelsTool
+];
+
+export default parameterTools;


### PR DESCRIPTION
## Summary
- add OSC parameter mappings and implement tools for wheel ticks, continuous motion, color, and position updates with input normalization
- parse active wheel responses into normalized structures and expose a retrieval tool
- cover numeric conversions and active wheel parsing with focused tests

## Testing
- npm test -- --runTestsByPath src/tools/parameters/__tests__/parameters.test.ts
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f54d2c7284832a86d8c9157d58c684