### PR TITLE
Add Focus Palette Encoder tools and tests

### DIFF
--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -63,6 +63,11 @@ export const oscMappings = {
     positionXYZ: '/eos/param/position/xyz',
     activeWheels: '/eos/get/active/wheels'
   },
+  fpe: {
+    getSetCount: '/eos/get/fpe/set/count',
+    getSetInfo: '/eos/get/fpe/set',
+    getPointInfo: '/eos/get/fpe/point'
+  },
   faders: {
     base: '/eos/fader',
     bankCreate: '/eos/fader/bank/create',

--- a/src/tools/fpe/__tests__/fpe.test.ts
+++ b/src/tools/fpe/__tests__/fpe.test.ts
@@ -1,0 +1,267 @@
+import type { OscMessage } from '../../../services/osc/index';
+import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { oscMappings } from '../../../services/osc/mappings';
+import {
+  eosFpeGetSetCountTool,
+  eosFpeGetSetInfoTool,
+  eosFpeGetPointInfoTool
+} from '../index';
+
+interface ToolHandler {
+  (args: unknown, extra?: unknown): Promise<any>;
+}
+
+class FakeOscService implements OscGateway {
+  public readonly sentMessages: OscMessage[] = [];
+
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  public send(message: OscMessage): void {
+    this.sentMessages.push(message);
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public emit(message: OscMessage): void {
+    this.listeners.forEach((listener) => listener(message));
+  }
+}
+
+function extractObjectContent(result: any): any {
+  const content = (result?.content ?? []) as any[];
+  return content.find((item) => item.type === 'object')?.data ?? null;
+}
+
+function extractTextContent(result: any): string | null {
+  const content = (result?.content ?? []) as any[];
+  return content.find((item) => item.type === 'text')?.text ?? null;
+}
+
+describe('fpe tools', () => {
+  let service: FakeOscService;
+
+  const runTool = async (tool: any, args: unknown, extra: unknown = {}): Promise<any> => {
+    const handler = tool.handler as ToolHandler;
+    return handler(args, extra);
+  };
+
+  beforeEach(() => {
+    service = new FakeOscService();
+    const client = new OscClient(service, { defaultTimeoutMs: 50 });
+    setOscClient(client);
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it('recupere le nombre de sets FPE', async () => {
+    const promise = runTool(eosFpeGetSetCountTool, {});
+
+    expect(service.sentMessages).toHaveLength(1);
+    const [message] = service.sentMessages;
+    expect(message.address).toBe(oscMappings.fpe.getSetCount);
+    expect(message.args).toEqual([]);
+
+    queueMicrotask(() => {
+      const payload = {
+        status: 'ok',
+        count: '5',
+        sets: [{ set: 1 }, { set: 2 }, { set: 3 }, { set: 4 }, { set: 5 }]
+      };
+
+      service.emit({
+        address: oscMappings.fpe.getSetCount,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify(payload)
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const textContent = extractTextContent(result);
+    const objectContent = extractObjectContent(result);
+
+    expect(textContent).toBe('Nombre de sets FPE: 5.');
+    expect(objectContent).toMatchObject({
+      action: 'get_set_count',
+      set_count: 5,
+      status: 'ok'
+    });
+  });
+
+  it("normalise les informations d'un set et de ses points", async () => {
+    const promise = runTool(eosFpeGetSetInfoTool, { set_number: 3 });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const [message] = service.sentMessages;
+    expect(message.address).toBe(oscMappings.fpe.getSetInfo);
+    const payload = JSON.parse(String(message.args?.[0]?.value ?? '{}'));
+    expect(payload).toEqual({ set: 3 });
+
+    queueMicrotask(() => {
+      const responsePayload = {
+        status: 'ok',
+        sets: [
+          { set: '2', label: 'Rehearsal', point_count: 1, points: [] },
+          {
+            id: '3',
+            name: 'Main Stage',
+            total_points: '2',
+            points: [
+              { point: '1', label: 'Upstage', focus_palette: '101', position: ['1.5', '-2.25', '3.75'] },
+              { index: 2, name: 'Downstage', fp: 102, x: 0, y: '1.5', z: '3.25' }
+            ]
+          }
+        ]
+      };
+
+      service.emit({
+        address: oscMappings.fpe.getSetInfo,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify(responsePayload)
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const textContent = extractTextContent(result);
+    const objectContent = extractObjectContent(result);
+
+    expect(textContent).toBe('Set FPE 3 "Main Stage" - 2 points.');
+    expect(objectContent).toMatchObject({
+      action: 'get_set_info',
+      status: 'ok',
+      set_number: 3,
+      set: {
+        set_number: 3,
+        label: 'Main Stage',
+        point_count: 2,
+        points: [
+          {
+            point_number: 1,
+            label: 'Upstage',
+            focus_palette_number: 101,
+            position: { x: 1.5, y: -2.25, z: 3.75 }
+          },
+          {
+            point_number: 2,
+            label: 'Downstage',
+            focus_palette_number: 102,
+            position: { x: 0, y: 1.5, z: 3.25 }
+          }
+        ]
+      }
+    });
+  });
+
+  it("normalise les informations d'un point FPE", async () => {
+    const promise = runTool(eosFpeGetPointInfoTool, { set_number: 4, point_number: 2 });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const [message] = service.sentMessages;
+    expect(message.address).toBe(oscMappings.fpe.getPointInfo);
+    const payload = JSON.parse(String(message.args?.[0]?.value ?? '{}'));
+    expect(payload).toEqual({ set: 4, point: 2 });
+
+    queueMicrotask(() => {
+      const responsePayload = {
+        status: 'ok',
+        set: {
+          set_number: '4',
+          label: 'Balcony',
+          points: [
+            { point_number: 1, label: 'Left', focus_palette: '201', position: { x: '1', y: '2', z: '3' } },
+            {
+              point_number: '2',
+              label: 'Right',
+              focusPaletteNumber: '202',
+              coordinates: ['4.5', '6.1', null]
+            }
+          ]
+        },
+        point: {
+          set: '4',
+          point: '2',
+          name: 'Right Balcony',
+          focus: '202',
+          location: { horizontal: '4.5', vertical: '6.1', depth: '0.0' }
+        }
+      };
+
+      service.emit({
+        address: oscMappings.fpe.getPointInfo,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify(responsePayload)
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const textContent = extractTextContent(result);
+    const objectContent = extractObjectContent(result);
+
+    expect(textContent).toBe(
+      'Point FPE 4.2 "Right Balcony" - Palette focus 202 - Position (4.5, 6.1, 0).'
+    );
+    expect(objectContent).toMatchObject({
+      action: 'get_point_info',
+      status: 'ok',
+      set_number: 4,
+      point_number: 2,
+      point: {
+        set_number: 4,
+        point_number: 2,
+        label: 'Right Balcony',
+        focus_palette_number: 202,
+        position: { x: 4.5, y: 6.1, z: 0 }
+      }
+    });
+  });
+
+  it('signale les sets introuvables', async () => {
+    const promise = runTool(eosFpeGetSetInfoTool, { set_number: 12 });
+
+    queueMicrotask(() => {
+      const responsePayload = {
+        status: 'error',
+        error: 'Set not found'
+      };
+
+      service.emit({
+        address: oscMappings.fpe.getSetInfo,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify(responsePayload)
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const textContent = extractTextContent(result);
+    const objectContent = extractObjectContent(result);
+
+    expect(textContent).toBe('Set FPE 12 introuvable.');
+    expect(objectContent).toMatchObject({
+      status: 'error',
+      set_number: 12,
+      error: 'Set not found'
+    });
+  });
+});

--- a/src/tools/fpe/index.ts
+++ b/src/tools/fpe/index.ts
@@ -1,0 +1,746 @@
+import { z, type ZodRawShape } from 'zod';
+import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+import type { ToolDefinition, ToolExecutionResult } from '../types.js';
+
+const targetOptionsSchema = {
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.number().int().min(1).max(65535).optional()
+} satisfies ZodRawShape;
+
+const timeoutSchema = z.number().int().min(50).optional();
+
+const setNumberSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(9999)
+  .describe('Numero de set FPE (1-9999).');
+
+const pointNumberSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(9999)
+  .describe('Numero de point FPE (1-9999).');
+
+const getSetCountInputSchema = {
+  timeoutMs: timeoutSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const getSetInfoInputSchema = {
+  set_number: setNumberSchema,
+  timeoutMs: timeoutSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+const getPointInfoInputSchema = {
+  set_number: setNumberSchema,
+  point_number: pointNumberSchema,
+  timeoutMs: timeoutSchema,
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+interface FpePosition {
+  x: number | null;
+  y: number | null;
+  z: number | null;
+}
+
+export interface FpePointInfo {
+  set_number: number;
+  point_number: number;
+  label: string | null;
+  focus_palette_number: number | null;
+  position: FpePosition;
+}
+
+export interface FpeSetInfo {
+  set_number: number;
+  label: string | null;
+  point_count: number;
+  points: FpePointInfo[];
+}
+
+function annotate(osc: string): Record<string, unknown> {
+  return {
+    mapping: {
+      osc
+    }
+  };
+}
+
+function parseInteger(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value === 'string') {
+    const match = value.match(/(-?\d+)/);
+    if (match) {
+      return Number.parseInt(match[1] ?? '', 10);
+    }
+  }
+
+  return null;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalised = value.trim().replace(',', '.');
+    if (normalised.length === 0) {
+      return null;
+    }
+    const parsed = Number.parseFloat(normalised);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function normalisePosition(raw: unknown): FpePosition {
+  if (Array.isArray(raw)) {
+    return {
+      x: asFiniteNumber(raw[0] ?? null),
+      y: asFiniteNumber(raw[1] ?? null),
+      z: asFiniteNumber(raw[2] ?? null)
+    };
+  }
+
+  if (raw && typeof raw === 'object') {
+    const data = raw as Record<string, unknown>;
+    const xCandidate = data.x ?? data.X ?? data.lon ?? data.longitude ?? data.east_west ?? data.horizontal;
+    const yCandidate = data.y ?? data.Y ?? data.lat ?? data.latitude ?? data.north_south ?? data.vertical;
+    const zCandidate = data.z ?? data.Z ?? data.alt ?? data.altitude ?? data.height ?? data.depth;
+
+    return {
+      x: asFiniteNumber(xCandidate),
+      y: asFiniteNumber(yCandidate),
+      z: asFiniteNumber(zCandidate)
+    };
+  }
+
+  if (typeof raw === 'number' || typeof raw === 'string') {
+    const parsed = asFiniteNumber(raw);
+    return {
+      x: parsed,
+      y: null,
+      z: null
+    };
+  }
+
+  return { x: null, y: null, z: null };
+}
+
+function normalisePoint(raw: unknown, fallbackSet: number, fallbackPoint: number): FpePointInfo {
+  let setNumber = fallbackSet;
+  let pointNumber = fallbackPoint;
+  let label: string | null = null;
+  let focusPaletteNumber: number | null = null;
+  let position: FpePosition = { x: null, y: null, z: null };
+
+  if (raw && typeof raw === 'object') {
+    const data = raw as Record<string, unknown>;
+
+    const setCandidates = [data.set_number, data.set, data.setId, data.set_index, data.parent_set];
+    for (const candidate of setCandidates) {
+      const parsed = parseInteger(candidate);
+      if (parsed != null) {
+        setNumber = parsed;
+        break;
+      }
+    }
+
+    const pointCandidates = [data.point_number, data.point, data.number, data.id, data.index];
+    for (const candidate of pointCandidates) {
+      const parsed = parseInteger(candidate);
+      if (parsed != null) {
+        pointNumber = parsed;
+        break;
+      }
+    }
+
+    const labelCandidate =
+      data.label ?? data.name ?? data.title ?? data.description ?? data.point_label ?? data.text;
+    label = asString(labelCandidate);
+
+    const focusPaletteCandidates = [
+      data.focus_palette,
+      data.focusPalette,
+      data.focus_palette_number,
+      data.focusPaletteNumber,
+      data.fp,
+      data.focus,
+      data.palette
+    ];
+    for (const candidate of focusPaletteCandidates) {
+      const parsed = parseInteger(candidate);
+      if (parsed != null) {
+        focusPaletteNumber = parsed;
+        break;
+      }
+    }
+
+    const positionCandidates = [
+      data.position,
+      data.pos,
+      data.xyz,
+      data.coordinates,
+      data.location,
+      data.vector,
+      Array.isArray(data) ? data : null,
+      [data.x, data.y, data.z]
+    ];
+    for (const candidate of positionCandidates) {
+      if (candidate != null) {
+        position = normalisePosition(candidate);
+        break;
+      }
+    }
+  } else if (Array.isArray(raw)) {
+    position = normalisePosition(raw);
+  }
+
+  return {
+    set_number: setNumber,
+    point_number: pointNumber,
+    label,
+    focus_palette_number: focusPaletteNumber,
+    position
+  };
+}
+
+function normalisePointCollection(raw: unknown, setNumber: number): FpePointInfo[] {
+  if (Array.isArray(raw)) {
+    return raw
+      .map((item, index) => normalisePoint(item, setNumber, index + 1))
+      .filter((item) => item != null);
+  }
+
+  if (raw && typeof raw === 'object') {
+    const data = raw as Record<string, unknown>;
+    const entries = Object.entries(data);
+    if (entries.length === 0) {
+      return [];
+    }
+
+    return entries
+      .map(([key, value], index) => {
+        const fallbackPoint = parseInteger(key) ?? index + 1;
+        return normalisePoint(value, setNumber, fallbackPoint);
+      })
+      .filter((item) => item != null);
+  }
+
+  return [];
+}
+
+function normaliseSet(raw: unknown, fallbackNumber: number): FpeSetInfo {
+  let setNumber = fallbackNumber;
+  let label: string | null = null;
+  let pointCount = 0;
+  let points: FpePointInfo[] = [];
+
+  if (raw && typeof raw === 'object') {
+    const data = raw as Record<string, unknown>;
+
+    const setCandidates = [data.set_number, data.set, data.number, data.id, data.index];
+    for (const candidate of setCandidates) {
+      const parsed = parseInteger(candidate);
+      if (parsed != null) {
+        setNumber = parsed;
+        break;
+      }
+    }
+
+    const labelCandidate = data.label ?? data.name ?? data.title ?? data.description ?? data.set_label;
+    label = asString(labelCandidate);
+
+    const pointCountCandidates = [data.point_count, data.points, data.count, data.total_points, data.size];
+    for (const candidate of pointCountCandidates) {
+      if (Array.isArray(candidate)) {
+        pointCount = candidate.length;
+        break;
+      }
+      const parsed = parseInteger(candidate);
+      if (parsed != null) {
+        pointCount = parsed;
+        break;
+      }
+    }
+
+    const pointsCandidates = [data.points, data.point_list, data.items, data.point, data.data, data.entries];
+    for (const candidate of pointsCandidates) {
+      if (candidate != null) {
+        points = normalisePointCollection(candidate, setNumber);
+        break;
+      }
+    }
+  }
+
+  if (pointCount === 0) {
+    pointCount = points.length;
+  }
+
+  return {
+    set_number: setNumber,
+    label,
+    point_count: pointCount,
+    points
+  };
+}
+
+function collectCandidates(raw: unknown): unknown[] {
+  const visited = new Set<unknown>();
+  const queue: unknown[] = [];
+
+  if (raw != null) {
+    queue.push(raw);
+  }
+
+  const candidates: unknown[] = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current == null) {
+      continue;
+    }
+
+    if (typeof current !== 'object') {
+      continue;
+    }
+
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    candidates.push(current);
+
+    if (Array.isArray(current)) {
+      queue.push(...current);
+      continue;
+    }
+
+    const data = current as Record<string, unknown>;
+    for (const value of Object.values(data)) {
+      if (value && typeof value === 'object') {
+        queue.push(value);
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function findSetPayload(raw: unknown, setNumber: number): unknown | null {
+  const candidates = collectCandidates(raw);
+  for (const candidate of candidates) {
+    if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+      const data = candidate as Record<string, unknown>;
+      const setCandidates = [data.set_number, data.set, data.number, data.id, data.index];
+      for (const setCandidate of setCandidates) {
+        const parsed = parseInteger(setCandidate);
+        if (parsed != null && parsed === setNumber) {
+          return candidate;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function findPointPayload(raw: unknown, setNumber: number, pointNumber: number): unknown | null {
+  const candidates = collectCandidates(raw);
+  let fallback: unknown | null = null;
+
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') {
+      continue;
+    }
+
+    const data = candidate as Record<string, unknown>;
+    const pointCandidates = [data.point_number, data.point, data.number, data.id, data.index];
+
+    let pointMatch = false;
+    for (const pointCandidate of pointCandidates) {
+      const parsed = parseInteger(pointCandidate);
+      if (parsed != null && parsed === pointNumber) {
+        pointMatch = true;
+        break;
+      }
+    }
+
+    if (!pointMatch) {
+      continue;
+    }
+
+    const setCandidates = [data.set_number, data.set, data.parent_set];
+    let setMatch = false;
+    let hasSetInfo = false;
+
+    for (const setCandidate of setCandidates) {
+      const parsed = parseInteger(setCandidate);
+      if (parsed != null) {
+        hasSetInfo = true;
+        if (parsed === setNumber) {
+          setMatch = true;
+          break;
+        }
+      }
+    }
+
+    if (setMatch) {
+      return candidate;
+    }
+
+    if (!hasSetInfo && fallback == null) {
+      fallback = candidate;
+    }
+  }
+
+  return fallback;
+}
+
+function extractMessageCandidate(data: unknown): string | null {
+  if (typeof data === 'string') {
+    return data;
+  }
+
+  if (data && typeof data === 'object') {
+    const record = data as Record<string, unknown>;
+    const candidates = [record.message, record.error, record.reason, record.detail, record.status];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function containsSetNotFound(value: unknown, depth = 0): boolean {
+  if (depth > 5 || value == null) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    const lower = value.toLowerCase();
+    if (lower.includes('set not found') || lower.includes('fpe set not found')) {
+      return true;
+    }
+    return lower.includes('not found') && lower.includes('set');
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsSetNotFound(item, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some((item) =>
+      containsSetNotFound(item, depth + 1)
+    );
+  }
+
+  return false;
+}
+
+function buildSetCountResult(
+  response: OscJsonResponse,
+  payload: Record<string, unknown>,
+  oscAddress: string
+): ToolExecutionResult {
+  let setCount = 0;
+
+  if (response.data != null) {
+    if (typeof response.data === 'number') {
+      setCount = Math.max(0, Math.trunc(response.data));
+    } else if (typeof response.data === 'string') {
+      const parsed = parseInteger(response.data);
+      setCount = parsed != null ? Math.max(0, parsed) : 0;
+    } else if (typeof response.data === 'object') {
+      const record = response.data as Record<string, unknown>;
+      const countCandidates = [
+        record.count,
+        record.total,
+        record.set_count,
+        record.sets,
+        record.items,
+        record.total_sets
+      ];
+      for (const candidate of countCandidates) {
+        if (Array.isArray(candidate)) {
+          setCount = candidate.length;
+          break;
+        }
+        const parsed = parseInteger(candidate);
+        if (parsed != null) {
+          setCount = parsed;
+          break;
+        }
+      }
+    }
+  }
+
+  const message = response.status === 'timeout'
+    ? 'Lecture du nombre de sets FPE expiree.'
+    : `Nombre de sets FPE: ${setCount}.`;
+
+  return {
+    content: [
+      { type: 'text', text: message },
+      {
+        type: 'object',
+        data: {
+          action: 'get_set_count',
+          status: response.status,
+          set_count: setCount,
+          data: response.data,
+          error: response.error ?? null,
+          osc: {
+            address: oscAddress,
+            args: payload
+          }
+        }
+      }
+    ]
+  } as ToolExecutionResult;
+}
+
+function buildSetInfoResult(
+  response: OscJsonResponse,
+  setNumber: number,
+  payload: Record<string, unknown>,
+  oscAddress: string
+): ToolExecutionResult {
+  const setPayload = findSetPayload(response.data, setNumber);
+  const details = normaliseSet(setPayload ?? response.data, setNumber);
+  const rawMessage =
+    extractMessageCandidate(response.data) ??
+    (typeof response.error === 'string' ? response.error : null);
+  const setMissing = containsSetNotFound(response.data);
+
+  let text: string;
+  if (setMissing) {
+    text = `Set FPE ${setNumber} introuvable.`;
+  } else if (response.status === 'timeout') {
+    text = `Lecture du set FPE ${setNumber} expiree.`;
+  } else if (response.status === 'ok') {
+    const labelPart = details.label ? `"${details.label}"` : 'sans label';
+    const pointPart = details.point_count === 1 ? '1 point' : `${details.point_count} points`;
+    text = `Set FPE ${details.set_number} ${labelPart} - ${pointPart}.`;
+  } else {
+    text = `Lecture du set FPE ${setNumber} terminee avec le statut ${response.status}.`;
+  }
+
+  return {
+    content: [
+      { type: 'text', text },
+      {
+        type: 'object',
+        data: {
+          action: 'get_set_info',
+          status: response.status,
+          set_number: setNumber,
+          set: details,
+          data: response.data,
+          error: rawMessage,
+          osc: {
+            address: oscAddress,
+            args: payload
+          }
+        }
+      }
+    ]
+  } as ToolExecutionResult;
+}
+
+function buildPointInfoResult(
+  response: OscJsonResponse,
+  setNumber: number,
+  pointNumber: number,
+  payload: Record<string, unknown>,
+  oscAddress: string
+): ToolExecutionResult {
+  const setPayload = findSetPayload(response.data, setNumber);
+  const setInfo = normaliseSet(setPayload ?? response.data, setNumber);
+  const pointPayload =
+    findPointPayload(response.data, setNumber, pointNumber) ??
+    (setPayload ? findPointPayload(setPayload, setNumber, pointNumber) : null);
+  let pointInfo = normalisePoint(pointPayload ?? response.data, setNumber, pointNumber);
+
+  if (!pointPayload) {
+    const fallback = setInfo.points.find((point) => point.point_number === pointNumber);
+    if (fallback) {
+      pointInfo = fallback;
+    }
+  }
+
+  const rawMessage =
+    extractMessageCandidate(response.data) ??
+    (typeof response.error === 'string' ? response.error : null);
+  const setMissing = containsSetNotFound(response.data);
+
+  let text: string;
+  if (setMissing) {
+    text = `Set FPE ${setNumber} introuvable.`;
+  } else if (response.status === 'timeout') {
+    text = `Lecture du point FPE ${setNumber}.${pointNumber} expiree.`;
+  } else if (response.status === 'ok') {
+    const labelPart = pointInfo.label ? `"${pointInfo.label}"` : 'sans label';
+    const fpPart =
+      pointInfo.focus_palette_number != null
+        ? ` - Palette focus ${pointInfo.focus_palette_number}`
+        : '';
+    const position = pointInfo.position;
+    const posPart =
+      position.x != null || position.y != null || position.z != null
+        ? ` - Position (${position.x ?? '∅'}, ${position.y ?? '∅'}, ${position.z ?? '∅'})`
+        : '';
+    text = `Point FPE ${pointInfo.set_number}.${pointInfo.point_number} ${labelPart}${fpPart}${posPart}.`;
+  } else {
+    text = `Lecture du point FPE ${setNumber}.${pointNumber} terminee avec le statut ${response.status}.`;
+  }
+
+  return {
+    content: [
+      { type: 'text', text },
+      {
+        type: 'object',
+        data: {
+          action: 'get_point_info',
+          status: response.status,
+          set_number: setNumber,
+          point_number: pointNumber,
+          point: pointInfo,
+          set: setInfo,
+          data: response.data,
+          error: rawMessage,
+          osc: {
+            address: oscAddress,
+            args: payload
+          }
+        }
+      }
+    ]
+  } as ToolExecutionResult;
+}
+
+function extractTargetOptions(options: { targetAddress?: string; targetPort?: number }): {
+  targetAddress?: string;
+  targetPort?: number;
+} {
+  const target: { targetAddress?: string; targetPort?: number } = {};
+  if (options.targetAddress) {
+    target.targetAddress = options.targetAddress;
+  }
+  if (typeof options.targetPort === 'number') {
+    target.targetPort = options.targetPort;
+  }
+  return target;
+}
+
+export const eosFpeGetSetCountTool: ToolDefinition<typeof getSetCountInputSchema> = {
+  name: 'eos_fpe_get_set_count',
+  config: {
+    title: 'Compter les sets FPE',
+    description: 'Recupere le nombre total de sets Focus Palette Encoder.',
+    inputSchema: getSetCountInputSchema,
+    annotations: annotate(oscMappings.fpe.getSetCount)
+  },
+  handler: async (args) => {
+    const schema = z.object(getSetCountInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+
+    const response = await client.requestJson(oscMappings.fpe.getSetCount, {
+      timeoutMs: options.timeoutMs,
+      ...extractTargetOptions(options)
+    });
+
+    return buildSetCountResult(response, {}, oscMappings.fpe.getSetCount);
+  }
+};
+
+export const eosFpeGetSetInfoTool: ToolDefinition<typeof getSetInfoInputSchema> = {
+  name: 'eos_fpe_get_set_info',
+  config: {
+    title: 'Informations set FPE',
+    description: 'Recupere les informations detaillees pour un set Focus Palette Encoder.',
+    inputSchema: getSetInfoInputSchema,
+    annotations: annotate(oscMappings.fpe.getSetInfo)
+  },
+  handler: async (args) => {
+    const schema = z.object(getSetInfoInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+
+    const payload = { set: options.set_number };
+    const response = await client.requestJson(oscMappings.fpe.getSetInfo, {
+      timeoutMs: options.timeoutMs,
+      payload,
+      ...extractTargetOptions(options)
+    });
+
+    return buildSetInfoResult(response, options.set_number, payload, oscMappings.fpe.getSetInfo);
+  }
+};
+
+export const eosFpeGetPointInfoTool: ToolDefinition<typeof getPointInfoInputSchema> = {
+  name: 'eos_fpe_get_point_info',
+  config: {
+    title: 'Informations point FPE',
+    description: 'Recupere les informations detaillees pour un point Focus Palette Encoder.',
+    inputSchema: getPointInfoInputSchema,
+    annotations: annotate(oscMappings.fpe.getPointInfo)
+  },
+  handler: async (args) => {
+    const schema = z.object(getPointInfoInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+
+    const payload = { set: options.set_number, point: options.point_number };
+    const response = await client.requestJson(oscMappings.fpe.getPointInfo, {
+      timeoutMs: options.timeoutMs,
+      payload,
+      ...extractTargetOptions(options)
+    });
+
+    return buildPointInfoResult(
+      response,
+      options.set_number,
+      options.point_number,
+      payload,
+      oscMappings.fpe.getPointInfo
+    );
+  }
+};
+
+export const fpeTools = [
+  eosFpeGetSetCountTool,
+  eosFpeGetSetInfoTool,
+  eosFpeGetPointInfoTool
+];
+
+export default fpeTools;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -23,6 +23,7 @@ import curveTools from './curves/index.js';
 import patchTools from './patch/index.js';
 import showControlTools from './showControl/index.js';
 import queryTools from './queries/index.js';
+import fpeTools from './fpe/index.js';
 import type { ToolDefinition } from './types.js';
 
 export const toolDefinitions: ToolDefinition[] = [
@@ -50,7 +51,8 @@ export const toolDefinitions: ToolDefinition[] = [
   ...patchTools,
   ...snapshotTools,
   ...showControlTools,
-  ...queryTools
+  ...queryTools,
+  ...fpeTools
 ];
 
 export default toolDefinitions;


### PR DESCRIPTION
## Summary
- add OSC mapping entries for Focus Palette Encoder endpoints
- implement FPE tools to read set counts, set info, and point info with normalized outputs and error handling
- add unit tests covering parsing of multiple sets, points, and missing-set errors

## Testing
- npm test -- fpe

------
https://chatgpt.com/codex/tasks/task_e_68f57faf7548832aaaa6393878cfbd0c