### PR TITLE
Add curve selection and info tools

### DIFF
--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -45,6 +45,10 @@ export const oscMappings = {
     recall: '/eos/snapshot/recall',
     info: '/eos/get/snapshot'
   },
+  curves: {
+    select: '/eos/curve/select',
+    info: '/eos/get/curve'
+  },
   effects: {
     select: '/eos/effect/select',
     stop: '/eos/effect/stop',

--- a/src/tools/curves/__tests__/curves.test.ts
+++ b/src/tools/curves/__tests__/curves.test.ts
@@ -1,0 +1,149 @@
+import type { OscMessage } from '../../../services/osc/index';
+import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { oscMappings } from '../../../services/osc/mappings';
+import { eosCurveGetInfoTool, eosCurveSelectTool } from '../index';
+
+type ToolHandler = (args: unknown, extra?: unknown) => Promise<any>;
+
+class FakeOscService implements OscGateway {
+  public readonly sentMessages: OscMessage[] = [];
+
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  public send(message: OscMessage): void {
+    this.sentMessages.push(message);
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public emit(message: OscMessage): void {
+    this.listeners.forEach((listener) => listener(message));
+  }
+}
+
+describe('curve tools', () => {
+  let service: FakeOscService;
+
+  const runTool = async (tool: any, args: unknown): Promise<any> => {
+    const handler = tool.handler as ToolHandler;
+    return handler(args, {});
+  };
+
+  beforeEach(() => {
+    service = new FakeOscService();
+    const client = new OscClient(service, { defaultTimeoutMs: 50 });
+    setOscClient(client);
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it("envoie la selection de courbe avec le numero attendu", async () => {
+    await runTool(eosCurveSelectTool, { curve_number: 4 });
+
+    expect(service.sentMessages).toHaveLength(1);
+    expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.curves.select });
+
+    const payload = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
+    expect(payload).toMatchObject({ curve: 4 });
+  });
+
+  it('normalise les informations renvoyees pour une courbe custom', async () => {
+    const promise = runTool(eosCurveGetInfoTool, {
+      curve_number: 8,
+      fields: ['label', 'points', 'type']
+    });
+
+    queueMicrotask(() => {
+      const payload = {
+        status: 'ok',
+        curve: {
+          curve_number: '8',
+          name: 'Custom Fade',
+          type: 'Time',
+          data: [
+            [0, 0],
+            { in: 50, out: '65.5' },
+            { x: '100', y: 100 }
+          ]
+        }
+      };
+
+      service.emit({
+        address: oscMappings.curves.info,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify(payload)
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    expect(textContent.text).toBe('Courbe 8 "Custom Fade" (Time) - 3 points.');
+
+    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    expect(objectContent.data).toMatchObject({
+      status: 'ok',
+      error: null,
+      curve: {
+        curve_number: 8,
+        label: 'Custom Fade',
+        kind: 'Time',
+        points: [
+          { input: 0, output: 0 },
+          { input: 50, output: 65.5 },
+          { input: 100, output: 100 }
+        ]
+      }
+    });
+
+    const request = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
+    expect(request.fields).toEqual(['label', 'points', 'type']);
+  });
+
+  it('signale une erreur lorsque la courbe est introuvable', async () => {
+    const promise = runTool(eosCurveGetInfoTool, { curve_number: 42 });
+
+    queueMicrotask(() => {
+      const payload = {
+        status: 'error',
+        message: 'Curve not found'
+      };
+
+      service.emit({
+        address: oscMappings.curves.info,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify(payload)
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    expect(textContent.text).toBe('Courbe 42 introuvable.');
+
+    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    expect(objectContent.data).toMatchObject({
+      status: 'error',
+      error: 'Curve not found',
+      curve: {
+        curve_number: 42,
+        label: null,
+        kind: null,
+        points: []
+      }
+    });
+  });
+});

--- a/src/tools/curves/index.ts
+++ b/src/tools/curves/index.ts
@@ -1,0 +1,421 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
+import type { OscMessageArgument } from '../../services/osc/index';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+
+const targetOptionsSchema = {
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+} satisfies ZodRawShape;
+
+const curveNumberSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(9999)
+  .describe('Numero de courbe (1-9999).');
+
+const timeoutSchema = z.number().int().min(50).optional();
+
+const selectInputSchema = {
+  curve_number: curveNumberSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const getInfoInputSchema = {
+  curve_number: curveNumberSchema,
+  fields: z.array(z.string().min(1)).optional(),
+  timeoutMs: timeoutSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+interface CurvePoint {
+  input: number | null;
+  output: number | null;
+}
+
+interface CurveInfo {
+  curve_number: number;
+  label: string | null;
+  kind: string | null;
+  points: CurvePoint[];
+}
+
+function buildJsonArgs(payload: Record<string, unknown>): OscMessageArgument[] {
+  return [
+    {
+      type: 's' as const,
+      value: JSON.stringify(payload)
+    }
+  ];
+}
+
+function annotate(osc: string): Record<string, unknown> {
+  return {
+    mapping: {
+      osc
+    }
+  };
+}
+
+function createSelectResult(
+  curveNumber: number,
+  payload: Record<string, unknown>,
+  oscAddress: string
+): ToolExecutionResult {
+  return {
+    content: [
+      { type: 'text', text: `Courbe ${curveNumber} selectionnee.` },
+      {
+        type: 'object',
+        data: {
+          action: 'curve_select',
+          curve_number: curveNumber,
+          request: payload,
+          osc: {
+            address: oscAddress,
+            args: payload
+          }
+        }
+      }
+    ]
+  } as ToolExecutionResult;
+}
+
+function parseInteger(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value === 'string') {
+    const match = value.match(/(-?\d+)/);
+    if (match) {
+      return Number.parseInt(match[1] ?? '', 10);
+    }
+  }
+
+  return null;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalised = value.trim().replace(',', '.');
+    if (normalised.length === 0) {
+      return null;
+    }
+    const parsed = Number.parseFloat(normalised);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function normalisePoint(raw: unknown): CurvePoint | null {
+  if (raw == null) {
+    return null;
+  }
+
+  if (Array.isArray(raw)) {
+    const input = asFiniteNumber(raw[0]);
+    const output = asFiniteNumber(raw[1] ?? raw[0]);
+    if (input == null && output == null) {
+      return null;
+    }
+    return { input, output };
+  }
+
+  if (typeof raw === 'object') {
+    const data = raw as Record<string, unknown>;
+    const inputCandidates = [data.input, data.in, data.x, data.source, data.position, data.time];
+    const outputCandidates = [data.output, data.out, data.y, data.value, data.target];
+
+    let input: number | null = null;
+    for (const candidate of inputCandidates) {
+      const parsed = asFiniteNumber(candidate);
+      if (parsed != null) {
+        input = parsed;
+        break;
+      }
+    }
+
+    let output: number | null = null;
+    for (const candidate of outputCandidates) {
+      const parsed = asFiniteNumber(candidate);
+      if (parsed != null) {
+        output = parsed;
+        break;
+      }
+    }
+
+    if (input == null && output == null) {
+      return null;
+    }
+
+    return { input, output };
+  }
+
+  const numberValue = asFiniteNumber(raw);
+  if (numberValue != null) {
+    return { input: numberValue, output: numberValue };
+  }
+
+  return null;
+}
+
+function normalisePointCollection(raw: unknown): CurvePoint[] {
+  if (Array.isArray(raw)) {
+    return raw
+      .map((item) => normalisePoint(item))
+      .filter((item): item is CurvePoint => item != null);
+  }
+
+  if (raw && typeof raw === 'object') {
+    const data = raw as Record<string, unknown>;
+    const candidates = [data.points, data.data, data.entries, data.values, data.curve_points, data.curve];
+    for (const candidate of candidates) {
+      const points = normalisePointCollection(candidate);
+      if (points.length > 0) {
+        return points;
+      }
+    }
+  }
+
+  return [];
+}
+
+function normaliseCurveInfo(raw: unknown, fallbackNumber: number): CurveInfo {
+  let curveNumber = fallbackNumber;
+  let label: string | null = null;
+  let kind: string | null = null;
+  let points: CurvePoint[] = [];
+
+  if (raw && typeof raw === 'object') {
+    const data = raw as Record<string, unknown>;
+
+    const numberCandidates = [data.curve_number, data.number, data.id, data.index, data.curve];
+    for (const candidate of numberCandidates) {
+      const parsed = parseInteger(candidate);
+      if (parsed != null) {
+        curveNumber = parsed;
+        break;
+      }
+    }
+
+    const labelCandidate = data.label ?? data.name ?? data.title ?? data.description ?? data.curve_label;
+    label = asString(labelCandidate);
+
+    const kindCandidate = data.kind ?? data.type ?? data.mode ?? data.category ?? data.curve_type;
+    kind = asString(kindCandidate);
+
+    points = normalisePointCollection(
+      data.points ?? data.data ?? data.curve_data ?? data.entries ?? data.values ?? null
+    );
+  }
+
+  return {
+    curve_number: curveNumber,
+    label,
+    kind,
+    points
+  };
+}
+
+function extractMessageCandidate(data: unknown): string | null {
+  if (typeof data === 'string') {
+    return data;
+  }
+
+  if (data && typeof data === 'object') {
+    const record = data as Record<string, unknown>;
+    const candidates = [record.message, record.error, record.reason, record.detail, record.status];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function containsCurveMissing(value: unknown, depth = 0): boolean {
+  if (depth > 5 || value == null) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    const lower = value.toLowerCase();
+    if (lower.includes('curve not found') || lower.includes('curve missing')) {
+      return true;
+    }
+    return lower.includes('not found') && lower.includes('curve');
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsCurveMissing(item, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some((item) =>
+      containsCurveMissing(item, depth + 1)
+    );
+  }
+
+  return false;
+}
+
+function buildCurveInfoResult(
+  response: OscJsonResponse,
+  curveNumber: number,
+  payload: Record<string, unknown>
+): ToolExecutionResult {
+  const rawData =
+    response.data && typeof response.data === 'object'
+      ? ((response.data as Record<string, unknown>).curve ?? response.data)
+      : response.data;
+
+  const details = normaliseCurveInfo(rawData, curveNumber);
+  const rawMessage =
+    extractMessageCandidate(response.data) ??
+    (typeof response.error === 'string' ? response.error : null);
+
+  const lowerMessage = rawMessage?.trim().toLowerCase() ?? '';
+  const excludedMessages = ['ok', 'success', 'error', 'timeout', 'skipped'];
+  const meaningfulMessage =
+    rawMessage && !excludedMessages.includes(lowerMessage) ? rawMessage : null;
+  const curveMissing = containsCurveMissing(response.data);
+
+  let text: string;
+  if (curveMissing) {
+    text = `Courbe ${details.curve_number} introuvable.`;
+  } else if (response.status === 'timeout') {
+    text = `Lecture de la courbe ${details.curve_number} expiree.`;
+  } else if (response.status === 'ok') {
+    const labelPart = details.label ? `"${details.label}"` : 'sans label';
+    const kindPart = details.kind ? ` (${details.kind})` : '';
+    const pointCount = details.points.length;
+    const pointPart = pointCount > 0 ? ` - ${pointCount} points` : '';
+    text = `Courbe ${details.curve_number} ${labelPart}${kindPart}${pointPart}.`;
+  } else {
+    text = `Lecture de la courbe ${details.curve_number} terminee avec le statut ${response.status}.`;
+    if (meaningfulMessage) {
+      text += ` (${meaningfulMessage})`;
+    }
+  }
+
+  return {
+    content: [
+      { type: 'text', text },
+      {
+        type: 'object',
+        data: {
+          action: 'curve_get_info',
+          status: response.status,
+          request: payload,
+          curve: details,
+          error: meaningfulMessage,
+          osc: {
+            address: oscMappings.curves.info,
+            response: response.payload
+          }
+        }
+      }
+    ]
+  } as ToolExecutionResult;
+}
+
+export const eosCurveSelectTool: ToolDefinition<typeof selectInputSchema> = {
+  name: 'eos_curve_select',
+  config: {
+    title: 'Selection de courbe',
+    description: 'Selectionne une courbe en envoyant son numero a la console.',
+    inputSchema: selectInputSchema,
+    annotations: annotate(oscMappings.curves.select)
+  },
+  handler: async (args) => {
+    const schema = z.object(selectInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const payload = {
+      curve: options.curve_number
+    };
+
+    client.sendMessage(oscMappings.curves.select, buildJsonArgs(payload), {
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort
+    });
+
+    return createSelectResult(options.curve_number, payload, oscMappings.curves.select);
+  }
+};
+
+export const eosCurveGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
+  name: 'eos_curve_get_info',
+  config: {
+    title: 'Lecture des informations de courbe',
+    description: 'Recupere les informations d\'une courbe, incluant label et points.',
+    inputSchema: getInfoInputSchema,
+    outputSchema: {
+      curve: z.object({
+        curve_number: curveNumberSchema,
+        label: z.string().nullable(),
+        kind: z.string().nullable(),
+        points: z
+          .array(
+            z.object({
+              input: z.number().nullable(),
+              output: z.number().nullable()
+            })
+          )
+          .describe('Points constitutifs de la courbe normalises (input/output).')
+      }),
+      status: z.enum(['ok', 'timeout', 'error', 'skipped'])
+    },
+    annotations: annotate(oscMappings.curves.info)
+  },
+  handler: async (args) => {
+    const schema = z.object(getInfoInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const payload: Record<string, unknown> = {
+      curve: options.curve_number
+    };
+
+    if (options.fields && options.fields.length > 0) {
+      payload.fields = options.fields;
+    }
+
+    const response = await client.requestJson(oscMappings.curves.info, {
+      payload,
+      timeoutMs: options.timeoutMs,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort
+    });
+
+    return buildCurveInfoResult(response, options.curve_number, payload);
+  }
+};
+
+export const curveTools = [eosCurveSelectTool, eosCurveGetInfoTool];
+
+export default curveTools;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,6 +19,7 @@ import directSelectTools from './directSelects/index.js';
 import magicSheetTools from './magicSheets/index.js';
 import pixelMapTools from './pixelMaps/index.js';
 import snapshotTools from './snapshots/index.js';
+import curveTools from './curves/index.js';
 import type { ToolDefinition } from './types.js';
 
 export const toolDefinitions: ToolDefinition[] = [
@@ -42,6 +43,7 @@ export const toolDefinitions: ToolDefinition[] = [
   ...directSelectTools,
   ...magicSheetTools,
   ...pixelMapTools,
+  ...curveTools,
   ...snapshotTools
 ];
 


### PR DESCRIPTION
## Summary
- add curve tools to select and introspect console curves with input validation
- normalize curve details including labels, types, and points from OSC responses
- register OSC curve endpoints and cover the tools with automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f56f8a8224832a8b7455ab633c343d