### PR TITLE
Add direct select MCP tools with pagination tracking

### DIFF
--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -60,6 +60,11 @@ export const oscMappings = {
     bankCreate: '/eos/fader/bank/create',
     bankPage: '/eos/fader/bank/page'
   },
+  directSelects: {
+    base: '/eos/direct_select/bank',
+    bankCreate: '/eos/direct_select/bank/create',
+    bankPage: '/eos/direct_select/bank/page'
+  },
   submasters: {
     base: '/eos/sub',
     info: '/eos/get/submaster'

--- a/src/tools/directSelects/__tests__/directSelects.test.ts
+++ b/src/tools/directSelects/__tests__/directSelects.test.ts
@@ -1,0 +1,160 @@
+import type { OscMessage } from '../../../services/osc/index';
+import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { oscMappings } from '../../../services/osc/mappings';
+import {
+  __resetDirectSelectBankCacheForTests,
+  eosDirectSelectBankCreateTool,
+  eosDirectSelectPageTool,
+  eosDirectSelectPressTool
+} from '../index';
+
+class FakeOscService implements OscGateway {
+  public readonly sentMessages: OscMessage[] = [];
+
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  public send(message: OscMessage): void {
+    this.sentMessages.push(message);
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+}
+
+const runTool = async (tool: any, args: unknown): Promise<any> => {
+  const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
+  return handler(args, {});
+};
+
+describe('direct select tools', () => {
+  let service: FakeOscService;
+
+  beforeEach(() => {
+    service = new FakeOscService();
+    const client = new OscClient(service, { defaultTimeoutMs: 50 });
+    setOscClient(client);
+    __resetDirectSelectBankCacheForTests();
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it('cree un bank avec normalisation du type et conserve la page', async () => {
+    await runTool(eosDirectSelectBankCreateTool, {
+      bank_index: 2,
+      target_type: 'group',
+      button_count: 40,
+      flexi_mode: true,
+      page_number: 3
+    });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const message = service.sentMessages[0];
+    expect(message.address).toBe(oscMappings.directSelects.bankCreate);
+
+    const payload = JSON.parse(String(message.args?.[0]?.value));
+    expect(payload).toEqual({ bank: 2, target: 'Group', buttons: 40, flexi: true, page: 3 });
+
+    service.sentMessages.length = 0;
+
+    await runTool(eosDirectSelectPressTool, { bank_index: 2, button_index: 5, state: 1 });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const pressMessage = service.sentMessages[0];
+    expect(pressMessage.address).toBe(`${oscMappings.directSelects.base}/2/3/5`);
+    expect(pressMessage.args?.[0]).toMatchObject({ type: 'f', value: 1 });
+  });
+
+  it('gere la pagination locale et evite les pages negatives', async () => {
+    await runTool(eosDirectSelectBankCreateTool, {
+      bank_index: 4,
+      target_type: 'Chan',
+      button_count: 20,
+      flexi_mode: false,
+      page_number: 1
+    });
+
+    service.sentMessages.length = 0;
+
+    const nextPageResult = await runTool(eosDirectSelectPageTool, { bank_index: 4, delta: 2 });
+    expect(service.sentMessages).toHaveLength(1);
+    const forwardMessage = service.sentMessages[0];
+    expect(forwardMessage.address).toBe(oscMappings.directSelects.bankPage);
+    const forwardPayload = JSON.parse(String(forwardMessage.args?.[0]?.value));
+    expect(forwardPayload).toEqual({ bank: 4, delta: 2 });
+
+    const forwardData = (nextPageResult.content as any[]).find((item) => item.type === 'object');
+    expect(forwardData.data).toMatchObject({ previousPage: 1, page: 3 });
+
+    service.sentMessages.length = 0;
+
+    const backResult = await runTool(eosDirectSelectPageTool, { bank_index: 4, delta: -5 });
+    expect(service.sentMessages).toHaveLength(1);
+    const backMessage = service.sentMessages[0];
+    expect(backMessage.address).toBe(oscMappings.directSelects.bankPage);
+    const backPayload = JSON.parse(String(backMessage.args?.[0]?.value));
+    expect(backPayload).toEqual({ bank: 4, delta: -5 });
+
+    const backData = (backResult.content as any[]).find((item) => item.type === 'object');
+    expect(backData.data).toMatchObject({ previousPage: 3, page: 0 });
+
+    service.sentMessages.length = 0;
+
+    await runTool(eosDirectSelectPressTool, { bank_index: 4, button_index: 1, state: 0 });
+    expect(service.sentMessages).toHaveLength(1);
+    expect(service.sentMessages[0].address).toBe(`${oscMappings.directSelects.base}/4/0/1`);
+  });
+
+  it('supporte plusieurs types de cibles', async () => {
+    const combinations = [
+      { input: 'Chan', expected: 'Chan' },
+      { input: 'FX', expected: 'FX' },
+      { input: 'scene', expected: 'Scene' }
+    ];
+
+    for (const [index, combo] of combinations.entries()) {
+      service.sentMessages.length = 0;
+      await runTool(eosDirectSelectBankCreateTool, {
+        bank_index: 10 + index,
+        target_type: combo.input,
+        button_count: 8,
+        flexi_mode: false
+      });
+
+      expect(service.sentMessages).toHaveLength(1);
+      const message = service.sentMessages[0];
+      expect(message.address).toBe(oscMappings.directSelects.bankCreate);
+      const payload = JSON.parse(String(message.args?.[0]?.value));
+      expect(payload.target).toBe(combo.expected);
+    }
+  });
+
+  it('refuse un appui hors limites', async () => {
+    await runTool(eosDirectSelectBankCreateTool, {
+      bank_index: 6,
+      target_type: 'Macro',
+      button_count: 10,
+      flexi_mode: false
+    });
+
+    await expect(
+      runTool(eosDirectSelectPressTool, { bank_index: 6, button_index: 11, state: 1 })
+    ).rejects.toThrow('depasse');
+  });
+
+  it('rejette un type de cible invalide', async () => {
+    await expect(
+      runTool(eosDirectSelectBankCreateTool, {
+        bank_index: 1,
+        target_type: 'invalid',
+        button_count: 5,
+        flexi_mode: false
+      })
+    ).rejects.toThrow('Type de cible invalide');
+  });
+});

--- a/src/tools/directSelects/index.ts
+++ b/src/tools/directSelects/index.ts
@@ -1,0 +1,380 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient } from '../../services/osc/client';
+import type { OscMessageArgument } from '../../services/osc/index';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+
+interface DirectSelectBankState {
+  page: number;
+  targetType: string;
+  buttonCount: number;
+  flexiMode: boolean;
+}
+
+interface DirectSelectTargetOptions {
+  targetAddress?: string;
+  targetPort?: number;
+}
+
+interface BankCreateOptions extends DirectSelectTargetOptions {
+  bank_index: number;
+  target_type: string;
+  button_count: number;
+  flexi_mode: boolean;
+  page_number?: number;
+}
+
+interface PressOptions extends DirectSelectTargetOptions {
+  bank_index: number;
+  button_index: number;
+  state: number;
+}
+
+interface PageOptions extends DirectSelectTargetOptions {
+  bank_index: number;
+  delta: number;
+}
+
+const TARGET_TYPE_LOOKUP: Record<string, string> = {
+  chan: 'Chan',
+  group: 'Group',
+  macro: 'Macro',
+  sub: 'Sub',
+  preset: 'Preset',
+  ip: 'IP',
+  fp: 'FP',
+  cp: 'CP',
+  bp: 'BP',
+  ms: 'MS',
+  curve: 'Curve',
+  snap: 'Snap',
+  fx: 'FX',
+  pixmap: 'Pixmap',
+  scene: 'Scene'
+};
+
+const TARGET_TYPE_ERROR_MESSAGE = [
+  'Type de cible invalide. Valeurs supportees:',
+  'Chan, Group, Macro, Sub, Preset, IP, FP, CP, BP, MS, Curve, Snap, FX, Pixmap, Scene.'
+].join(' ');
+
+const bankStateCache = new Map<number, DirectSelectBankState>();
+
+export function __resetDirectSelectBankCacheForTests(): void {
+  bankStateCache.clear();
+}
+
+function getBankState(bankIndex: number): DirectSelectBankState {
+  const existing = bankStateCache.get(bankIndex);
+  if (existing) {
+    return existing;
+  }
+
+  const state: DirectSelectBankState = {
+    page: 0,
+    targetType: 'Chan',
+    buttonCount: 0,
+    flexiMode: false
+  };
+  bankStateCache.set(bankIndex, state);
+  return state;
+}
+
+function setBankState(bankIndex: number, state: DirectSelectBankState): void {
+  bankStateCache.set(bankIndex, state);
+}
+
+function buildJsonArgs(payload: Record<string, unknown>): OscMessageArgument[] {
+  return [
+    {
+      type: 's',
+      value: JSON.stringify(payload)
+    }
+  ];
+}
+
+function buildFloatArgs(value: number): OscMessageArgument[] {
+  return [
+    {
+      type: 'f',
+      value
+    }
+  ];
+}
+
+function extractTargetOptions(options: DirectSelectTargetOptions): DirectSelectTargetOptions {
+  const target: DirectSelectTargetOptions = {};
+  if (options.targetAddress) {
+    target.targetAddress = options.targetAddress;
+  }
+  if (typeof options.targetPort === 'number') {
+    target.targetPort = options.targetPort;
+  }
+  return target;
+}
+
+function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+  return {
+    content: [
+      { type: 'text', text },
+      { type: 'object', data }
+    ]
+  } as ToolExecutionResult;
+}
+
+function normaliseTargetType(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const key = trimmed.toLowerCase();
+  return TARGET_TYPE_LOOKUP[key] ?? null;
+}
+
+const targetOptionsSchema = {
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+} satisfies ZodRawShape;
+
+const bankIndexSchema = z
+  .number()
+  .int()
+  .min(0)
+  .describe("Index du bank de direct selects (0 pour le premier bank).");
+
+const buttonIndexSchema = z
+  .number()
+  .int()
+  .min(1)
+  .describe('Position du bouton dans le bank (1-n).');
+
+const stateValueSchema = z
+  .number()
+  .finite()
+  .min(0)
+  .max(1)
+  .describe('Etat du bouton (1.0 = enfonce, 0.0 = relache).');
+
+const targetTypeSchema = z
+  .string()
+  .min(1)
+  .transform((value, ctx) => {
+    const normalised = normaliseTargetType(value);
+    if (!normalised) {
+      ctx.addIssue({
+        code: 'custom',
+        message: TARGET_TYPE_ERROR_MESSAGE
+      });
+      return z.NEVER;
+    }
+    return normalised;
+  });
+
+const bankCreateInputSchema = {
+  bank_index: bankIndexSchema,
+  target_type: targetTypeSchema,
+  button_count: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .describe('Nombre de boutons a creer dans le bank (1-100).'),
+  flexi_mode: z.boolean().describe('Active ou non le mode Flexi pour le bank.'),
+  page_number: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe('Page initiale (0 par defaut).'),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const pressInputSchema = {
+  bank_index: bankIndexSchema,
+  button_index: buttonIndexSchema,
+  state: stateValueSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const pageInputSchema = {
+  bank_index: bankIndexSchema,
+  delta: z.number().int(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const bankCreateSchema = z.object(bankCreateInputSchema).strict();
+
+const pressSchema = z.object(pressInputSchema).strict();
+
+const pageSchema = z.object(pageInputSchema).strict();
+
+export const eosDirectSelectBankCreateTool: ToolDefinition<typeof bankCreateInputSchema> = {
+  name: 'eos_direct_select_bank_create',
+  config: {
+    title: 'Creation de bank de direct selects',
+    description: 'Cree un bank de direct selects OSC avec configuration de cible et pagination.',
+    inputSchema: bankCreateInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.directSelects.bankCreate
+      }
+    }
+  },
+  handler: async (args) => {
+    const options: BankCreateOptions = bankCreateSchema.parse(args ?? {});
+    const client = getOscClient();
+
+    const payload: Record<string, unknown> = {
+      bank: options.bank_index,
+      target: options.target_type,
+      buttons: options.button_count,
+      flexi: options.flexi_mode
+    };
+
+    const state: DirectSelectBankState = {
+      page: options.page_number ?? 0,
+      targetType: options.target_type,
+      buttonCount: options.button_count,
+      flexiMode: options.flexi_mode
+    };
+
+    if (typeof options.page_number === 'number') {
+      payload.page = options.page_number;
+    }
+
+    setBankState(options.bank_index, state);
+
+    client.sendMessage(
+      oscMappings.directSelects.bankCreate,
+      buildJsonArgs(payload),
+      extractTargetOptions(options)
+    );
+
+    const textParts = [
+      `Bank ${options.bank_index} configure en ${options.target_type}`,
+      `${options.button_count} boutons`,
+      `Flexi ${options.flexi_mode ? 'active' : 'desactive'}`
+    ];
+
+    if (typeof options.page_number === 'number') {
+      textParts.push(`page ${options.page_number}`);
+    }
+
+    return createResult(textParts.join(' - '), {
+      action: 'direct_select_bank_create',
+      bank: options.bank_index,
+      page: state.page,
+      targetType: state.targetType,
+      buttonCount: state.buttonCount,
+      flexiMode: state.flexiMode,
+      request: payload,
+      osc: {
+        address: oscMappings.directSelects.bankCreate,
+        args: payload
+      }
+    });
+  }
+};
+
+export const eosDirectSelectPressTool: ToolDefinition<typeof pressInputSchema> = {
+  name: 'eos_direct_select_press',
+  config: {
+    title: 'Appui de direct select',
+    description: 'Simule un appui ou relachement sur un bouton de direct select.',
+    inputSchema: pressInputSchema
+  },
+  handler: async (args) => {
+    const options: PressOptions = pressSchema.parse(args ?? {});
+    const client = getOscClient();
+    const state = getBankState(options.bank_index);
+
+    if (state.buttonCount > 0 && options.button_index > state.buttonCount) {
+      throw new Error(
+        `Le bouton ${options.button_index} depasse le nombre de boutons configure (${state.buttonCount}).`
+      );
+    }
+
+    const address = `${oscMappings.directSelects.base}/${options.bank_index}/${state.page}/${options.button_index}`;
+    const stateValue: number = options.state;
+
+    client.sendMessage(address, buildFloatArgs(stateValue), extractTargetOptions(options));
+
+    const actionText = stateValue >= 1 ? 'enfonce' : stateValue <= 0 ? 'relache' : `etat ${stateValue}`;
+    const text = `Bank ${options.bank_index} page ${state.page}: bouton ${options.button_index} ${actionText}.`;
+
+    return createResult(text, {
+      action: 'direct_select_press',
+      bank: options.bank_index,
+      page: state.page,
+      button: options.button_index,
+      buttonCount: state.buttonCount,
+      targetType: state.targetType,
+      flexiMode: state.flexiMode,
+      state: stateValue,
+      osc: {
+        address,
+        args: stateValue
+      }
+    });
+  }
+};
+
+export const eosDirectSelectPageTool: ToolDefinition<typeof pageInputSchema> = {
+  name: 'eos_direct_select_page',
+  config: {
+    title: 'Navigation de direct select',
+    description: 'Change la page active dans un bank de direct selects.',
+    inputSchema: pageInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.directSelects.bankPage
+      }
+    }
+  },
+  handler: async (args) => {
+    const options: PageOptions = pageSchema.parse(args ?? {});
+    const client = getOscClient();
+    const state = getBankState(options.bank_index);
+    const previousPage = state.page;
+
+    const payload = {
+      bank: options.bank_index,
+      delta: options.delta
+    };
+
+    client.sendMessage(
+      oscMappings.directSelects.bankPage,
+      buildJsonArgs(payload),
+      extractTargetOptions(options)
+    );
+
+    const nextPage = Math.max(0, previousPage + options.delta);
+    state.page = nextPage;
+
+    return createResult(
+      `Bank ${options.bank_index}: passage de la page ${previousPage} a ${nextPage}.`,
+      {
+        action: 'direct_select_bank_page',
+        bank: options.bank_index,
+        previousPage,
+        page: nextPage,
+        targetType: state.targetType,
+        buttonCount: state.buttonCount,
+        flexiMode: state.flexiMode,
+        request: payload,
+        osc: {
+          address: oscMappings.directSelects.bankPage,
+          args: payload
+        }
+      }
+    );
+  }
+};
+
+const directSelectTools = [
+  eosDirectSelectBankCreateTool,
+  eosDirectSelectPressTool,
+  eosDirectSelectPageTool
+];
+
+export default directSelectTools;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,6 +15,7 @@ import macroTools from './macros/index.js';
 import effectTools from './effects/index.js';
 import parameterTools from './parameters/index.js';
 import keyTools from './keys/index.js';
+import directSelectTools from './directSelects/index.js';
 import type { ToolDefinition } from './types.js';
 
 export const toolDefinitions: ToolDefinition[] = [
@@ -34,7 +35,8 @@ export const toolDefinitions: ToolDefinition[] = [
   ...macroTools,
   ...effectTools,
   ...parameterTools,
-  ...keyTools
+  ...keyTools,
+  ...directSelectTools
 ];
 
 export default toolDefinitions;


### PR DESCRIPTION
## Summary
- add OSC mappings and MCP tools for direct select bank creation, button presses, and pagination with local state
- validate direct select target types, button counts, and flexi mode before sending OSC messages
- exercise direct select flows across multiple pages and target types with unit tests

## Testing
- npm test
- npx jest src/tools/directSelects/__tests__/directSelects.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f553031bc4832abdc79c30a89daeb7