### PR TITLE
Add OSC snapshot recall and info tools

### DIFF
--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -41,6 +41,10 @@ export const oscMappings = {
     select: '/eos/macro/select',
     info: '/eos/get/macro'
   },
+  snapshots: {
+    recall: '/eos/snapshot/recall',
+    info: '/eos/get/snapshot'
+  },
   effects: {
     select: '/eos/effect/select',
     stop: '/eos/effect/stop',

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,7 @@ import keyTools from './keys/index.js';
 import directSelectTools from './directSelects/index.js';
 import magicSheetTools from './magicSheets/index.js';
 import pixelMapTools from './pixelMaps/index.js';
+import snapshotTools from './snapshots/index.js';
 import type { ToolDefinition } from './types.js';
 
 export const toolDefinitions: ToolDefinition[] = [
@@ -40,7 +41,8 @@ export const toolDefinitions: ToolDefinition[] = [
   ...keyTools,
   ...directSelectTools,
   ...magicSheetTools,
-  ...pixelMapTools
+  ...pixelMapTools,
+  ...snapshotTools
 ];
 
 export default toolDefinitions;

--- a/src/tools/snapshots/__tests__/snapshots.test.ts
+++ b/src/tools/snapshots/__tests__/snapshots.test.ts
@@ -1,0 +1,149 @@
+import type { OscMessage } from '../../../services/osc/index';
+import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { oscMappings } from '../../../services/osc/mappings';
+import { eosSnapshotGetInfoTool, eosSnapshotRecallTool } from '../index';
+
+type ToolHandler = (args: unknown, extra?: unknown) => Promise<any>;
+
+class FakeOscService implements OscGateway {
+  public readonly sentMessages: OscMessage[] = [];
+
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  public send(message: OscMessage): void {
+    this.sentMessages.push(message);
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public emit(message: OscMessage): void {
+    this.listeners.forEach((listener) => listener(message));
+  }
+}
+
+describe('snapshot tools', () => {
+  let service: FakeOscService;
+
+  const runTool = async (tool: any, args: unknown, extra: unknown = {}): Promise<any> => {
+    const handler = tool.handler as ToolHandler;
+    return handler(args, extra);
+  };
+
+  beforeEach(() => {
+    service = new FakeOscService();
+    const client = new OscClient(service, { defaultTimeoutMs: 50 });
+    setOscClient(client);
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it("envoie l'ordre de rappel avec le numero de snapshot", async () => {
+    await runTool(eosSnapshotRecallTool, { snapshot_number: 5 });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const [message] = service.sentMessages;
+    expect(message.address).toBe(oscMappings.snapshots.recall);
+    expect(message.args).toHaveLength(1);
+    const payload = JSON.parse(String(message.args?.[0]?.value ?? '{}'));
+    expect(payload).toMatchObject({ snapshot: 5 });
+  });
+
+  it('valide la borne inferieure du numero de snapshot', async () => {
+    await expect(runTool(eosSnapshotRecallTool, { snapshot_number: 0 })).rejects.toThrow();
+  });
+
+  it('permet d\'enclencher plusieurs rappels consecutifs', async () => {
+    await runTool(eosSnapshotRecallTool, { snapshot_number: 3 });
+    await runTool(eosSnapshotRecallTool, { snapshot_number: 7 });
+
+    expect(service.sentMessages).toHaveLength(2);
+    const [first, second] = service.sentMessages;
+    const firstPayload = JSON.parse(String(first.args?.[0]?.value ?? '{}'));
+    const secondPayload = JSON.parse(String(second.args?.[0]?.value ?? '{}'));
+    expect(firstPayload).toMatchObject({ snapshot: 3 });
+    expect(secondPayload).toMatchObject({ snapshot: 7 });
+  });
+
+  it('normalise les informations recues pour un snapshot et son UID', async () => {
+    const promise = runTool(eosSnapshotGetInfoTool, { snapshot_number: 12 });
+
+    queueMicrotask(() => {
+      const payload = {
+        status: 'ok',
+        snapshot: {
+          number: '12',
+          label: 'Ballet Acte II',
+          uid: '1.2.3.4.5'
+        }
+      };
+
+      service.emit({
+        address: oscMappings.snapshots.info,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify(payload)
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    expect(textContent.text).toBe('Snapshot 12 "Ballet Acte II" (UID 1.2.3.4.5).');
+
+    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    expect(objectContent).toBeDefined();
+    expect(objectContent.data).toMatchObject({
+      status: 'ok',
+      snapshot: {
+        snapshot_number: 12,
+        label: 'Ballet Acte II',
+        uid: '1.2.3.4.5'
+      }
+    });
+  });
+
+  it('signale une erreur lorsque le snapshot est introuvable', async () => {
+    const promise = runTool(eosSnapshotGetInfoTool, { snapshot_number: 99 });
+
+    queueMicrotask(() => {
+      const payload = {
+        status: 'error',
+        message: 'Snapshot missing'
+      };
+
+      service.emit({
+        address: oscMappings.snapshots.info,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify(payload)
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    expect(textContent.text).toBe('Snapshot 99 introuvable.');
+
+    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    expect(objectContent.data).toMatchObject({
+      status: 'error',
+      error: 'Snapshot missing',
+      snapshot: {
+        snapshot_number: 99,
+        label: null,
+        uid: null
+      }
+    });
+  });
+});

--- a/src/tools/snapshots/index.ts
+++ b/src/tools/snapshots/index.ts
@@ -1,0 +1,350 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
+import type { OscMessageArgument } from '../../services/osc/index';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+
+const targetOptionsSchema = {
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+} satisfies ZodRawShape;
+
+const snapshotNumberSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(9999)
+  .describe('Numero de snapshot (1-9999)');
+
+const recallInputSchema = {
+  snapshot_number: snapshotNumberSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const getInfoInputSchema = {
+  snapshot_number: snapshotNumberSchema,
+  fields: z.array(z.string().min(1)).optional(),
+  timeoutMs: z.number().int().min(50).optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+interface SnapshotInfo {
+  snapshot_number: number;
+  label: string | null;
+  uid: string | null;
+}
+
+function buildJsonArgs(payload: Record<string, unknown>): OscMessageArgument[] {
+  return [
+    {
+      type: 's' as const,
+      value: JSON.stringify(payload)
+    }
+  ];
+}
+
+function extractTargetOptions(options: { targetAddress?: string; targetPort?: number }): {
+  targetAddress?: string;
+  targetPort?: number;
+} {
+  const target: { targetAddress?: string; targetPort?: number } = {};
+  if (options.targetAddress) {
+    target.targetAddress = options.targetAddress;
+  }
+  if (typeof options.targetPort === 'number') {
+    target.targetPort = options.targetPort;
+  }
+  return target;
+}
+
+function annotate(osc: string): Record<string, unknown> {
+  return {
+    mapping: {
+      osc
+    }
+  };
+}
+
+function createRecallResult(
+  snapshotNumber: number,
+  payload: Record<string, unknown>,
+  oscAddress: string
+): ToolExecutionResult {
+  return {
+    content: [
+      { type: 'text', text: `Snapshot ${snapshotNumber} rappelle.` },
+      {
+        type: 'object',
+        data: {
+          action: 'snapshot_recall',
+          snapshot_number: snapshotNumber,
+          request: payload,
+          osc: {
+            address: oscAddress,
+            args: payload
+          }
+        }
+      }
+    ]
+  } as ToolExecutionResult;
+}
+
+function parseInteger(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value === 'string') {
+    const match = value.match(/(-?\d+)/);
+    if (match) {
+      return Number.parseInt(match[1] ?? '', 10);
+    }
+  }
+
+  return null;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+}
+
+function normaliseSnapshotInfo(raw: unknown, fallbackNumber: number): SnapshotInfo {
+  let snapshotNumber = fallbackNumber;
+  let label: string | null = null;
+  let uid: string | null = null;
+
+  if (raw && typeof raw === 'object') {
+    const data = raw as Record<string, unknown>;
+    const numberCandidates = [
+      data.snapshot_number,
+      data.number,
+      data.id,
+      data.index,
+      data.snapshot,
+      data.uid_number
+    ];
+
+    for (const candidate of numberCandidates) {
+      const parsed = parseInteger(candidate);
+      if (parsed != null) {
+        snapshotNumber = parsed;
+        break;
+      }
+    }
+
+    const labelCandidate = data.label ?? data.name ?? data.title ?? data.description;
+    const uidCandidate = data.uid ?? data.uuid ?? data.uid_string ?? data.uid_value ?? data.uidNumber;
+
+    label = asString(labelCandidate);
+    uid = asString(uidCandidate);
+  }
+
+  return {
+    snapshot_number: snapshotNumber,
+    label,
+    uid
+  };
+}
+
+function extractMessageCandidate(data: unknown): string | null {
+  if (typeof data === 'string') {
+    return data;
+  }
+
+  if (data && typeof data === 'object') {
+    const record = data as Record<string, unknown>;
+    const candidates = [
+      record.message,
+      record.error,
+      record.reason,
+      record.detail,
+      record.status
+    ];
+
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function containsSnapshotMissing(value: unknown, depth = 0): boolean {
+  if (depth > 5 || value == null) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    const lower = value.toLowerCase();
+    if (lower.includes('snapshot missing')) {
+      return true;
+    }
+    return lower.includes('not found') && lower.includes('snapshot');
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsSnapshotMissing(item, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some((item) =>
+      containsSnapshotMissing(item, depth + 1)
+    );
+  }
+
+  return false;
+}
+
+function buildSnapshotInfoResult(
+  response: OscJsonResponse,
+  snapshotNumber: number,
+  payload: Record<string, unknown>
+): ToolExecutionResult {
+  const rawData =
+    response.data && typeof response.data === 'object'
+      ? ((response.data as Record<string, unknown>).snapshot ?? response.data)
+      : response.data;
+
+  const details = normaliseSnapshotInfo(rawData, snapshotNumber);
+  const rawMessage =
+    extractMessageCandidate(response.data) ??
+    (typeof response.error === 'string' ? response.error : null);
+  const trimmedMessage = rawMessage?.trim() ?? '';
+  const loweredMessage = trimmedMessage.toLowerCase();
+  const excludedMessages = ['ok', 'success', 'error', 'timeout', 'skipped'];
+  const meaningfulMessage =
+    trimmedMessage.length > 0 && !excludedMessages.includes(loweredMessage)
+      ? trimmedMessage
+      : null;
+  const snapshotMissing =
+    containsSnapshotMissing(response.data) || loweredMessage.includes('snapshot missing');
+
+  let text: string;
+  let errorMessage: string | null = null;
+
+  if (snapshotMissing) {
+    text = `Snapshot ${details.snapshot_number} introuvable.`;
+    errorMessage = meaningfulMessage ?? 'Snapshot missing';
+  } else if (response.status === 'timeout') {
+    text = `Lecture du snapshot ${details.snapshot_number} expiree.`;
+    errorMessage = meaningfulMessage ?? response.error ?? null;
+  } else if (response.status === 'ok') {
+    const labelPart = details.label ? `"${details.label}"` : 'sans label';
+    const uidPart = details.uid ? ` (UID ${details.uid})` : '';
+    text = `Snapshot ${details.snapshot_number} ${labelPart}${uidPart}.`;
+  } else {
+    text = `Lecture du snapshot ${details.snapshot_number} terminee avec le statut ${response.status}.`;
+    if (meaningfulMessage) {
+      text += ` (${meaningfulMessage})`;
+      errorMessage = meaningfulMessage;
+    }
+  }
+
+  if (!errorMessage && meaningfulMessage) {
+    errorMessage = meaningfulMessage;
+  }
+  if (!errorMessage && typeof response.error === 'string') {
+    const trimmed = response.error.trim();
+    if (trimmed.length > 0 && !excludedMessages.includes(trimmed.toLowerCase())) {
+      errorMessage = trimmed;
+    }
+  }
+
+  return {
+    content: [
+      { type: 'text', text },
+      {
+        type: 'object',
+        data: {
+          action: 'snapshot_get_info',
+          status: response.status,
+          request: payload,
+          snapshot: details,
+          error: errorMessage,
+          osc: {
+            address: oscMappings.snapshots.info,
+            response: response.payload
+          }
+        }
+      }
+    ]
+  } as ToolExecutionResult;
+}
+
+export const eosSnapshotRecallTool: ToolDefinition<typeof recallInputSchema> = {
+  name: 'eos_snapshot_recall',
+  config: {
+    title: 'Rappel de snapshot',
+    description: 'Rappelle un snapshot en envoyant son numero a la console.',
+    inputSchema: recallInputSchema,
+    annotations: annotate(oscMappings.snapshots.recall)
+  },
+  handler: async (args) => {
+    const schema = z.object(recallInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const payload = {
+      snapshot: options.snapshot_number
+    };
+
+    client.sendMessage(
+      oscMappings.snapshots.recall,
+      buildJsonArgs(payload),
+      extractTargetOptions(options)
+    );
+
+    return createRecallResult(options.snapshot_number, payload, oscMappings.snapshots.recall);
+  }
+};
+
+export const eosSnapshotGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
+  name: 'eos_snapshot_get_info',
+  config: {
+    title: 'Lecture des informations de snapshot',
+    description: 'Recupere les informations d\'un snapshot, incluant label et UID.',
+    inputSchema: getInfoInputSchema,
+    outputSchema: {
+      snapshot: z.object({
+        snapshot_number: snapshotNumberSchema,
+        label: z.string().nullable(),
+        uid: z.string().nullable()
+      }),
+      status: z.enum(['ok', 'timeout', 'error', 'skipped'])
+    },
+    annotations: annotate(oscMappings.snapshots.info)
+  },
+  handler: async (args) => {
+    const schema = z.object(getInfoInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const payload: Record<string, unknown> = {
+      snapshot: options.snapshot_number
+    };
+
+    if (options.fields && options.fields.length > 0) {
+      payload.fields = options.fields;
+    }
+
+    const response = await client.requestJson(oscMappings.snapshots.info, {
+      payload,
+      timeoutMs: options.timeoutMs,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort
+    });
+
+    return buildSnapshotInfoResult(response, options.snapshot_number, payload);
+  }
+};
+
+export const snapshotTools = [eosSnapshotRecallTool, eosSnapshotGetInfoTool];
+
+export default snapshotTools;


### PR DESCRIPTION
## Summary
- add snapshot toolset for recalling snapshots and fetching metadata including label and UID
- wire new OSC snapshot mappings into the global tool registry
- ensure missing snapshot errors are handled and validated via dedicated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f56df99590832a9f8480ae77978d79