### PR TITLE
Add OSC query tools for counts and listings

### DIFF
--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -82,6 +82,68 @@ export const oscMappings = {
     sendString: '/eos/magic_sheet/send_string',
     info: '/eos/get/magic_sheet'
   },
+  queries: {
+    cue: {
+      count: '/eos/get/cue/count',
+      list: '/eos/get/cue/list'
+    },
+    cuelist: {
+      count: '/eos/get/cuelist/count',
+      list: '/eos/get/cuelist/list'
+    },
+    group: {
+      count: '/eos/get/group/count',
+      list: '/eos/get/group/list'
+    },
+    macro: {
+      count: '/eos/get/macro/count',
+      list: '/eos/get/macro/list'
+    },
+    ms: {
+      count: '/eos/get/magic_sheet/count',
+      list: '/eos/get/magic_sheet/list'
+    },
+    ip: {
+      count: '/eos/get/ip/count',
+      list: '/eos/get/ip/list'
+    },
+    fp: {
+      count: '/eos/get/fp/count',
+      list: '/eos/get/fp/list'
+    },
+    cp: {
+      count: '/eos/get/cp/count',
+      list: '/eos/get/cp/list'
+    },
+    bp: {
+      count: '/eos/get/bp/count',
+      list: '/eos/get/bp/list'
+    },
+    preset: {
+      count: '/eos/get/preset/count',
+      list: '/eos/get/preset/list'
+    },
+    sub: {
+      count: '/eos/get/submaster/count',
+      list: '/eos/get/submaster/list'
+    },
+    fx: {
+      count: '/eos/get/effect/count',
+      list: '/eos/get/effect/list'
+    },
+    curve: {
+      count: '/eos/get/curve/count',
+      list: '/eos/get/curve/list'
+    },
+    snap: {
+      count: '/eos/get/snapshot/count',
+      list: '/eos/get/snapshot/list'
+    },
+    pixmap: {
+      count: '/eos/get/pixmap/count',
+      list: '/eos/get/pixmap/list'
+    }
+  },
   patch: {
     channelInfo: '/eos/get/patch/chan_info',
     augment3dPosition: '/eos/get/patch/chan_pos',

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -22,6 +22,7 @@ import snapshotTools from './snapshots/index.js';
 import curveTools from './curves/index.js';
 import patchTools from './patch/index.js';
 import showControlTools from './showControl/index.js';
+import queryTools from './queries/index.js';
 import type { ToolDefinition } from './types.js';
 
 export const toolDefinitions: ToolDefinition[] = [
@@ -48,7 +49,8 @@ export const toolDefinitions: ToolDefinition[] = [
   ...curveTools,
   ...patchTools,
   ...snapshotTools,
-  ...showControlTools
+  ...showControlTools,
+  ...queryTools
 ];
 
 export default toolDefinitions;

--- a/src/tools/queries/__tests__/queries.test.ts
+++ b/src/tools/queries/__tests__/queries.test.ts
@@ -1,0 +1,181 @@
+import type { OscMessage } from '../../../services/osc/index';
+import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { oscMappings } from '../../../services/osc/mappings';
+import { eosGetCountTool, eosGetListAllTool } from '../index';
+
+class FakeOscService implements OscGateway {
+  public readonly sentMessages: OscMessage[] = [];
+
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  public send(message: OscMessage): void {
+    this.sentMessages.push(message);
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public emit(message: OscMessage): void {
+    this.listeners.forEach((listener) => listener(message));
+  }
+}
+
+const runTool = async (tool: any, args: unknown): Promise<any> => {
+  const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
+  return handler(args, {});
+};
+
+describe('query tools', () => {
+  let service: FakeOscService;
+
+  beforeEach(() => {
+    service = new FakeOscService();
+    const client = new OscClient(service, { defaultTimeoutMs: 50 });
+    setOscClient(client);
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it('envoie la requete de count vers le mapping FX et normalise la reponse', async () => {
+    const promise = runTool(eosGetCountTool, { target_type: 'FX' });
+
+    queueMicrotask(() => {
+      expect(service.sentMessages).toHaveLength(1);
+      expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.queries.fx.count });
+
+      service.emit({
+        address: oscMappings.queries.fx.count,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify({ status: 'ok', count: '7' })
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    expect(objectContent).toBeDefined();
+    expect(objectContent.data).toMatchObject({
+      action: 'get_count',
+      status: 'ok',
+      target_type: 'fx',
+      count: 7
+    });
+  });
+
+  it('normalise la liste de cues a partir de tableaux separes', async () => {
+    const promise = runTool(eosGetListAllTool, { target_type: 'cue' });
+
+    queueMicrotask(() => {
+      expect(service.sentMessages).toHaveLength(1);
+      expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.queries.cue.list });
+
+      service.emit({
+        address: oscMappings.queries.cue.list,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify({
+              status: 'ok',
+              numbers: ['1', '2.5'],
+              uids: ['1/1', '1/2'],
+              labels: ['Intro', null]
+            })
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    expect(objectContent).toBeDefined();
+
+    expect(objectContent.data).toMatchObject({
+      action: 'list_all',
+      status: 'ok',
+      target_type: 'cue',
+      items: [
+        { number: '1', uid: '1/1', label: 'Intro' },
+        { number: '2.5', uid: '1/2', label: null }
+      ]
+    });
+  });
+
+  it('normalise la liste de macros a partir dun dictionnaire', async () => {
+    const promise = runTool(eosGetListAllTool, { target_type: 'macro', timeoutMs: 100 });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: oscMappings.queries.macro.list,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify({
+              status: 'ok',
+              macros: {
+                '1': { uid: 'macro:1', label: 'Premier' },
+                '2': 'Second'
+              }
+            })
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    expect(objectContent).toBeDefined();
+
+    expect(objectContent.data).toMatchObject({
+      action: 'list_all',
+      status: 'ok',
+      target_type: 'macro',
+      items: [
+        { number: '1', uid: 'macro:1', label: 'Premier' },
+        { number: '2', uid: '2', label: 'Second' }
+      ]
+    });
+  });
+
+  it('supporte la recuperation de magic sheets avec structure items', async () => {
+    const promise = runTool(eosGetListAllTool, { target_type: 'MS' });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: oscMappings.queries.ms.list,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify({
+              status: 'ok',
+              items: [
+                { number: 1, uid: 'ms:1', label: 'Layout' },
+                { number: 2, uid: 'ms:2' }
+              ]
+            })
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    expect(objectContent).toBeDefined();
+
+    expect(objectContent.data).toMatchObject({
+      target_type: 'ms',
+      items: [
+        { number: '1', uid: 'ms:1', label: 'Layout' },
+        { number: '2', uid: 'ms:2', label: null }
+      ]
+    });
+  });
+});

--- a/src/tools/queries/index.ts
+++ b/src/tools/queries/index.ts
@@ -1,0 +1,517 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types.js';
+
+interface QueryListItem {
+  number: string;
+  uid: string;
+  label: string | null;
+}
+
+interface QueryTargetConfig {
+  label: string;
+  countAddress: string;
+  listAddress: string;
+  responseKeys: string[];
+}
+
+type QueryTargetType = keyof typeof TARGET_TYPE_CONFIGS;
+
+const TARGET_TYPE_CONFIGS = {
+  cue: {
+    label: 'cues',
+    countAddress: oscMappings.queries.cue.count,
+    listAddress: oscMappings.queries.cue.list,
+    responseKeys: ['cues', 'items']
+  },
+  cuelist: {
+    label: 'cue lists',
+    countAddress: oscMappings.queries.cuelist.count,
+    listAddress: oscMappings.queries.cuelist.list,
+    responseKeys: ['cuelists', 'lists', 'items']
+  },
+  group: {
+    label: 'groupes',
+    countAddress: oscMappings.queries.group.count,
+    listAddress: oscMappings.queries.group.list,
+    responseKeys: ['groups', 'items']
+  },
+  macro: {
+    label: 'macros',
+    countAddress: oscMappings.queries.macro.count,
+    listAddress: oscMappings.queries.macro.list,
+    responseKeys: ['macros', 'items']
+  },
+  ms: {
+    label: 'magic sheets',
+    countAddress: oscMappings.queries.ms.count,
+    listAddress: oscMappings.queries.ms.list,
+    responseKeys: ['magic_sheets', 'magicSheets', 'items']
+  },
+  ip: {
+    label: 'intensity palettes',
+    countAddress: oscMappings.queries.ip.count,
+    listAddress: oscMappings.queries.ip.list,
+    responseKeys: ['intensity_palettes', 'ip', 'items']
+  },
+  fp: {
+    label: 'focus palettes',
+    countAddress: oscMappings.queries.fp.count,
+    listAddress: oscMappings.queries.fp.list,
+    responseKeys: ['focus_palettes', 'fp', 'items']
+  },
+  cp: {
+    label: 'color palettes',
+    countAddress: oscMappings.queries.cp.count,
+    listAddress: oscMappings.queries.cp.list,
+    responseKeys: ['color_palettes', 'cp', 'items']
+  },
+  bp: {
+    label: 'beam palettes',
+    countAddress: oscMappings.queries.bp.count,
+    listAddress: oscMappings.queries.bp.list,
+    responseKeys: ['beam_palettes', 'bp', 'items']
+  },
+  preset: {
+    label: 'presets',
+    countAddress: oscMappings.queries.preset.count,
+    listAddress: oscMappings.queries.preset.list,
+    responseKeys: ['presets', 'items']
+  },
+  sub: {
+    label: 'submasters',
+    countAddress: oscMappings.queries.sub.count,
+    listAddress: oscMappings.queries.sub.list,
+    responseKeys: ['submasters', 'subs', 'items']
+  },
+  fx: {
+    label: 'effects',
+    countAddress: oscMappings.queries.fx.count,
+    listAddress: oscMappings.queries.fx.list,
+    responseKeys: ['effects', 'fx', 'items']
+  },
+  curve: {
+    label: 'courbes',
+    countAddress: oscMappings.queries.curve.count,
+    listAddress: oscMappings.queries.curve.list,
+    responseKeys: ['curves', 'items']
+  },
+  snap: {
+    label: 'snapshots',
+    countAddress: oscMappings.queries.snap.count,
+    listAddress: oscMappings.queries.snap.list,
+    responseKeys: ['snapshots', 'snaps', 'items']
+  },
+  pixmap: {
+    label: 'pixel maps',
+    countAddress: oscMappings.queries.pixmap.count,
+    listAddress: oscMappings.queries.pixmap.list,
+    responseKeys: ['pixmaps', 'pixel_maps', 'items']
+  }
+} as const satisfies Record<string, QueryTargetConfig>;
+
+const TARGET_TYPE_ERROR_MESSAGE = [
+  'Type de cible invalide.',
+  'Valeurs supportees: cue, cuelist, group, macro, ms, ip, fp, cp, bp, preset, sub, fx, curve, snap, pixmap.'
+].join(' ');
+
+const statusSchema = z.enum(['ok', 'timeout', 'error', 'skipped']);
+
+const listItemOutputSchema = z.object({
+  number: z.string(),
+  uid: z.string(),
+  label: z.string().nullable()
+});
+
+const targetOptionsSchema = {
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+} satisfies ZodRawShape;
+
+const targetTypeSchema = z
+  .string()
+  .min(1)
+  .transform((value, ctx) => {
+    const key = value.trim().toLowerCase();
+    if (!isQueryTargetType(key)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: TARGET_TYPE_ERROR_MESSAGE
+      });
+      return z.NEVER;
+    }
+    return key;
+  });
+
+const countInputSchema = {
+  target_type: targetTypeSchema,
+  timeoutMs: z.number().int().min(50).optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const listInputSchema = {
+  target_type: targetTypeSchema,
+  timeoutMs: z.number().int().min(50).optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const countOutputSchema = {
+  action: z.literal('get_count'),
+  status: statusSchema,
+  target_type: z.string(),
+  count: z.number().int().min(0),
+  data: z.unknown(),
+  error: z.string().nullable(),
+  osc: z.object({
+    address: z.string(),
+    args: z.record(z.string(), z.unknown())
+  })
+} satisfies ZodRawShape;
+
+const listOutputSchema = {
+  action: z.literal('list_all'),
+  status: statusSchema,
+  target_type: z.string(),
+  items: z.array(listItemOutputSchema),
+  data: z.unknown(),
+  error: z.string().nullable(),
+  osc: z.object({
+    address: z.string(),
+    args: z.record(z.string(), z.unknown())
+  })
+} satisfies ZodRawShape;
+
+export const eosGetCountTool: ToolDefinition<typeof countInputSchema> = {
+  name: 'eos_get_count',
+  config: {
+    title: 'Compter les elements',
+    description: 'Recupere le nombre total d\'elements pour un type donne.',
+    inputSchema: countInputSchema,
+    outputSchema: countOutputSchema,
+    annotations: annotate('count')
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(countInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const config = getTargetConfig(options.target_type);
+    const client = getOscClient();
+
+    const response: OscJsonResponse = await client.requestJson(config.countAddress, {
+      timeoutMs: options.timeoutMs,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort
+    });
+
+    const count = Math.max(0, normaliseCount(response.data));
+
+    const baseText =
+      response.status === 'ok'
+        ? `Nombre de ${config.label}: ${count}.`
+        : `Lecture du compte des ${config.label} terminee avec le statut ${response.status}.`;
+
+    return createResult(baseText, {
+      action: 'get_count',
+      status: response.status,
+      target_type: config.key,
+      count,
+      data: response.data,
+      error: response.error ?? null,
+      osc: {
+        address: config.countAddress,
+        args: {}
+      }
+    });
+  }
+};
+
+export const eosGetListAllTool: ToolDefinition<typeof listInputSchema> = {
+  name: 'eos_get_list_all',
+  config: {
+    title: 'Lister tous les elements',
+    description: 'Recupere la liste complete des elements pour un type donne.',
+    inputSchema: listInputSchema,
+    outputSchema: listOutputSchema,
+    annotations: annotate('list')
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(listInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const config = getTargetConfig(options.target_type);
+    const client = getOscClient();
+
+    const response: OscJsonResponse = await client.requestJson(config.listAddress, {
+      timeoutMs: options.timeoutMs,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort
+    });
+
+    const items = normaliseList(response.data, config);
+
+    const baseText =
+      response.status === 'ok'
+        ? `Elements ${config.label}: ${items.length}.`
+        : `Lecture de la liste des ${config.label} terminee avec le statut ${response.status}.`;
+
+    return createResult(baseText, {
+      action: 'list_all',
+      status: response.status,
+      target_type: config.key,
+      items,
+      data: response.data,
+      error: response.error ?? null,
+      osc: {
+        address: config.listAddress,
+        args: {}
+      }
+    });
+  }
+};
+
+const queryTools = [eosGetCountTool, eosGetListAllTool];
+
+export default queryTools;
+
+function annotate(mode: 'count' | 'list'): Record<string, unknown> {
+  const mappingEntries = Object.entries(TARGET_TYPE_CONFIGS).map(([key, config]) => {
+    const address = mode === 'count' ? config.countAddress : config.listAddress;
+    return [key, address];
+  });
+
+  return {
+    mapping: {
+      osc: Object.fromEntries(mappingEntries)
+    }
+  };
+}
+
+function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+  return {
+    content: [
+      { type: 'text', text },
+      { type: 'object', data }
+    ]
+  } as ToolExecutionResult;
+}
+
+function isQueryTargetType(value: string): value is QueryTargetType {
+  return value in TARGET_TYPE_CONFIGS;
+}
+
+function getTargetConfig(value: string): QueryTargetConfig & { key: QueryTargetType } {
+  const config = TARGET_TYPE_CONFIGS[value as QueryTargetType];
+  if (!config) {
+    throw new Error(TARGET_TYPE_ERROR_MESSAGE);
+  }
+  return { ...config, key: value as QueryTargetType };
+}
+
+function normaliseCount(raw: unknown): number {
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return Math.max(0, Math.trunc(raw));
+  }
+
+  if (typeof raw === 'string') {
+    const numeric = Number.parseInt(raw.trim(), 10);
+    if (Number.isFinite(numeric)) {
+      return Math.max(0, numeric);
+    }
+  }
+
+  if (raw && typeof raw === 'object') {
+    const candidate = raw as Record<string, unknown>;
+    const fromKey = ['count', 'total', 'value', 'length']
+      .map((key) => candidate[key])
+      .find((value) => typeof value === 'number' || typeof value === 'string');
+
+    if (typeof fromKey === 'number') {
+      return normaliseCount(fromKey);
+    }
+
+    if (typeof fromKey === 'string') {
+      return normaliseCount(fromKey);
+    }
+
+    if (Array.isArray(candidate.items)) {
+      return candidate.items.length;
+    }
+  }
+
+  return 0;
+}
+
+function normaliseList(data: unknown, config: QueryTargetConfig): QueryListItem[] {
+  const payload = extractListPayload(data, config);
+  const items: QueryListItem[] = [];
+
+  if (Array.isArray(payload)) {
+    for (const entry of payload) {
+      const normalised = normaliseListItem(entry);
+      if (normalised) {
+        items.push(normalised);
+      }
+    }
+    return items;
+  }
+
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+
+    if (Array.isArray(record.items)) {
+      for (const entry of record.items) {
+        const normalised = normaliseListItem(entry);
+        if (normalised) {
+          items.push(normalised);
+        }
+      }
+      return items;
+    }
+
+    const numbers = extractStringArray(record.numbers ?? record.list ?? record.ids ?? record.index ?? record.indexes);
+    const uids = extractStringArray(record.uids ?? record.uid);
+    const labels = extractStringArray(record.labels ?? record.names ?? record.texts ?? record.label);
+
+    if (numbers.length > 0 || uids.length > 0 || labels.length > 0) {
+      const maxLength = Math.max(numbers.length, uids.length, labels.length);
+      for (let index = 0; index < maxLength; index += 1) {
+        const uid = uids[index] ?? numbers[index] ?? '';
+        if (!uid) {
+          continue;
+        }
+        items.push({
+          number: numbers[index] ?? uid,
+          uid,
+          label: labels[index] ?? null
+        });
+      }
+      return items;
+    }
+
+    for (const [key, value] of Object.entries(record)) {
+      if (['status', 'error', 'count', 'total'].includes(key)) {
+        continue;
+      }
+      const normalised = normaliseListItem(value, key);
+      if (normalised) {
+        items.push(normalised);
+      }
+    }
+  }
+
+  return items;
+}
+
+function extractListPayload(data: unknown, config: QueryTargetConfig): unknown {
+  if (data && typeof data === 'object') {
+    const record = data as Record<string, unknown>;
+    for (const key of config.responseKeys) {
+      if (key in record) {
+        return record[key];
+      }
+    }
+    if ('items' in record) {
+      return record.items;
+    }
+    if ('all' in record) {
+      return record.all;
+    }
+    if ('data' in record) {
+      const nested = record.data;
+      if (nested && typeof nested === 'object') {
+        const nestedRecord = nested as Record<string, unknown>;
+        for (const key of config.responseKeys) {
+          if (key in nestedRecord) {
+            return nestedRecord[key];
+          }
+        }
+        if ('items' in nestedRecord) {
+          return nestedRecord.items;
+        }
+      }
+      return nested;
+    }
+  }
+  return data;
+}
+
+function normaliseListItem(value: unknown, fallbackNumber?: string): QueryListItem | null {
+  if (value && typeof value === 'object') {
+    const candidate = value as Record<string, unknown>;
+    const number = normaliseString(candidate.number ?? candidate.index ?? candidate.id ?? fallbackNumber);
+    const uid = normaliseString(candidate.uid ?? candidate.UUID ?? candidate.uuid ?? candidate.id ?? fallbackNumber);
+    const label = normaliseOptionalString(candidate.label ?? candidate.name ?? candidate.text ?? null);
+
+    if (uid) {
+      return {
+        number: number ?? uid,
+        uid,
+        label
+      };
+    }
+
+    if (fallbackNumber) {
+      const fallback = normaliseString(fallbackNumber);
+      if (fallback) {
+        return {
+          number: fallback,
+          uid: fallback,
+          label
+        };
+      }
+    }
+
+    return null;
+  }
+
+  const stringValue = normaliseString(value);
+  const fallback = normaliseString(fallbackNumber);
+
+  if (!stringValue && !fallback) {
+    return null;
+  }
+
+  if (fallback) {
+    return {
+      number: fallback,
+      uid: fallback,
+      label: stringValue ?? null
+    };
+  }
+
+  return {
+    number: stringValue ?? '',
+    uid: stringValue ?? '',
+    label: null
+  };
+}
+
+function extractStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => normaliseString(item))
+      .filter((item): item is string => typeof item === 'string' && item.length > 0);
+  }
+
+  return [];
+}
+
+function normaliseString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+}
+
+function normaliseOptionalString(value: unknown): string | null {
+  if (value == null) {
+    return null;
+  }
+  const normalised = normaliseString(value);
+  return normalised ?? null;
+}


### PR DESCRIPTION
## Summary
- add OSC mappings for generic query count/list endpoints
- implement eos_get_count and eos_get_list_all tools with parsing helpers
- cover cue, macro, magic sheet and other target types with unit tests

## Testing
- npm test -- queries

------
https://chatgpt.com/codex/tasks/task_e_68f5768ad610832ab29e047f1566159b