### PR TITLE
Add diagnostics tooling and logging controls for OSC service

### DIFF
--- a/src/services/osc/__tests__/service.test.ts
+++ b/src/services/osc/__tests__/service.test.ts
@@ -1,0 +1,131 @@
+import { EventEmitter } from 'events';
+import { OscService } from '../index';
+
+type MockHandler = jest.Mock<void, [unknown?]>;
+
+interface MockUdpPort extends EventEmitter {
+  options: Record<string, unknown>;
+  send: MockHandler;
+  close: MockHandler;
+  open: MockHandler;
+}
+
+declare module 'osc' {
+  interface __MockModule {
+    instances: MockUdpPort[];
+    reset(): void;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const __mock: __MockModule;
+}
+
+jest.mock('osc', () => {
+  const instances: MockUdpPort[] = [];
+
+  class MockUdpPortImpl extends EventEmitter {
+    public readonly options: Record<string, unknown>;
+    public readonly send: MockHandler;
+    public readonly close: MockHandler;
+    public readonly open: MockHandler;
+
+    constructor(options: Record<string, unknown>) {
+      super();
+      this.options = options;
+      this.send = jest.fn();
+      this.close = jest.fn();
+      this.open = jest.fn();
+      instances.push(this as unknown as MockUdpPort);
+    }
+  }
+
+  return {
+    UDPPort: jest.fn((options: Record<string, unknown>) => new MockUdpPortImpl(options)),
+    __mock: {
+      instances,
+      reset: () => {
+        instances.splice(0, instances.length);
+      }
+    }
+  };
+});
+
+describe('OscService diagnostics', () => {
+  const oscModule = jest.requireMock('osc') as {
+    __mock: {
+      instances: MockUdpPort[];
+      reset: () => void;
+    };
+  };
+
+  const logger = {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn()
+  };
+
+  beforeEach(() => {
+    oscModule.__mock.reset();
+    jest.clearAllMocks();
+  });
+
+  const createService = (): { service: OscService; port: MockUdpPort } => {
+    const service = new OscService({ localPort: 9000, remotePort: 9001, remoteAddress: '127.0.0.1', logger });
+    const port = oscModule.__mock.instances[oscModule.__mock.instances.length - 1];
+    if (!port) {
+      throw new Error('Le port OSC simule est introuvable');
+    }
+    return { service, port };
+  };
+
+  it('met a jour le logging et consigne les changements', () => {
+    const { service } = createService();
+
+    try {
+      const state = service.setLoggingOptions({ incoming: true });
+
+      expect(state).toEqual({ incoming: true, outgoing: false });
+      expect(logger.info).toHaveBeenLastCalledWith(
+        expect.stringContaining('entrant: active')
+      );
+
+      const nextState = service.setLoggingOptions({ outgoing: true });
+      expect(nextState).toEqual({ incoming: true, outgoing: true });
+    } finally {
+      service.close();
+    }
+  });
+
+  it('agrège les statistiques des messages entrants et sortants', () => {
+    const { service, port } = createService();
+
+    try {
+      service.setLoggingOptions({ incoming: true, outgoing: true });
+      service.send({ address: '/test/out', args: [{ type: 'i', value: 1 }] });
+
+      expect(logger.debug).toHaveBeenCalledWith('[OSC] -> /test/out', [{ type: 'i', value: 1 }]);
+
+      port.emit('message', { address: '/test/in', args: [{ type: 's', value: 'hello' }] });
+
+      expect(logger.debug).toHaveBeenCalledWith('[OSC] <- /test/in', [{ type: 's', value: 'hello' }]);
+
+      const diagnostics = service.getDiagnostics();
+
+      expect(diagnostics.stats.outgoing.count).toBe(1);
+      expect(diagnostics.stats.outgoing.addresses[0]).toMatchObject({
+        address: '/test/out',
+        count: 1
+      });
+      expect(diagnostics.stats.incoming.count).toBe(1);
+      expect(diagnostics.stats.incoming.addresses[0]).toMatchObject({
+        address: '/test/in',
+        count: 1
+      });
+      expect(diagnostics.logging).toEqual({ incoming: true, outgoing: true });
+      expect(diagnostics.listeners.active).toBe(0);
+      expect(diagnostics.uptimeMs).toBeGreaterThanOrEqual(0);
+    } finally {
+      service.close();
+    }
+  });
+});

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -1,4 +1,11 @@
-import type { OscMessage, OscMessageArgument, OscService } from './index.js';
+import type {
+  OscDiagnostics,
+  OscLoggingOptions,
+  OscLoggingState,
+  OscMessage,
+  OscMessageArgument,
+  OscService
+} from './index.js';
 
 const HANDSHAKE_REQUEST = '/eos/handshake';
 const HANDSHAKE_REPLY = '/eos/handshake/reply';
@@ -32,6 +39,8 @@ export class OscTimeoutError extends Error {
 export interface OscGateway {
   send(message: OscMessage, targetAddress?: string, targetPort?: number): void;
   onMessage(listener: (message: OscMessage) => void): () => void;
+  setLoggingOptions?(options: OscLoggingOptions): OscLoggingState;
+  getDiagnostics?(): OscDiagnostics;
 }
 
 export interface OscClientConfig {
@@ -362,6 +371,20 @@ export class OscClient {
       }
       throw error;
     }
+  }
+
+  public setLogging(options: OscLoggingOptions = {}): OscLoggingState {
+    if (typeof this.gateway.setLoggingOptions !== 'function') {
+      throw new Error('Le service OSC ne supporte pas la configuration du logging.');
+    }
+    return this.gateway.setLoggingOptions(options);
+  }
+
+  public getDiagnostics(): OscDiagnostics {
+    if (typeof this.gateway.getDiagnostics !== 'function') {
+      throw new Error('Le service OSC ne fournit pas de diagnostics.');
+    }
+    return this.gateway.getDiagnostics();
   }
 
   public async getCommandLine(options: CommandLineRequestOptions = {}): Promise<CommandLineState> {

--- a/src/services/osc/index.ts
+++ b/src/services/osc/index.ts
@@ -10,21 +10,92 @@ export interface OscMessage {
   args?: OscMessageArgument[];
 }
 
+export interface OscMessageSummary {
+  address: string;
+  args: OscMessageArgument[];
+}
+
 export type OscMessageListener = (message: OscMessage) => void;
+
+export type OscLogger = Pick<Console, 'info' | 'debug' | 'error'>;
+
+export interface OscLoggingState {
+  incoming: boolean;
+  outgoing: boolean;
+}
+
+export type OscLoggingOptions = Partial<OscLoggingState>;
+
+export interface OscAddressDiagnostics {
+  address: string;
+  count: number;
+  lastTimestamp: number | null;
+}
+
+export interface OscDirectionDiagnostics {
+  count: number;
+  bytes: number;
+  lastTimestamp: number | null;
+  lastMessage: OscMessageSummary | null;
+  addresses: OscAddressDiagnostics[];
+}
+
+export interface OscDiagnostics {
+  config: {
+    localAddress: string;
+    localPort: number;
+    remoteAddress?: string;
+    remotePort?: number;
+  };
+  logging: OscLoggingState;
+  stats: {
+    incoming: OscDirectionDiagnostics;
+    outgoing: OscDirectionDiagnostics;
+  };
+  listeners: {
+    active: number;
+  };
+  startedAt: number;
+  uptimeMs: number;
+}
 
 export interface OscServiceConfig {
   localAddress?: string;
   localPort: number;
   remoteAddress?: string;
   remotePort?: number;
+  logger?: OscLogger;
+}
+
+type Direction = 'incoming' | 'outgoing';
+
+interface DirectionStats {
+  count: number;
+  bytes: number;
+  lastTimestamp: number | null;
+  lastMessage: OscMessageSummary | null;
+  addresses: Map<string, { count: number; lastTimestamp: number | null }>;
 }
 
 export class OscService {
   private readonly port: UDPPort;
 
+  private readonly logger: OscLogger;
+
   private readonly listeners = new Set<OscMessageListener>();
 
+  private readonly loggingState: OscLoggingState = { incoming: false, outgoing: false };
+
+  private readonly stats: Record<Direction, DirectionStats> = {
+    incoming: { count: 0, bytes: 0, lastTimestamp: null, lastMessage: null, addresses: new Map() },
+    outgoing: { count: 0, bytes: 0, lastTimestamp: null, lastMessage: null, addresses: new Map() }
+  };
+
+  private readonly startedAt = Date.now();
+
   constructor(private readonly config: OscServiceConfig) {
+    this.logger = config.logger ?? console;
+
     this.port = new UDPPort({
       localAddress: config.localAddress ?? '0.0.0.0',
       localPort: config.localPort,
@@ -34,16 +105,30 @@ export class OscService {
     });
 
     this.port.on('ready', () => {
-      console.info(`OSC UDP port ouvert sur ${config.localAddress ?? '0.0.0.0'}:${config.localPort}`);
+      this.logger.info(
+        `OSC UDP port ouvert sur ${config.localAddress ?? '0.0.0.0'}:${config.localPort}`
+      );
     });
 
-    this.port.on('message', (message: OscMessage) => {
-      console.debug('[OSC] message recu', message);
+    this.port.on('message', (rawMessage: unknown) => {
+      const message = this.normaliseIncomingMessage(rawMessage);
+      if (!message) {
+        this.logger.error('[OSC] Message recu dans un format inattendu', rawMessage);
+        return;
+      }
+
+      const summary = this.createMessageSummary(message);
+      this.updateStats('incoming', summary);
+
+      if (this.loggingState.incoming) {
+        this.logger.debug(`[OSC] <- ${summary.address}`, summary.args);
+      }
+
       this.listeners.forEach((listener) => {
         try {
           listener(message);
         } catch (error) {
-          console.error('[OSC] Erreur lors du traitement du message', error);
+          this.logger.error('[OSC] Erreur lors du traitement du message', error);
         }
       });
     });
@@ -52,6 +137,13 @@ export class OscService {
   }
 
   public send(message: OscMessage, targetAddress?: string, targetPort?: number): void {
+    const summary = this.createMessageSummary(message);
+    this.updateStats('outgoing', summary);
+
+    if (this.loggingState.outgoing) {
+      this.logger.debug(`[OSC] -> ${summary.address}`, summary.args);
+    }
+
     this.port.send(message, targetAddress ?? this.config.remoteAddress, targetPort ?? this.config.remotePort);
   }
 
@@ -62,9 +154,109 @@ export class OscService {
     };
   }
 
+  public setLoggingOptions(options: OscLoggingOptions): OscLoggingState {
+    if (typeof options.incoming === 'boolean') {
+      this.loggingState.incoming = options.incoming;
+    }
+    if (typeof options.outgoing === 'boolean') {
+      this.loggingState.outgoing = options.outgoing;
+    }
+
+    this.logger.info(
+      `[OSC] Logging mis a jour - entrant: ${this.loggingState.incoming ? 'active' : 'inactive'}, sortant: ${
+        this.loggingState.outgoing ? 'active' : 'inactive'
+      }`
+    );
+
+    return { ...this.loggingState };
+  }
+
+  public getDiagnostics(): OscDiagnostics {
+    const now = Date.now();
+    return {
+      config: {
+        localAddress: this.config.localAddress ?? '0.0.0.0',
+        localPort: this.config.localPort,
+        remoteAddress: this.config.remoteAddress,
+        remotePort: this.config.remotePort
+      },
+      logging: { ...this.loggingState },
+      stats: {
+        incoming: this.serialiseDirectionStats(this.stats.incoming),
+        outgoing: this.serialiseDirectionStats(this.stats.outgoing)
+      },
+      listeners: {
+        active: this.listeners.size
+      },
+      startedAt: this.startedAt,
+      uptimeMs: now - this.startedAt
+    };
+  }
+
   public close(): void {
     this.port.close();
     this.listeners.clear();
+  }
+
+  private createMessageSummary(message: OscMessage): OscMessageSummary {
+    return {
+      address: message.address,
+      args: message.args ? [...message.args] : []
+    };
+  }
+
+  private normaliseIncomingMessage(rawMessage: unknown): OscMessage | null {
+    if (typeof rawMessage !== 'object' || rawMessage === null) {
+      return null;
+    }
+
+    const candidate = rawMessage as Partial<OscMessage>;
+    if (typeof candidate.address !== 'string') {
+      return null;
+    }
+
+    const args = Array.isArray(candidate.args) ? (candidate.args as OscMessageArgument[]) : [];
+    return { address: candidate.address, args };
+  }
+
+  private updateStats(direction: Direction, summary: OscMessageSummary): void {
+    const stats = this.stats[direction];
+    stats.count += 1;
+    stats.lastTimestamp = Date.now();
+    stats.lastMessage = summary;
+    stats.bytes += this.estimateMessageSize(summary);
+
+    const addressStats = stats.addresses.get(summary.address) ?? { count: 0, lastTimestamp: null };
+    addressStats.count += 1;
+    addressStats.lastTimestamp = stats.lastTimestamp;
+    stats.addresses.set(summary.address, addressStats);
+  }
+
+  private estimateMessageSize(summary: OscMessageSummary): number {
+    try {
+      return Buffer.byteLength(JSON.stringify(summary), 'utf8');
+    } catch (error) {
+      this.logger.error('[OSC] Impossible de calculer la taille du message', error);
+      return 0;
+    }
+  }
+
+  private serialiseDirectionStats(stats: DirectionStats): OscDirectionDiagnostics {
+    const addresses = Array.from(stats.addresses.entries())
+      .map(([address, data]) => ({
+        address,
+        count: data.count,
+        lastTimestamp: data.lastTimestamp
+      }))
+      .sort((a, b) => b.count - a.count || (b.lastTimestamp ?? 0) - (a.lastTimestamp ?? 0));
+
+    return {
+      count: stats.count,
+      bytes: stats.bytes,
+      lastTimestamp: stats.lastTimestamp,
+      lastMessage: stats.lastMessage,
+      addresses
+    };
   }
 }
 

--- a/src/tools/diagnostics/index.ts
+++ b/src/tools/diagnostics/index.ts
@@ -1,0 +1,136 @@
+import { z } from 'zod';
+import { getOscClient } from '../../services/osc/client.js';
+import type { OscDiagnostics, OscLoggingState } from '../../services/osc/index.js';
+import type { ToolDefinition } from '../types.js';
+
+const loggingInputSchema = {
+  incoming: z.boolean().optional(),
+  outgoing: z.boolean().optional()
+};
+
+const emptyInputSchema = {} as const;
+
+const formatLoggingState = (state: OscLoggingState): string => {
+  const lines = [
+    `Journalisation entrante: ${state.incoming ? 'activee' : 'desactivee'}`,
+    `Journalisation sortante: ${state.outgoing ? 'activee' : 'desactivee'}`
+  ];
+  return lines.join('\n');
+};
+
+const formatBytes = (bytes: number): string => {
+  if (!Number.isFinite(bytes)) {
+    return 'n/a';
+  }
+  if (bytes < 1024) {
+    return `${bytes} o`;
+  }
+  const kb = bytes / 1024;
+  if (kb < 1024) {
+    return `${kb.toFixed(2)} Ko`;
+  }
+  const mb = kb / 1024;
+  return `${mb.toFixed(2)} Mo`;
+};
+
+const formatDirectionStats = (label: string, diagnostics: OscDiagnostics, key: 'incoming' | 'outgoing'): string => {
+  const stats = diagnostics.stats[key];
+  const base = `${label}: ${stats.count} messages, ${formatBytes(stats.bytes)}`;
+  const lastMessage = stats.lastTimestamp ? new Date(stats.lastTimestamp).toISOString() : 'jamais';
+  const lines = [base, `  Dernier message: ${lastMessage}`];
+
+  if (stats.addresses.length > 0) {
+    lines.push('  Adresses principales:');
+    stats.addresses.slice(0, 3).forEach((address) => {
+      const seen = address.count === 1 ? '1 message' : `${address.count} messages`;
+      const lastSeen = address.lastTimestamp ? new Date(address.lastTimestamp).toISOString() : 'jamais';
+      lines.push(`    • ${address.address} (${seen}, dernier: ${lastSeen})`);
+    });
+  }
+
+  return lines.join('\n');
+};
+
+const formatDiagnostics = (diagnostics: OscDiagnostics): string => {
+  const lines = [
+    'Configuration OSC:',
+    `- Local: ${diagnostics.config.localAddress}:${diagnostics.config.localPort}`,
+    `- Remote: ${diagnostics.config.remoteAddress ?? 'inconnu'}:${diagnostics.config.remotePort ?? 'n/a'}`,
+    '',
+    'Journalisation:',
+    `- Entrante: ${diagnostics.logging.incoming ? 'activee' : 'desactivee'}`,
+    `- Sortante: ${diagnostics.logging.outgoing ? 'activee' : 'desactivee'}`,
+    '',
+    'Statistiques messages:',
+    formatDirectionStats('  Entrants', diagnostics, 'incoming'),
+    formatDirectionStats('  Sortants', diagnostics, 'outgoing'),
+    '',
+    `Auditeurs actifs: ${diagnostics.listeners.active}`,
+    `Demarrage service: ${new Date(diagnostics.startedAt).toISOString()}`,
+    `Uptime: ${(diagnostics.uptimeMs / 1000).toFixed(2)} s`
+  ];
+
+  return lines.join('\n');
+};
+
+export const eosEnableLoggingTool: ToolDefinition<typeof loggingInputSchema> = {
+  name: 'eos_enable_logging',
+  config: {
+    title: 'Basculer le logging OSC',
+    description: 'Active ou desactive la journalisation des messages OSC entrants et sortants.',
+    inputSchema: loggingInputSchema
+  },
+  handler: async (args) => {
+    const schema = z.object(loggingInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const state = client.setLogging(options);
+    const summary = formatLoggingState(state);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: summary
+        },
+        {
+          type: 'object',
+          data: { logging: state }
+        }
+      ]
+    };
+  }
+};
+
+export const eosGetDiagnosticsTool: ToolDefinition<typeof emptyInputSchema> = {
+  name: 'eos_get_diagnostics',
+  config: {
+    title: 'Diagnostics OSC',
+    description: 'Recupere les informations de diagnostic du service OSC.',
+    inputSchema: emptyInputSchema
+  },
+  handler: async (args) => {
+    const schema = z.object(emptyInputSchema).strict();
+    schema.parse(args ?? {});
+    const client = getOscClient();
+    const diagnostics = client.getDiagnostics();
+    const summary = formatDiagnostics(diagnostics);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: summary
+        },
+        {
+          type: 'object',
+          data: diagnostics
+        }
+      ]
+    };
+  }
+};
+
+const diagnosticsTools: ToolDefinition[] = [eosEnableLoggingTool, eosGetDiagnosticsTool];
+
+export default diagnosticsTools;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@ import commandTools from './commands/command_tools.js';
 import channelTools from './channels/index.js';
 import groupTools from './groups/index.js';
 import pingTool from './ping.js';
+import diagnosticsTools from './diagnostics/index.js';
 import cueTools from './cues/index.js';
 import paletteTools from './palettes/index.js';
 import presetTools from './presets/index.js';
@@ -36,6 +37,7 @@ export const toolDefinitions: ToolDefinition[] = [
   ...commandTools,
   ...channelTools,
   ...groupTools,
+  ...diagnosticsTools,
   ...cueTools,
   ...paletteTools,
   ...presetTools,


### PR DESCRIPTION
## Summary
- add logging toggles and diagnostics reporting to the OSC service
- expose logging and diagnostics helpers through the OSC client and new diagnostics tools
- cover the new logging toggles and stats aggregation with dedicated service tests

## Testing
- npm test -- --runTestsByPath src/services/osc/__tests__/service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f61b870bf4832a81dc91661448808e