### PR TITLE
docs: generate MCP tool documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@ npm install
 - `npm test` : exécute la suite de tests (Jest).
 - `npm start` : lance le serveur MCP compilé en mode stdio.
 - `npm run start:dev` : lance le serveur MCP directement avec `ts-node`.
+- `npm run docs:generate` : régénère la documentation complète des outils MCP et les commentaires JSDoc.
+- `npm run docs:check` : vérifie que `docs/tools.md` est synchronisé avec le code source.
+
+## Documentation des outils
+
+La description détaillée de chaque outil MCP est disponible dans [`docs/tools.md`](docs/tools.md). Le fichier est généré automatiquement à partir des schémas Zod déclarés dans `src/tools/**`. Utilisez :
+
+```bash
+npm run docs:generate
+```
+
+pour mettre à jour la documentation et les commentaires JSDoc, puis :
+
+```bash
+npm run docs:check
+```
+
+dans votre CI pour garantir que la documentation est à jour.
 
 ## Configuration réseau
 
@@ -46,3 +64,25 @@ npm start
 ```
 
 Le serveur démarre sur le transport stdio du SDK MCP et initialisera un service OSC écoutant sur les ports configurés.
+
+## Utilisation
+
+### Appel via la CLI MCP
+
+Après avoir démarré le serveur (`npm run start:dev`), vous pouvez déclencher un outil directement avec le client officiel :
+
+```bash
+npx @modelcontextprotocol/cli call --tool ping --args '{"message":"Bonjour"}'
+```
+
+Les arguments attendus et d'autres exemples sont listés dans [`docs/tools.md`](docs/tools.md).
+
+### Appel via OSC
+
+Chaque outil documente également le chemin OSC correspondant. Par exemple, pour reproduire le `ping` via OSC :
+
+```bash
+oscsend 127.0.0.1 8001 /eos/ping s:'{"message":"Bonjour"}'
+```
+
+Adaptez le chemin et la charge utile selon la section dédiée dans la documentation des outils.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,2842 @@
+# Documentation des outils
+
+> Ce document est généré automatiquement via `npm run docs:generate`.
+> Merci de ne pas le modifier manuellement.
+
+Chaque outil expose son nom MCP, une description, la liste des arguments attendus ainsi qu'un exemple d'appel en CLI et par OSC.
+
+<a id="eos-address-select"></a>
+## Selection d'adresse DMX (`eos_address_select`)
+
+**Description :** Selectionne une adresse DMX specifique sur la console.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `address_number` | string \| number | Oui | Adresse DMX au format 'univers/adresse' ou numero absolu. |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_address_select --args '{"address_number":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/dmx/address/select s:'{"address_number":"exemple"}'
+```
+
+<a id="eos-address-set-dmx"></a>
+## Reglage DMX brut (`eos_address_set_dmx`)
+
+**Description :** Fixe une valeur DMX brute (0-255) pour une adresse DMX.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `address_number` | string \| number | Oui | Adresse DMX au format 'univers/adresse' ou numero absolu. |
+| `dmx_value` | number \| string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_address_set_dmx --args '{"address_number":"exemple","dmx_value":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/dmx/address/dmx s:'{"address_number":"exemple","dmx_value":1}'
+```
+
+<a id="eos-address-set-level"></a>
+## Reglage de niveau d'adresse DMX (`eos_address_set_level`)
+
+**Description :** Ajuste le niveau (0-100) pour une adresse DMX donnee.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `address_number` | string \| number | Oui | Adresse DMX au format 'univers/adresse' ou numero absolu. |
+| `level` | number \| string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_address_set_level --args '{"address_number":"exemple","level":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/dmx/address/level s:'{"address_number":"exemple","level":1}'
+```
+
+<a id="eos-beam-palette-fire"></a>
+## Declenchement de palette de beam (`eos_beam_palette_fire`)
+
+**Description :** Declenche une palette de beam sur la console Eos.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `palette_number` | number | Oui | Numero de palette (1-99999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_beam_palette_fire --args '{"palette_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/bp/fire s:'{"palette_number":1}'
+```
+
+<a id="eos-channel-get-info"></a>
+## Informations de canaux (`eos_channel_get_info`)
+
+**Description :** Recupere des informations sur les canaux depuis la console.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `channels` | number \| array<number> | Oui | Un numero de canal ou une liste de canaux |
+| `fields` | array<string> | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_channel_get_info --args '{"channels":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/channels s:'{"channels":1}'
+```
+
+<a id="eos-channel-select"></a>
+## Selection de canaux (`eos_channel_select`)
+
+**Description :** Selectionne un ou plusieurs canaux sur la console.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `channels` | number \| array<number> | Oui | Un numero de canal ou une liste de canaux |
+| `exclusive` | boolean | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_channel_select --args '{"channels":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/chan/select s:'{"channels":1}'
+```
+
+<a id="eos-channel-set-level"></a>
+## Reglage de niveau (`eos_channel_set_level`)
+
+**Description :** Ajuste le niveau intensite de canaux specifiques (0-100).
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `channels` | number \| array<number> | Oui | Un numero de canal ou une liste de canaux |
+| `level` | number \| string | Oui | — |
+| `snap` | boolean | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_channel_set_level --args '{"channels":1,"level":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/chan/level s:'{"channels":1,"level":1}'
+```
+
+<a id="eos-channel-set-parameter"></a>
+## Reglage de parametre (`eos_channel_set_parameter`)
+
+**Description :** Ajuste un parametre de canal sur une echelle de 0 a 100.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `channels` | number \| array<number> | Oui | Un numero de canal ou une liste de canaux |
+| `parameter` | string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `value` | number \| string | Oui | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_channel_set_parameter --args '{"channels":1,"parameter":"exemple","value":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/chan/param s:'{"channels":1,"parameter":"exemple","value":1}'
+```
+
+<a id="eos-color-palette-fire"></a>
+## Declenchement de palette de couleur (`eos_color_palette_fire`)
+
+**Description :** Declenche une palette de couleur sur la console Eos.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `palette_number` | number | Oui | Numero de palette (1-99999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_color_palette_fire --args '{"palette_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/cp/fire s:'{"palette_number":1}'
+```
+
+<a id="eos-command"></a>
+## Commande EOS (`eos_command`)
+
+**Description :** Envoie du texte sur la ligne de commande existante de la console.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `command` | string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `terminateWithEnter` | boolean | Non | — |
+| `user` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_command --args '{"command":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/cmd s:'{"command":"exemple"}'
+```
+
+<a id="eos-command-with-substitution"></a>
+## Commande avec substitution (`eos_command_with_substitution`)
+
+**Description :** Applique des substitutions %1, %2, ... puis envoie la commande.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `template` | string | Oui | — |
+| `terminateWithEnter` | boolean | Non | — |
+| `user` | number | Non | — |
+| `values` | array<string \| number \| boolean> | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_command_with_substitution --args '{"template":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/cmd s:'{"template":"exemple"}'
+```
+
+<a id="eos-connect"></a>
+## Connexion OSC EOS (`eos_connect`)
+
+**Description :** Initie un handshake OSC avec la console EOS, choisit un protocole et retourne la version detectee.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `clientId` | string | Non | — |
+| `handshakeTimeoutMs` | number | Non | — |
+| `preferredProtocols` | array<string> | Non | — |
+| `protocolTimeoutMs` | number | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_connect --args '{"targetAddress":"exemple"}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="eos-cue-fire"></a>
+## Declenchement de cue (`eos_cue_fire`)
+
+**Description :** Declenche immediatement une cue specifique dans une liste donnee.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `cue_number` | string \| number | Oui | — |
+| `cue_part` | number | Non | — |
+| `cuelist_number` | number | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_cue_fire --args '{"cuelist_number":1,"cue_number":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/cue/fire s:'{"cuelist_number":1,"cue_number":"exemple"}'
+```
+
+<a id="eos-cue-get-info"></a>
+## Informations de cue (`eos_cue_get_info`)
+
+**Description :** Recupere les informations detaillees d'une cue (timings, flags, notes...).
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `cue_number` | string \| number | Oui | — |
+| `cue_part` | number | Non | — |
+| `cuelist_number` | number | Oui | — |
+| `fields` | array<string> | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_cue_get_info --args '{"cuelist_number":1,"cue_number":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/cue s:'{"cuelist_number":1,"cue_number":"exemple"}'
+```
+
+<a id="eos-cue-go"></a>
+## GO sur liste de cues (`eos_cue_go`)
+
+**Description :** Declenche un GO sur la liste de cues cible, optionnellement vers une cue precise.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `cue_number` | string \| number | Non | — |
+| `cue_part` | number | Non | — |
+| `cuelist_number` | number | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_cue_go --args '{"cuelist_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/cue/go s:'{"cuelist_number":1}'
+```
+
+<a id="eos-cue-list-all"></a>
+## Liste des cues (`eos_cue_list_all`)
+
+**Description :** Recupere toutes les cues d'une liste avec leurs labels.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `cuelist_number` | number | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_cue_list_all --args '{"cuelist_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/cuelist s:'{"cuelist_number":1}'
+```
+
+<a id="eos-cue-select"></a>
+## Selection de cue (`eos_cue_select`)
+
+**Description :** Selectionne une cue dans la liste sans la declencher.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `cue_number` | string \| number | Oui | — |
+| `cue_part` | number | Non | — |
+| `cuelist_number` | number | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_cue_select --args '{"cuelist_number":1,"cue_number":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/cue/select s:'{"cuelist_number":1,"cue_number":"exemple"}'
+```
+
+<a id="eos-cue-stop-back"></a>
+## Stop ou Back sur liste de cues (`eos_cue_stop_back`)
+
+**Description :** Stoppe la lecture de la liste ou effectue un back selon l'option fournie.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `back` | boolean | Non | — |
+| `cuelist_number` | number | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_cue_stop_back --args '{"cuelist_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/cue/stop/back s:'{"cuelist_number":1}'
+```
+
+<a id="eos-cuelist-bank-create"></a>
+## Creation de bank de cuelist (`eos_cuelist_bank_create`)
+
+**Description :** Configure un bank OSC pour surveiller une liste de cues.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `bank_index` | number | Oui | — |
+| `cuelist_number` | number | Oui | — |
+| `num_pending_cues` | number | Oui | — |
+| `num_prev_cues` | number | Oui | — |
+| `offset` | number | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_cuelist_bank_create --args '{"bank_index":1,"cuelist_number":1,"num_prev_cues":1,"num_pending_cues":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/cuelist/bank/create s:'{"bank_index":1,"cuelist_number":1,"num_prev_cues":1,"num_pending_cues":1}'
+```
+
+<a id="eos-cuelist-bank-page"></a>
+## Navigation de bank de cuelist (`eos_cuelist_bank_page`)
+
+**Description :** Change de page dans un bank de cues en ajoutant le delta specifie.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `bank_index` | number | Oui | — |
+| `delta` | number | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_cuelist_bank_page --args '{"bank_index":1,"delta":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/cuelist/bank/page s:'{"bank_index":1,"delta":1}'
+```
+
+<a id="eos-cuelist-get-info"></a>
+## Informations de cuelist (`eos_cuelist_get_info`)
+
+**Description :** Recupere les attributs d'une liste de cues (modes, flags...).
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `cuelist_number` | number | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_cuelist_get_info --args '{"cuelist_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/cuelist/info s:'{"cuelist_number":1}'
+```
+
+<a id="eos-curve-get-info"></a>
+## Lecture des informations de courbe (`eos_curve_get_info`)
+
+**Description :** Recupere les informations d'une courbe, incluant label et points.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `curve_number` | number | Oui | Numero de courbe (1-9999). |
+| `fields` | array<string> | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_curve_get_info --args '{"curve_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/curve s:'{"curve_number":1}'
+```
+
+<a id="eos-curve-select"></a>
+## Selection de courbe (`eos_curve_select`)
+
+**Description :** Selectionne une courbe en envoyant son numero a la console.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `curve_number` | number | Oui | Numero de courbe (1-9999). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_curve_select --args '{"curve_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/curve/select s:'{"curve_number":1}'
+```
+
+<a id="eos-direct-select-bank-create"></a>
+## Creation de bank de direct selects (`eos_direct_select_bank_create`)
+
+**Description :** Cree un bank de direct selects OSC avec configuration de cible et pagination.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `bank_index` | number | Oui | Index du bank de direct selects (0 pour le premier bank). |
+| `button_count` | number | Oui | Nombre de boutons a creer dans le bank (1-100). |
+| `flexi_mode` | boolean | Oui | Active ou non le mode Flexi pour le bank. |
+| `page_number` | number | Non | Page initiale (0 par defaut). |
+| `target_type` | string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_direct_select_bank_create --args '{"bank_index":1,"target_type":"exemple","button_count":1,"flexi_mode":true}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/direct_select/bank/create s:'{"bank_index":1,"target_type":"exemple","button_count":1,"flexi_mode":true}'
+```
+
+<a id="eos-direct-select-page"></a>
+## Navigation de direct select (`eos_direct_select_page`)
+
+**Description :** Change la page active dans un bank de direct selects.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `bank_index` | number | Oui | Index du bank de direct selects (0 pour le premier bank). |
+| `delta` | number | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_direct_select_page --args '{"bank_index":1,"delta":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/direct_select/bank/page s:'{"bank_index":1,"delta":1}'
+```
+
+<a id="eos-direct-select-press"></a>
+## Appui de direct select (`eos_direct_select_press`)
+
+**Description :** Simule un appui ou relachement sur un bouton de direct select.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `bank_index` | number | Oui | Index du bank de direct selects (0 pour le premier bank). |
+| `button_index` | number | Oui | Position du bouton dans le bank (1-n). |
+| `state` | number | Oui | Etat du bouton (1.0 = enfonce, 0.0 = relache). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_direct_select_press --args '{"bank_index":1,"button_index":1,"state":1}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="eos-effect-get-info"></a>
+## Informations d'effet (`eos_effect_get_info`)
+
+**Description :** Recupere les informations detaillees d'un effet.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `effect_number` | number | Oui | Numero d'effet (1-9999) |
+| `fields` | array<string> | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_effect_get_info --args '{"effect_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/effect s:'{"effect_number":1}'
+```
+
+<a id="eos-effect-select"></a>
+## Selection d'effet (`eos_effect_select`)
+
+**Description :** Selectionne un effet sans le lancer.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `effect_number` | number | Oui | Numero d'effet (1-9999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_effect_select --args '{"effect_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/effect/select s:'{"effect_number":1}'
+```
+
+<a id="eos-effect-stop"></a>
+## Arret d'effet (`eos_effect_stop`)
+
+**Description :** Stoppe un effet actif sur la selection.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `effect_number` | number | Non | Numero d'effet (1-9999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_effect_stop --args '{"effect_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/effect/stop s:'{"effect_number":1}'
+```
+
+<a id="eos-enable-logging"></a>
+## Basculer le logging OSC (`eos_enable_logging`)
+
+**Description :** Active ou desactive la journalisation des messages OSC entrants et sortants.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `incoming` | boolean | Non | — |
+| `outgoing` | boolean | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_enable_logging --args '{"incoming":true}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="eos-fader-bank-create"></a>
+## Creation de bank de faders (`eos_fader_bank_create`)
+
+**Description :** Cree un bank de faders OSC avec pagination optionnelle.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `bank_index` | number | Oui | Index du bank de faders (0 = Main, 1 = Mains, etc.). |
+| `fader_count` | number | Oui | Nombre de faders a creer dans le bank. |
+| `page_number` | number | Non | Numero de page initial (0 par defaut). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_fader_bank_create --args '{"bank_index":1,"fader_count":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/fader/bank/create s:'{"bank_index":1,"fader_count":1}'
+```
+
+<a id="eos-fader-load"></a>
+## Chargement de fader (`eos_fader_load`)
+
+**Description :** Charge le contenu courant sur le fader specifie.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `bank_index` | number | Oui | Index du bank de faders (0 = Main, 1 = Mains, etc.). |
+| `fader_index` | number | Oui | Position du fader dans le bank (1-n). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_fader_load --args '{"bank_index":1,"fader_index":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/fader/{bank}/{page}/{fader}/load s:'{"bank_index":1,"fader_index":1}'
+```
+
+<a id="eos-fader-page"></a>
+## Navigation de bank de faders (`eos_fader_page`)
+
+**Description :** Change de page dans le bank en ajoutant le delta specifie.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `bank_index` | number | Oui | Index du bank de faders (0 = Main, 1 = Mains, etc.). |
+| `delta` | number | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_fader_page --args '{"bank_index":1,"delta":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/fader/bank/page s:'{"bank_index":1,"delta":1}'
+```
+
+<a id="eos-fader-set-level"></a>
+## Reglage de niveau de fader (`eos_fader_set_level`)
+
+**Description :** Definit le niveau (0-1 ou 0-100%) du fader cible.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `bank_index` | number | Oui | Index du bank de faders (0 = Main, 1 = Mains, etc.). |
+| `fader_index` | number | Oui | Position du fader dans le bank (1-n). |
+| `level` | number \| string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_fader_set_level --args '{"bank_index":1,"fader_index":1,"level":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/fader/{bank}/{page}/{fader} s:'{"bank_index":1,"fader_index":1,"level":1}'
+```
+
+<a id="eos-fader-unload"></a>
+## Dechargement de fader (`eos_fader_unload`)
+
+**Description :** Decharge le contenu du fader specifie.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `bank_index` | number | Oui | Index du bank de faders (0 = Main, 1 = Mains, etc.). |
+| `fader_index` | number | Oui | Position du fader dans le bank (1-n). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_fader_unload --args '{"bank_index":1,"fader_index":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/fader/{bank}/{page}/{fader}/unload s:'{"bank_index":1,"fader_index":1}'
+```
+
+<a id="eos-focus-palette-fire"></a>
+## Declenchement de palette de focus (`eos_focus_palette_fire`)
+
+**Description :** Declenche une palette de focus sur la console Eos.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `palette_number` | number | Oui | Numero de palette (1-99999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_focus_palette_fire --args '{"palette_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/fp/fire s:'{"palette_number":1}'
+```
+
+<a id="eos-fpe-get-point-info"></a>
+## Informations point FPE (`eos_fpe_get_point_info`)
+
+**Description :** Recupere les informations detaillees pour un point Focus Palette Encoder.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `point_number` | number | Oui | Numero de point FPE (1-9999). |
+| `set_number` | number | Oui | Numero de set FPE (1-9999). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_fpe_get_point_info --args '{"set_number":1,"point_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/fpe/point s:'{"set_number":1,"point_number":1}'
+```
+
+<a id="eos-fpe-get-set-count"></a>
+## Compter les sets FPE (`eos_fpe_get_set_count`)
+
+**Description :** Recupere le nombre total de sets Focus Palette Encoder.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_fpe_get_set_count --args '{"timeoutMs":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/fpe/set/count s:'{"timeoutMs":1}'
+```
+
+<a id="eos-fpe-get-set-info"></a>
+## Informations set FPE (`eos_fpe_get_set_info`)
+
+**Description :** Recupere les informations detaillees pour un set Focus Palette Encoder.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `set_number` | number | Oui | Numero de set FPE (1-9999). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_fpe_get_set_info --args '{"set_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/fpe/set s:'{"set_number":1}'
+```
+
+<a id="eos-get-active-cue"></a>
+## Cue active (`eos_get_active_cue`)
+
+**Description :** Recupere la cue actuellement en lecture sur la liste specifiee (ou principale).
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `cuelist_number` | number | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_get_active_cue --args '{"cuelist_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/active/cue s:'{"cuelist_number":1}'
+```
+
+<a id="eos-get-active-wheels"></a>
+## Encodeurs actifs (`eos_get_active_wheels`)
+
+**Description :** Recupere et normalise la liste des encodeurs actifs.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_get_active_wheels --args '{"timeoutMs":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/active/wheels s:'{"timeoutMs":1}'
+```
+
+<a id="eos-get-command-line"></a>
+## Lecture de la ligne de commande EOS (`eos_get_command_line`)
+
+**Description :** Recupere le contenu courant de la ligne de commande via OSC Get.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+| `user` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_get_command_line --args '{"user":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/cmd_line s:'{"user":1}'
+```
+
+<a id="eos-get-count"></a>
+## Compter les elements (`eos_get_count`)
+
+**Description :** Recupere le nombre total d'elements pour un type donne.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `target_type` | string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_get_count --args '{"target_type":"exemple"}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="eos-get-diagnostics"></a>
+## Diagnostics OSC (`eos_get_diagnostics`)
+
+**Description :** Recupere les informations de diagnostic du service OSC.
+
+**Arguments :** Aucun argument.
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_get_diagnostics --args '{}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="eos-get-list-all"></a>
+## Lister tous les elements (`eos_get_list_all`)
+
+**Description :** Recupere la liste complete des elements pour un type donne.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `target_type` | string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_get_list_all --args '{"target_type":"exemple"}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="eos-get-live-blind-state"></a>
+## Etat Live/Blind (`eos_get_live_blind_state`)
+
+**Description :** Indique si la console est en mode Live ou Blind.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | Delai maximum d'attente en millisecondes. |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_get_live_blind_state --args '{"timeoutMs":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/live/blind s:'{"timeoutMs":1}'
+```
+
+<a id="eos-get-pending-cue"></a>
+## Cue en attente (`eos_get_pending_cue`)
+
+**Description :** Recupere la prochaine cue en attente sur la liste specifiee (ou principale).
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `cuelist_number` | number | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_get_pending_cue --args '{"cuelist_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/pending/cue s:'{"cuelist_number":1}'
+```
+
+<a id="eos-get-show-name"></a>
+## Nom du show (`eos_get_show_name`)
+
+**Description :** Recupere le nom du show actuellement charge sur la console.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | Delai maximum d'attente en millisecondes. |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_get_show_name --args '{"timeoutMs":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/show/name s:'{"timeoutMs":1}'
+```
+
+<a id="eos-get-softkey-labels"></a>
+## Libelles des softkeys (`eos_get_softkey_labels`)
+
+**Description :** Recupere les libelles affiches des softkeys 1-12.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_get_softkey_labels --args '{"timeoutMs":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/softkey_labels s:'{"timeoutMs":1}'
+```
+
+<a id="eos-group-get-info"></a>
+## Informations sur un groupe (`eos_group_get_info`)
+
+**Description :** Recupere les informations detaillees pour un groupe donne.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `group_number` | number | Oui | Numero de groupe (1-99999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_group_get_info --args '{"group_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/group/info s:'{"group_number":1}'
+```
+
+<a id="eos-group-list-all"></a>
+## Liste des groupes (`eos_group_list_all`)
+
+**Description :** Recupere la liste des groupes disponibles avec leurs membres.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_group_list_all --args '{"timeoutMs":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/group/list s:'{"timeoutMs":1}'
+```
+
+<a id="eos-group-select"></a>
+## Selection de groupe (`eos_group_select`)
+
+**Description :** Selectionne un groupe sur la console Eos.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `group_number` | number | Oui | Numero de groupe (1-99999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_group_select --args '{"group_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/group/select s:'{"group_number":1}'
+```
+
+<a id="eos-group-set-level"></a>
+## Reglage de niveau de groupe (`eos_group_set_level`)
+
+**Description :** Ajuste le niveau d'un groupe sur une echelle de 0 a 100.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `group_number` | number | Oui | Numero de groupe (1-99999) |
+| `level` | number \| string | Oui | — |
+| `snap` | boolean | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_group_set_level --args '{"group_number":1,"level":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/group/level s:'{"group_number":1,"level":1}'
+```
+
+<a id="eos-intensity-palette-fire"></a>
+## Declenchement de palette d'intensite (`eos_intensity_palette_fire`)
+
+**Description :** Declenche une palette d'intensite sur la console Eos.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `palette_number` | number | Oui | Numero de palette (1-99999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_intensity_palette_fire --args '{"palette_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/ip/fire s:'{"palette_number":1}'
+```
+
+<a id="eos-key-press"></a>
+## Appui sur touche (`eos_key_press`)
+
+**Description :** Simule l'appui ou le relachement d'une touche du clavier EOS.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `key_name` | string | Oui | — |
+| `state` | number \| boolean | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_key_press --args '{"key_name":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/key/<key> s:'{"key_name":"exemple"}'
+```
+
+<a id="eos-macro-fire"></a>
+## Declenchement de macro (`eos_macro_fire`)
+
+**Description :** Declenche une macro en envoyant son numero a la console.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `macro_number` | number | Oui | Numero de macro (1-9999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_macro_fire --args '{"macro_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/macro/fire s:'{"macro_number":1}'
+```
+
+<a id="eos-macro-get-info"></a>
+## Informations de macro (`eos_macro_get_info`)
+
+**Description :** Recupere le libelle et le script d'une macro.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `macro_number` | number | Oui | Numero de macro (1-9999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_macro_get_info --args '{"macro_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/macro s:'{"macro_number":1}'
+```
+
+<a id="eos-macro-select"></a>
+## Selection de macro (`eos_macro_select`)
+
+**Description :** Selectionne une macro sans l'executer.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `macro_number` | number | Oui | Numero de macro (1-9999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_macro_select --args '{"macro_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/macro/select s:'{"macro_number":1}'
+```
+
+<a id="eos-magic-sheet-get-info"></a>
+## Informations de magic sheet (`eos_magic_sheet_get_info`)
+
+**Description :** Recupere le label et l'UID d'un magic sheet.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `ms_number` | number | Oui | Numero du magic sheet (1-9999). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_magic_sheet_get_info --args '{"ms_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/magic_sheet s:'{"ms_number":1}'
+```
+
+<a id="eos-magic-sheet-open"></a>
+## Ouverture de magic sheet (`eos_magic_sheet_open`)
+
+**Description :** Ouvre un magic sheet specifique sur la console.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `ms_number` | number | Oui | Numero du magic sheet (1-9999). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `view_number` | number | Non | Numero de vue (1-99). |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_magic_sheet_open --args '{"ms_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/magic_sheet/open s:'{"ms_number":1}'
+```
+
+<a id="eos-magic-sheet-send-string"></a>
+## Envoi de commande via magic sheet (`eos_magic_sheet_send_string`)
+
+**Description :** Envoie une commande OSC via la fonctionnalite Magic Sheet.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `osc_command` | string | Oui | Commande OSC a envoyer via le magic sheet. |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_magic_sheet_send_string --args '{"osc_command":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/magic_sheet/send_string s:'{"osc_command":"exemple"}'
+```
+
+<a id="eos-new-command"></a>
+## Nouvelle commande EOS (`eos_new_command`)
+
+**Description :** Efface optionnellement la ligne de commande puis envoie le texte fourni.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `clearLine` | boolean | Non | — |
+| `command` | string | Oui | — |
+| `substitutions` | array<string \| number \| boolean> | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `terminateWithEnter` | boolean | Non | — |
+| `user` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_new_command --args '{"command":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/newcmd s:'{"command":"exemple"}'
+```
+
+<a id="eos-palette-get-info"></a>
+## Informations de palette (`eos_palette_get_info`)
+
+**Description :** Recupere les informations detaillees pour une palette donnee.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `fields` | array<string> | Non | — |
+| `palette_number` | number | Oui | Numero de palette (1-99999) |
+| `palette_type` | enum(ip, fp, cp, bp) | Oui | Type de palette: 'ip' (intensite), 'fp' (focus), 'cp' (couleur), 'bp' (beam) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_palette_get_info --args '{"palette_type":"ip","palette_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/palette s:'{"palette_type":"ip","palette_number":1}'
+```
+
+<a id="eos-patch-get-augment3d-beam"></a>
+## Faisceau Augment3d (`eos_patch_get_augment3d_beam`)
+
+**Description :** Recupere les informations de faisceau Augment3d pour une partie de canal.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `channel_number` | number | Oui | Numero de canal (1-99999). |
+| `part_number` | number | Oui | Numero de partie (1-99). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_patch_get_augment3d_beam --args '{"channel_number":1,"part_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/patch/chan_beam s:'{"channel_number":1,"part_number":1}'
+```
+
+<a id="eos-patch-get-augment3d-position"></a>
+## Position Augment3d (`eos_patch_get_augment3d_position`)
+
+**Description :** Recupere la position Augment3d d'une partie de canal.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `channel_number` | number | Oui | Numero de canal (1-99999). |
+| `part_number` | number | Oui | Numero de partie (1-99). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_patch_get_augment3d_position --args '{"channel_number":1,"part_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/patch/chan_pos s:'{"channel_number":1,"part_number":1}'
+```
+
+<a id="eos-patch-get-channel-info"></a>
+## Informations de patch (`eos_patch_get_channel_info`)
+
+**Description :** Recupere les informations de patch pour un canal donne.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `channel_number` | number | Oui | Numero de canal (1-99999). |
+| `part_number` | number | Non | Numero de partie (0 = toutes les parties, 1-99). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_patch_get_channel_info --args '{"channel_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/patch/chan_info s:'{"channel_number":1}'
+```
+
+<a id="eos-ping"></a>
+## Ping OSC EOS (`eos_ping`)
+
+**Description :** Envoie un ping OSC a la console EOS et retourne le statut.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `message` | string | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_ping --args '{"message":"exemple"}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="eos-pixmap-get-info"></a>
+## Informations sur un pixel map (`eos_pixmap_get_info`)
+
+**Description :** Recupere les informations detaillees pour un pixel map donne.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `pixmap_number` | number | Oui | Numero du pixel map (1-9999). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_pixmap_get_info --args '{"pixmap_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/pixmap s:'{"pixmap_number":1}'
+```
+
+<a id="eos-pixmap-select"></a>
+## Selection de pixel map (`eos_pixmap_select`)
+
+**Description :** Selectionne un pixel map sur la console Eos.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `pixmap_number` | number | Oui | Numero du pixel map (1-9999). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_pixmap_select --args '{"pixmap_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/pixmap/select s:'{"pixmap_number":1}'
+```
+
+<a id="eos-preset-fire"></a>
+## Declenchement de preset (`eos_preset_fire`)
+
+**Description :** Declenche un preset sur la console Eos.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `preset_number` | number | Oui | Numero de preset (1-99999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_preset_fire --args '{"preset_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/preset/fire s:'{"preset_number":1}'
+```
+
+<a id="eos-preset-get-info"></a>
+## Informations de preset (`eos_preset_get_info`)
+
+**Description :** Recupere les informations detaillees pour un preset donne.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `fields` | array<string> | Non | — |
+| `preset_number` | number | Oui | Numero de preset (1-99999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_preset_get_info --args '{"preset_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/preset s:'{"preset_number":1}'
+```
+
+<a id="eos-preset-select"></a>
+## Selection de preset (`eos_preset_select`)
+
+**Description :** Selectionne un preset sur la console Eos.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `preset_number` | number | Oui | Numero de preset (1-99999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_preset_select --args '{"preset_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/preset/select s:'{"preset_number":1}'
+```
+
+<a id="eos-reset"></a>
+## Reset OSC EOS (`eos_reset`)
+
+**Description :** Envoie une commande de reset a la console EOS.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `full` | boolean | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_reset --args '{"full":true}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="eos-set-color-hs"></a>
+## Couleur HS (`eos_set_color_hs`)
+
+**Description :** Definit une couleur via Hue/Saturation.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `hue` | number \| string | Oui | — |
+| `saturation` | number \| string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_set_color_hs --args '{"hue":1,"saturation":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/param/color/hs s:'{"hue":1,"saturation":1}'
+```
+
+<a id="eos-set-color-rgb"></a>
+## Couleur RGB (`eos_set_color_rgb`)
+
+**Description :** Definit une couleur via valeurs RGB (0-1).
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `blue` | number \| string | Oui | — |
+| `green` | number \| string | Oui | — |
+| `red` | number \| string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_set_color_rgb --args '{"red":1,"green":1,"blue":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/param/color/rgb s:'{"red":1,"green":1,"blue":1}'
+```
+
+<a id="eos-set-cue-receive-string"></a>
+## Format de reception des cues (`eos_set_cue_receive_string`)
+
+**Description :** Configure le format de reception OSC des cues (placeholders %1-%2).
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `format_string` | string | Oui | Format de reception des cues (placeholders %1-%2 disponibles). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_set_cue_receive_string --args '{"format_string":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/set/cue/receive_string s:'{"format_string":"exemple"}'
+```
+
+<a id="eos-set-cue-send-string"></a>
+## Format d'envoi des cues (`eos_set_cue_send_string`)
+
+**Description :** Configure le format d'envoi OSC des cues (placeholders %1-%5).
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `format_string` | string | Oui | Format d'envoi des cues (placeholders %1-%5 disponibles). |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_set_cue_send_string --args '{"format_string":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/set/cue/send_string s:'{"format_string":"exemple"}'
+```
+
+<a id="eos-set-dmx"></a>
+## Reglage DMX (`eos_set_dmx`)
+
+**Description :** Fixe une valeur DMX (0-255) sur une ou plusieurs adresses.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `addresses` | number \| array<number> | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `value` | number \| string | Oui | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_set_dmx --args '{"addresses":1,"value":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/dmx/level s:'{"addresses":1,"value":1}'
+```
+
+<a id="eos-set-pantilt-xy"></a>
+## Position Pan/Tilt XY (`eos_set_pantilt_xy`)
+
+**Description :** Definit une position normalisee sur le plan XY (0-1).
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `x` | number \| string | Oui | — |
+| `y` | number \| string | Oui | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_set_pantilt_xy --args '{"x":1,"y":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/param/position/xy s:'{"x":1,"y":1}'
+```
+
+<a id="eos-set-xyz-position"></a>
+## Position XYZ (`eos_set_xyz_position`)
+
+**Description :** Definit une position XYZ en metres.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `x` | number \| string | Oui | — |
+| `y` | number \| string | Oui | — |
+| `z` | number \| string | Oui | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_set_xyz_position --args '{"x":1,"y":1,"z":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/param/position/xyz s:'{"x":1,"y":1,"z":1}'
+```
+
+<a id="eos-snapshot-get-info"></a>
+## Lecture des informations de snapshot (`eos_snapshot_get_info`)
+
+**Description :** Recupere les informations d'un snapshot, incluant label et UID.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `fields` | array<string> | Non | — |
+| `snapshot_number` | number | Oui | Numero de snapshot (1-9999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_snapshot_get_info --args '{"snapshot_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/snapshot s:'{"snapshot_number":1}'
+```
+
+<a id="eos-snapshot-recall"></a>
+## Rappel de snapshot (`eos_snapshot_recall`)
+
+**Description :** Rappelle un snapshot en envoyant son numero a la console.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `snapshot_number` | number | Oui | Numero de snapshot (1-9999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_snapshot_recall --args '{"snapshot_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/snapshot/recall s:'{"snapshot_number":1}'
+```
+
+<a id="eos-softkey-press"></a>
+## Appui sur softkey (`eos_softkey_press`)
+
+**Description :** Simule l'appui ou le relachement d'une softkey (1-12).
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `softkey_number` | number | Oui | — |
+| `state` | number \| boolean | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_softkey_press --args '{"softkey_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/key/softkey# s:'{"softkey_number":1}'
+```
+
+<a id="eos-submaster-bump"></a>
+## Commande de bump (`eos_submaster_bump`)
+
+**Description :** Active ou desactive le bump d'un submaster.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `state` | boolean \| number \| string | Oui | — |
+| `submaster_number` | number | Oui | Numero de submaster (1-9999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_submaster_bump --args '{"submaster_number":1,"state":true}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/sub/{id}/bump s:'{"submaster_number":1,"state":true}'
+```
+
+<a id="eos-submaster-get-info"></a>
+## Informations sur un submaster (`eos_submaster_get_info`)
+
+**Description :** Recupere et normalise les informations d'un submaster.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `submaster_number` | number | Oui | Numero de submaster (1-9999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_submaster_get_info --args '{"submaster_number":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/get/submaster s:'{"submaster_number":1}'
+```
+
+<a id="eos-submaster-set-level"></a>
+## Reglage de submaster (`eos_submaster_set_level`)
+
+**Description :** Ajuste le niveau d'un submaster sur une echelle de 0.0 a 1.0.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `level` | number \| string | Oui | — |
+| `submaster_number` | number | Oui | Numero de submaster (1-9999) |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_submaster_set_level --args '{"submaster_number":1,"level":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/sub/{id} s:'{"submaster_number":1,"level":1}'
+```
+
+<a id="eos-subscribe"></a>
+## Souscription OSC EOS (`eos_subscribe`)
+
+**Description :** Active ou desactive une souscription OSC sur la console EOS.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `enable` | boolean | Non | — |
+| `path` | string | Oui | — |
+| `rateHz` | number | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_subscribe --args '{"path":"exemple"}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="eos-switch-continuous"></a>
+## Mouvement continu (`eos_switch_continuous`)
+
+**Description :** Active un mouvement continu d'encodeur sur un parametre.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `parameter_name` | string | Oui | — |
+| `rate` | number \| string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_switch_continuous --args '{"parameter_name":"exemple","rate":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/param/wheel/rate s:'{"parameter_name":"exemple","rate":1}'
+```
+
+<a id="eos-toggle-staging-mode"></a>
+## Toggle Staging Mode (`eos_toggle_staging_mode`)
+
+**Description :** Active ou desactive le mode Staging de la console.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_toggle_staging_mode --args '{"targetAddress":"exemple"}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/toggle/staging_mode s:'{"targetAddress":"exemple"}'
+```
+
+<a id="eos-wheel-tick"></a>
+## Rotation d'encodeur (`eos_wheel_tick`)
+
+**Description :** Simule une rotation d'encodeur pour un parametre donne.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `mode` | enum(coarse, fine) | Non | — |
+| `parameter_name` | string | Oui | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `ticks` | number \| string | Oui | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_wheel_tick --args '{"parameter_name":"exemple","ticks":1}'
+```
+
+_OSC_
+
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/param/wheel/tick s:'{"parameter_name":"exemple","ticks":1}'
+```
+
+<a id="ping"></a>
+## Ping tool (`ping`)
+
+**Description :** Retourne un message de confirmation.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `message` | string | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool ping --args '{"message":"exemple"}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="session-get-current-user"></a>
+## Utilisateur courant (`session_get_current_user`)
+
+**Description :** Renvoie le numero utilisateur EOS memorise localement.
+
+**Arguments :** Aucun argument.
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool session_get_current_user --args '{}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="session-set-current-user"></a>
+## Definir utilisateur courant (`session_set_current_user`)
+
+**Description :** Stocke en local le numero utilisateur EOS a utiliser par defaut.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `user` | number | Oui | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool session_set_current_user --args '{"user":1}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "globals": "^16.4.0",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.5",
+        "ts-morph": "^27.0.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
       }
@@ -879,6 +880,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1830,6 +1854,34 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
+      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.14"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -3101,6 +3153,13 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
@@ -5782,6 +5841,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6903,6 +6969,54 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -7009,6 +7123,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
+      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.28.1",
+        "code-block-writer": "^13.0.3"
       }
     },
     "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "lint": "eslint \"src/**/*.ts\"",
     "test": "jest --passWithNoTests",
     "start": "node dist/server/index.js",
-    "start:dev": "ts-node src/server/index.ts"
+    "start:dev": "ts-node src/server/index.ts",
+    "docs:generate": "ts-node --transpile-only --compiler-options '{\"allowImportingTsExtensions\":true}' scripts/toolDocs.ts",
+    "docs:check": "ts-node --transpile-only --compiler-options '{\"allowImportingTsExtensions\":true}' scripts/toolDocs.ts --check --skip-jsdoc"
   },
   "keywords": [
     "mcp",
@@ -35,6 +37,7 @@
     "globals": "^16.4.0",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.5",
+    "ts-morph": "^27.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   }

--- a/scripts/toolDocs.ts
+++ b/scripts/toolDocs.ts
@@ -1,0 +1,647 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ToolDefinition } from '../src/tools/types.js';
+import { z, type ZodTypeAny, type ZodOptional, type ZodNullable, type ZodDefault, type ZodEffects } from 'zod';
+import {
+  Project,
+  Node,
+  type Expression,
+  type ObjectLiteralExpression,
+  type VariableDeclaration,
+  type VariableStatement
+} from 'ts-morph';
+
+interface ToolMetadata {
+  tool: ToolDefinition;
+  schema?: z.ZodTypeAny;
+  exampleArgs?: Record<string, unknown> | undefined;
+  properties: ToolProperty[];
+}
+
+interface ToolProperty {
+  name: string;
+  type: string;
+  required: boolean;
+  description?: string;
+}
+
+type PrivateModule = typeof import('module') & {
+  _resolveFilename: (
+    request: string,
+    parent: NodeModule | undefined,
+    isMain: boolean,
+    options: unknown
+  ) => string;
+};
+
+function patchModuleResolution(): () => void {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const Module = require('module') as PrivateModule;
+  const originalResolveFilename = Module._resolveFilename.bind(Module);
+  Module._resolveFilename = function patchedResolveFilename(request, parent, isMain, options) {
+    try {
+      return originalResolveFilename(request, parent, isMain, options);
+    } catch (error) {
+      if (typeof request === 'string' && request.endsWith('.js')) {
+        const tsRequest = `${request.slice(0, -3)}.ts`;
+        return originalResolveFilename(tsRequest, parent, isMain, options);
+      }
+      throw error;
+    }
+  };
+
+  return () => {
+    Module._resolveFilename = originalResolveFilename;
+  };
+}
+
+function createZodSchema(schemaLike: unknown): z.ZodTypeAny | undefined {
+  if (!schemaLike) {
+    return undefined;
+  }
+
+  if (schemaLike instanceof z.ZodType) {
+    return schemaLike;
+  }
+
+  if (typeof schemaLike === 'object' && schemaLike != null && !Array.isArray(schemaLike)) {
+    const entries = Object.entries(schemaLike as Record<string, unknown>);
+    if (entries.length === 0) {
+      return z.object({}).strict();
+    }
+
+    const shape: Record<string, ZodTypeAny> = {};
+    for (const [key, value] of entries) {
+      if (value instanceof z.ZodType) {
+        shape[key] = value;
+      }
+    }
+
+    if (Object.keys(shape).length > 0) {
+      return z.object(shape).strict();
+    }
+  }
+
+  return undefined;
+}
+
+interface UnwrappedType {
+  type: ZodTypeAny;
+  optional: boolean;
+  nullable: boolean;
+}
+
+function unwrap(type: ZodTypeAny): UnwrappedType {
+  let current: ZodTypeAny = type;
+  let optional = false;
+  let nullable = false;
+
+  while (true) {
+    if (current instanceof z.ZodOptional) {
+      optional = true;
+      current = (current as ZodOptional<ZodTypeAny>).unwrap();
+      continue;
+    }
+
+    if (current instanceof z.ZodNullable) {
+      nullable = true;
+      current = (current as ZodNullable<ZodTypeAny>).unwrap();
+      continue;
+    }
+
+    if (current instanceof z.ZodDefault) {
+      optional = true;
+      current = (current as ZodDefault<ZodTypeAny>)._def.innerType as ZodTypeAny;
+      continue;
+    }
+
+    if (current instanceof z.ZodEffects) {
+      current = (current as ZodEffects<ZodTypeAny, unknown, unknown>)._def.schema as ZodTypeAny;
+      continue;
+    }
+
+    if (current instanceof z.ZodPipeline) {
+      current = current._def.in as ZodTypeAny;
+      continue;
+    }
+
+    if (current instanceof z.ZodBranded) {
+      current = current._def.type as ZodTypeAny;
+      continue;
+    }
+
+    if (current instanceof z.ZodCatch) {
+      current = current._def.innerType as ZodTypeAny;
+      optional = true;
+      continue;
+    }
+
+    if (current instanceof z.ZodLazy) {
+      current = current._def.getter() as ZodTypeAny;
+      continue;
+    }
+
+    break;
+  }
+
+  return { type: current, optional, nullable };
+}
+
+function describeType(type: ZodTypeAny): string {
+  const { type: base, nullable } = unwrap(type);
+
+  let description: string;
+
+  if (base instanceof z.ZodString) {
+    description = 'string';
+  } else if (base instanceof z.ZodNumber) {
+    description = 'number';
+  } else if (base instanceof z.ZodBoolean) {
+    description = 'boolean';
+  } else if (base instanceof z.ZodBigInt) {
+    description = 'bigint';
+  } else if (base instanceof z.ZodDate) {
+    description = 'date';
+  } else if (base instanceof z.ZodArray) {
+    description = `array<${describeType(base.element)}>`;
+  } else if (base instanceof z.ZodTuple) {
+    const items = base.items as ZodTypeAny[];
+    description = `tuple<${items.map((item) => describeType(item)).join(', ')}>`;
+  } else if (base instanceof z.ZodRecord) {
+    const recordValue = (base._def as { valueType: ZodTypeAny }).valueType;
+    description = `record<string, ${describeType(recordValue)}>`;
+  } else if (base instanceof z.ZodEnum) {
+    description = `enum(${base.options.join(', ')})`;
+  } else if (base instanceof z.ZodNativeEnum) {
+    const options = Object.values(base.enum).filter((value) => typeof value === 'string' || typeof value === 'number');
+    description = `enum(${options.join(', ')})`;
+  } else if (base instanceof z.ZodLiteral) {
+    description = `literal(${JSON.stringify(base.value)})`;
+  } else if (base instanceof z.ZodUnion) {
+    const options = base.options as ZodTypeAny[];
+    description = options.map((option) => describeType(option)).join(' | ');
+  } else if (base instanceof z.ZodDiscriminatedUnion) {
+    const options = Array.from(base.options.values()) as ZodTypeAny[];
+    description = options.map((option) => describeType(option)).join(' | ');
+  } else if (base instanceof z.ZodObject) {
+    description = 'object';
+  } else if (base instanceof z.ZodAny) {
+    description = 'any';
+  } else if (base instanceof z.ZodUnknown) {
+    description = 'unknown';
+  } else if (base instanceof z.ZodMap) {
+    const mapTypes = base._def as { keyType: ZodTypeAny; valueType: ZodTypeAny };
+    description = `map<${describeType(mapTypes.keyType)}, ${describeType(mapTypes.valueType)}>`;
+  } else if (base instanceof z.ZodSet) {
+    description = `set<${describeType(base._def.valueType as ZodTypeAny)}>`;
+  } else if (base instanceof z.ZodPromise) {
+    description = `promise<${describeType(base._def.type as ZodTypeAny)}>`;
+  } else {
+    description = base._def?.typeName ?? 'unknown';
+  }
+
+  if (nullable) {
+    return `${description} | null`;
+  }
+
+  return description;
+}
+
+function buildProperties(schema?: z.ZodTypeAny): ToolProperty[] {
+  if (!schema) {
+    return [];
+  }
+
+  const { type: base } = unwrap(schema);
+
+  if (!(base instanceof z.ZodObject)) {
+    return [];
+  }
+
+  const shape = base.shape;
+  const properties: ToolProperty[] = [];
+  for (const key of Object.keys(shape)) {
+    const propertyType = shape[key] as ZodTypeAny;
+    const { type: unwrapped, optional } = unwrap(propertyType);
+    const description = unwrapped.description ?? propertyType.description;
+    properties.push({
+      name: key,
+      type: describeType(propertyType),
+      required: !optional,
+      description: description ?? undefined
+    });
+  }
+
+  return properties.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function buildExample(schema?: z.ZodTypeAny): Record<string, unknown> | undefined {
+  if (!schema) {
+    return undefined;
+  }
+
+  const { type: base } = unwrap(schema);
+  if (!(base instanceof z.ZodObject)) {
+    return undefined;
+  }
+
+  const result: Record<string, unknown> = {};
+  const optionalFallback: Array<{ key: string; type: ZodTypeAny }> = [];
+
+  const shape = base.shape;
+  for (const key of Object.keys(shape)) {
+    const propertyType = shape[key] as ZodTypeAny;
+    const { type: unwrapped, optional } = unwrap(propertyType);
+    if (!optional) {
+      result[key] = buildSampleValue(unwrapped);
+    } else {
+      optionalFallback.push({ key, type: unwrapped });
+    }
+  }
+
+  if (Object.keys(result).length === 0 && optionalFallback.length > 0) {
+    const fallback = optionalFallback[0];
+    result[fallback.key] = buildSampleValue(fallback.type);
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function buildSampleValue(type: ZodTypeAny): unknown {
+  const { type: base } = unwrap(type);
+
+  if (base instanceof z.ZodString) {
+    return base.description?.includes('UUID') ? '00000000-0000-0000-0000-000000000000' : 'exemple';
+  }
+  if (base instanceof z.ZodNumber) {
+    return 1;
+  }
+  if (base instanceof z.ZodBoolean) {
+    return true;
+  }
+  if (base instanceof z.ZodArray) {
+    return [buildSampleValue(base.element)];
+  }
+  if (base instanceof z.ZodEnum) {
+    return base.options[0];
+  }
+  if (base instanceof z.ZodNativeEnum) {
+    const values = Object.values(base.enum).filter((value) => typeof value === 'string' || typeof value === 'number');
+    return values[0];
+  }
+  if (base instanceof z.ZodLiteral) {
+    return base.value;
+  }
+  if (base instanceof z.ZodRecord) {
+    const valueType = (base._def as { valueType: ZodTypeAny }).valueType;
+    return { cle: buildSampleValue(valueType) };
+  }
+  if (base instanceof z.ZodTuple) {
+    const items = base.items as ZodTypeAny[];
+    return items.map((item) => buildSampleValue(item));
+  }
+  if (base instanceof z.ZodObject) {
+    return buildExample(base) ?? {};
+  }
+  if (base instanceof z.ZodUnion) {
+    return buildSampleValue(base.options[0]);
+  }
+  if (base instanceof z.ZodDiscriminatedUnion) {
+    const first = base.options.values().next();
+    if (!first.done) {
+      return buildSampleValue(first.value as ZodTypeAny);
+    }
+  }
+  if (base instanceof z.ZodBigInt) {
+    return BigInt(1);
+  }
+  if (base instanceof z.ZodDate) {
+    return new Date().toISOString();
+  }
+
+  return `<${base._def?.typeName ?? 'valeur'}>`;
+}
+
+function formatCliArgs(args?: Record<string, unknown>): string {
+  const payload = args ?? {};
+  const json = JSON.stringify(payload);
+  return json.replace(/'/g, "\\'");
+}
+
+function formatOscExample(pathValue: unknown, args?: Record<string, unknown>): string[] {
+  if (!pathValue || (typeof pathValue !== 'string' && !Array.isArray(pathValue))) {
+    return ['_Pas de mapping OSC documenté._'];
+  }
+
+  const paths = Array.isArray(pathValue) ? pathValue : [pathValue];
+  const targetPath = paths[0];
+  const payload = args ?? {};
+  const json = JSON.stringify(payload);
+  const escaped = json.replace(/'/g, "\\'");
+  return [
+    '```bash',
+    "# Exemple d'envoi OSC via oscsend",
+    `oscsend 127.0.0.1 8001 ${targetPath} s:'${escaped}'`,
+    '```'
+  ];
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function buildDocumentation(tools: ToolDefinition[]): { markdown: string; metadata: Map<string, ToolMetadata> } {
+  const metadata = new Map<string, ToolMetadata>();
+  const sortedTools = [...tools].sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const tool of sortedTools) {
+    const schema = createZodSchema(tool.config.inputSchema);
+    const properties = buildProperties(schema);
+    const exampleArgs = buildExample(schema);
+    metadata.set(tool.name, { tool, schema, properties, exampleArgs });
+  }
+
+  const lines: string[] = [];
+  lines.push('# Documentation des outils');
+  lines.push('');
+  lines.push('> Ce document est généré automatiquement via `npm run docs:generate`.');
+  lines.push('> Merci de ne pas le modifier manuellement.');
+  lines.push('');
+  lines.push("Chaque outil expose son nom MCP, une description, la liste des arguments attendus ainsi qu'un exemple d'appel en CLI et par OSC.");
+  lines.push('');
+
+  for (const tool of sortedTools) {
+    const data = metadata.get(tool.name)!;
+    const title = tool.config.title ?? tool.name;
+    const description = tool.config.description ?? 'Pas de description fournie.';
+    const slug = slugify(tool.name);
+
+    lines.push(`<a id="${slug}"></a>`);
+    lines.push(`## ${title} (\`${tool.name}\`)`);
+    lines.push('');
+    lines.push(`**Description :** ${description}`);
+    lines.push('');
+
+    if (data.properties.length === 0) {
+      lines.push('**Arguments :** Aucun argument.');
+    } else {
+      lines.push('**Arguments :**');
+      lines.push('');
+      lines.push('| Nom | Type | Requis | Description |');
+      lines.push('| --- | --- | --- | --- |');
+      for (const property of data.properties) {
+        const desc = property.description ? property.description.replace(/\n/g, ' ') : '';
+        const typeText = property.type.replace(/\|/g, '\\|');
+        const descriptionText = (desc || '—').replace(/\|/g, '\\|');
+        lines.push(`| \`${property.name}\` | ${typeText} | ${property.required ? 'Oui' : 'Non'} | ${descriptionText} |`);
+      }
+    }
+    lines.push('');
+    lines.push('**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.');
+    lines.push('');
+    lines.push('**Exemples :**');
+    lines.push('');
+    const cliArgs = formatCliArgs(data.exampleArgs);
+    lines.push('_CLI_');
+    lines.push('');
+    lines.push('```bash');
+    lines.push(`npx @modelcontextprotocol/cli call --tool ${tool.name} --args '${cliArgs}'`);
+    lines.push('```');
+    lines.push('');
+    lines.push('_OSC_');
+    lines.push('');
+    const mapping = (tool.config.annotations as Record<string, unknown> | undefined)?.mapping as Record<string, unknown> | undefined;
+    const oscExample = formatOscExample(mapping?.osc, data.exampleArgs);
+    lines.push(...oscExample);
+    lines.push('');
+  }
+
+  return { markdown: `${lines.join('\n').trim()}\n`, metadata };
+}
+
+interface JsDocData {
+  toolName: string;
+  title: string;
+  description: string;
+}
+
+function extractObjectLiteral(expression: Expression): ObjectLiteralExpression | undefined {
+  const unwrapped = unwrapExpression(expression);
+  if (Node.isObjectLiteralExpression(unwrapped)) {
+    return unwrapped;
+  }
+
+  if (Node.isCallExpression(unwrapped)) {
+    for (const arg of unwrapped.getArguments()) {
+      const literal = extractObjectLiteral(arg as Expression);
+      if (literal) {
+        return literal;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function unwrapExpression(expression: Expression): Expression {
+  let current = expression;
+  while (true) {
+    if (Node.isAsExpression(current) || Node.isSatisfiesExpression(current) || Node.isParenthesizedExpression(current)) {
+      current = current.getExpression();
+      continue;
+    }
+    if (Node.isNonNullExpression(current)) {
+      current = current.getExpression();
+      continue;
+    }
+    break;
+  }
+  return current;
+}
+
+function extractJsDocData(declaration: VariableDeclaration): JsDocData | undefined {
+  const initializer = declaration.getInitializer();
+  if (!initializer) {
+    return undefined;
+  }
+
+  const objectLiteral = extractObjectLiteral(initializer as Expression);
+  if (!objectLiteral) {
+    return undefined;
+  }
+
+  let toolName: string | undefined;
+  let title: string | undefined;
+  let description: string | undefined;
+
+  for (const property of objectLiteral.getProperties()) {
+    if (!Node.isPropertyAssignment(property)) {
+      continue;
+    }
+
+    const name = property.getNameNode();
+    if (name.getText() === 'name') {
+      const valueNode = property.getInitializer();
+      if (valueNode && Node.isStringLiteral(valueNode)) {
+        toolName = valueNode.getLiteralValue();
+      }
+      continue;
+    }
+
+    if (name.getText() === 'config') {
+      const valueNode = property.getInitializer();
+      const configObject = valueNode ? extractObjectLiteral(valueNode as Expression) : undefined;
+      if (configObject) {
+        for (const configProperty of configObject.getProperties()) {
+          if (!Node.isPropertyAssignment(configProperty)) {
+            continue;
+          }
+          const configName = configProperty.getNameNode().getText();
+          const configValue = configProperty.getInitializer();
+          if (!configValue || !Node.isStringLiteral(configValue)) {
+            continue;
+          }
+          if (configName === 'title') {
+            title = configValue.getLiteralValue();
+          } else if (configName === 'description') {
+            description = configValue.getLiteralValue();
+          }
+        }
+      }
+    }
+  }
+
+  if (!toolName) {
+    return undefined;
+  }
+
+  return {
+    toolName,
+    title: title ?? toolName,
+    description: description ?? 'Voir la documentation des outils.'
+  };
+}
+
+function ensureJsDoc(metadata: Map<string, ToolMetadata>): boolean {
+  const project = new Project({ tsConfigFilePath: path.resolve(process.cwd(), 'tsconfig.json') });
+  const sourceFiles = project.getSourceFiles('src/tools/**/*.ts');
+  let updated = false;
+
+  for (const sourceFile of sourceFiles) {
+    if (sourceFile.getBaseName().endsWith('.test.ts') || sourceFile.getFilePath().includes('__tests__')) {
+      continue;
+    }
+
+    const variableStatements = sourceFile.getVariableStatements().filter((statement) => statement.isExported());
+    for (const statement of variableStatements) {
+      for (const declaration of statement.getDeclarations()) {
+        const name = declaration.getName();
+        if (!name.endsWith('Tool')) {
+          continue;
+        }
+
+        const jsDocData = extractJsDocData(declaration);
+        if (!jsDocData) {
+          continue;
+        }
+
+        const toolInfo = metadata.get(jsDocData.toolName);
+        if (!toolInfo) {
+          continue;
+        }
+
+        const slug = slugify(jsDocData.toolName);
+        const description = toolInfo.tool.config.description ?? jsDocData.description;
+        const lines = [
+          `@tool ${jsDocData.toolName}`,
+          `@summary ${jsDocData.title}`,
+          `@description ${description}`,
+          `@arguments Voir docs/tools.md#${slug} pour le schema complet.`,
+          '@returns ToolExecutionResult avec contenu texte et objet.',
+          `@example CLI Consultez docs/tools.md#${slug} pour un exemple CLI.`,
+          `@example OSC Consultez docs/tools.md#${slug} pour un exemple OSC.`
+        ];
+
+        const jsDocTarget = statement as VariableStatement;
+        const existingDocs = jsDocTarget.getJsDocs();
+        const currentText = existingDocs.map((doc) => doc.getInnerText().trim()).join('\n');
+        const newText = lines.join('\n');
+        if (currentText === newText) {
+          continue;
+        }
+
+        for (const doc of existingDocs) {
+          doc.remove();
+        }
+
+        jsDocTarget.addJsDoc({ description: newText });
+        updated = true;
+        break;
+      }
+    }
+  }
+
+  if (updated) {
+    project.saveSync();
+  }
+
+  return updated;
+}
+
+function loadToolDefinitions(): ToolDefinition[] {
+  const restore = patchModuleResolution();
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const moduleExports = require('../src/tools');
+    const definitions = moduleExports.toolDefinitions as ToolDefinition[];
+    if (!Array.isArray(definitions)) {
+      throw new Error('Impossible de charger les definitions des outils.');
+    }
+    return definitions;
+  } finally {
+    restore();
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const shouldCheck = args.includes('--check');
+  const shouldSkipJsDoc = args.includes('--skip-jsdoc');
+
+  const definitions = loadToolDefinitions();
+  const { markdown, metadata } = buildDocumentation(definitions);
+  const docsPath = path.resolve(process.cwd(), 'docs', 'tools.md');
+
+  if (!fs.existsSync(path.dirname(docsPath))) {
+    fs.mkdirSync(path.dirname(docsPath), { recursive: true });
+  }
+
+  if (!shouldSkipJsDoc) {
+    ensureJsDoc(metadata);
+  }
+
+  if (shouldCheck) {
+    if (!fs.existsSync(docsPath)) {
+      console.error('La documentation des outils est manquante.');
+      process.exitCode = 1;
+      return;
+    }
+    const current = fs.readFileSync(docsPath, 'utf8');
+    if (current.trim() !== markdown.trim()) {
+      console.error('La documentation des outils doit etre regeneree (executer `npm run docs:generate`).');
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  fs.writeFileSync(docsPath, markdown, 'utf8');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+

--- a/src/tools/channels/index.ts
+++ b/src/tools/channels/index.ts
@@ -169,6 +169,15 @@ const getInfoSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_channel_select
+ * @summary Selection de canaux
+ * @description Selectionne un ou plusieurs canaux sur la console.
+ * @arguments Voir docs/tools.md#eos-channel-select pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-channel-select pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-channel-select pour un exemple OSC.
+ */
 export const eosChannelSelectTool: ToolDefinition<typeof selectInputSchema> = {
   name: 'eos_channel_select',
   config: {
@@ -201,6 +210,15 @@ export const eosChannelSelectTool: ToolDefinition<typeof selectInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_channel_set_level
+ * @summary Reglage de niveau
+ * @description Ajuste le niveau intensite de canaux specifiques (0-100).
+ * @arguments Voir docs/tools.md#eos-channel-set-level pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-channel-set-level pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-channel-set-level pour un exemple OSC.
+ */
 export const eosChannelSetLevelTool: ToolDefinition<typeof setLevelSchema> = {
   name: 'eos_channel_set_level',
   config: {
@@ -236,6 +254,15 @@ export const eosChannelSetLevelTool: ToolDefinition<typeof setLevelSchema> = {
   }
 };
 
+/**
+ * @tool eos_set_dmx
+ * @summary Reglage DMX
+ * @description Fixe une valeur DMX (0-255) sur une ou plusieurs adresses.
+ * @arguments Voir docs/tools.md#eos-set-dmx pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-set-dmx pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-set-dmx pour un exemple OSC.
+ */
 export const eosSetDmxTool: ToolDefinition<typeof setDmxSchema> = {
   name: 'eos_set_dmx',
   config: {
@@ -269,6 +296,15 @@ export const eosSetDmxTool: ToolDefinition<typeof setDmxSchema> = {
   }
 };
 
+/**
+ * @tool eos_channel_set_parameter
+ * @summary Reglage de parametre
+ * @description Ajuste un parametre de canal sur une echelle de 0 a 100.
+ * @arguments Voir docs/tools.md#eos-channel-set-parameter pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-channel-set-parameter pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-channel-set-parameter pour un exemple OSC.
+ */
 export const eosChannelSetParameterTool: ToolDefinition<typeof setParameterSchema> = {
   name: 'eos_channel_set_parameter',
   config: {
@@ -304,6 +340,15 @@ export const eosChannelSetParameterTool: ToolDefinition<typeof setParameterSchem
   }
 };
 
+/**
+ * @tool eos_channel_get_info
+ * @summary Informations de canaux
+ * @description Recupere des informations sur les canaux depuis la console.
+ * @arguments Voir docs/tools.md#eos-channel-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-channel-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-channel-get-info pour un exemple OSC.
+ */
 export const eosChannelGetInfoTool: ToolDefinition<typeof getInfoSchema> = {
   name: 'eos_channel_get_info',
   config: {

--- a/src/tools/commands/command_tools.ts
+++ b/src/tools/commands/command_tools.ts
@@ -114,6 +114,15 @@ const commandInputSchema = {
   ...targetOptionsSchema
 };
 
+/**
+ * @tool eos_command
+ * @summary Commande EOS
+ * @description Envoie du texte sur la ligne de commande existante de la console.
+ * @arguments Voir docs/tools.md#eos-command pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-command pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-command pour un exemple OSC.
+ */
 export const eosCommandTool: ToolDefinition<typeof commandInputSchema> = {
   name: 'eos_command',
   config: {
@@ -149,6 +158,15 @@ const newCommandInputSchema = {
   ...targetOptionsSchema
 };
 
+/**
+ * @tool eos_new_command
+ * @summary Nouvelle commande EOS
+ * @description Efface optionnellement la ligne de commande puis envoie le texte fourni.
+ * @arguments Voir docs/tools.md#eos-new-command pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-new-command pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-new-command pour un exemple OSC.
+ */
 export const eosNewCommandTool: ToolDefinition<typeof newCommandInputSchema> = {
   name: 'eos_new_command',
   config: {
@@ -194,6 +212,15 @@ const substitutionCommandInputSchema = {
   ...targetOptionsSchema
 };
 
+/**
+ * @tool eos_command_with_substitution
+ * @summary Commande avec substitution
+ * @description Applique des substitutions %1, %2, ... puis envoie la commande.
+ * @arguments Voir docs/tools.md#eos-command-with-substitution pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-command-with-substitution pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-command-with-substitution pour un exemple OSC.
+ */
 export const eosCommandWithSubstitutionTool: ToolDefinition<typeof substitutionCommandInputSchema> = {
   name: 'eos_command_with_substitution',
   config: {
@@ -227,6 +254,15 @@ const commandLineInputSchema = {
   ...targetOptionsSchema
 };
 
+/**
+ * @tool eos_get_command_line
+ * @summary Lecture de la ligne de commande EOS
+ * @description Recupere le contenu courant de la ligne de commande via OSC Get.
+ * @arguments Voir docs/tools.md#eos-get-command-line pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-get-command-line pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-get-command-line pour un exemple OSC.
+ */
 export const eosGetCommandLineTool: ToolDefinition<typeof commandLineInputSchema> = {
   name: 'eos_get_command_line',
   config: {

--- a/src/tools/connection/eos_connect.ts
+++ b/src/tools/connection/eos_connect.ts
@@ -11,6 +11,15 @@ const inputSchema = {
   clientId: z.string().min(1).optional()
 };
 
+/**
+ * @tool eos_connect
+ * @summary Connexion OSC EOS
+ * @description Initie un handshake OSC avec la console EOS, choisit un protocole et retourne la version detectee.
+ * @arguments Voir docs/tools.md#eos-connect pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-connect pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-connect pour un exemple OSC.
+ */
 export const eosConnectTool: ToolDefinition<typeof inputSchema> = {
   name: 'eos_connect',
   config: {

--- a/src/tools/connection/eos_ping.ts
+++ b/src/tools/connection/eos_ping.ts
@@ -10,6 +10,15 @@ const inputSchema = {
   targetPort: optionalPortSchema
 };
 
+/**
+ * @tool eos_ping
+ * @summary Ping OSC EOS
+ * @description Envoie un ping OSC a la console EOS et retourne le statut.
+ * @arguments Voir docs/tools.md#eos-ping pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-ping pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-ping pour un exemple OSC.
+ */
 export const eosPingTool: ToolDefinition<typeof inputSchema> = {
   name: 'eos_ping',
   config: {

--- a/src/tools/connection/eos_reset.ts
+++ b/src/tools/connection/eos_reset.ts
@@ -9,6 +9,15 @@ const inputSchema = {
   targetPort: z.number().int().min(1).max(65535).optional()
 };
 
+/**
+ * @tool eos_reset
+ * @summary Reset OSC EOS
+ * @description Envoie une commande de reset a la console EOS.
+ * @arguments Voir docs/tools.md#eos-reset pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-reset pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-reset pour un exemple OSC.
+ */
 export const eosResetTool: ToolDefinition<typeof inputSchema> = {
   name: 'eos_reset',
   config: {

--- a/src/tools/connection/eos_subscribe.ts
+++ b/src/tools/connection/eos_subscribe.ts
@@ -11,6 +11,15 @@ const inputSchema = {
   targetPort: z.number().int().min(1).max(65535).optional()
 };
 
+/**
+ * @tool eos_subscribe
+ * @summary Souscription OSC EOS
+ * @description Active ou desactive une souscription OSC sur la console EOS.
+ * @arguments Voir docs/tools.md#eos-subscribe pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-subscribe pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-subscribe pour un exemple OSC.
+ */
 export const eosSubscribeTool: ToolDefinition<typeof inputSchema> = {
   name: 'eos_subscribe',
   config: {

--- a/src/tools/cues/cuelist_bank_create.ts
+++ b/src/tools/cues/cuelist_bank_create.ts
@@ -21,6 +21,15 @@ const bankCreateInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_cuelist_bank_create
+ * @summary Creation de bank de cuelist
+ * @description Configure un bank OSC pour surveiller une liste de cues.
+ * @arguments Voir docs/tools.md#eos-cuelist-bank-create pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-cuelist-bank-create pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-cuelist-bank-create pour un exemple OSC.
+ */
 export const eosCuelistBankCreateTool: ToolDefinition<typeof bankCreateInputSchema> = {
   name: 'eos_cuelist_bank_create',
   config: {

--- a/src/tools/cues/cuelist_bank_page.ts
+++ b/src/tools/cues/cuelist_bank_page.ts
@@ -10,6 +10,15 @@ const bankPageInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_cuelist_bank_page
+ * @summary Navigation de bank de cuelist
+ * @description Change de page dans un bank de cues en ajoutant le delta specifie.
+ * @arguments Voir docs/tools.md#eos-cuelist-bank-page pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-cuelist-bank-page pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-cuelist-bank-page pour un exemple OSC.
+ */
 export const eosCuelistBankPageTool: ToolDefinition<typeof bankPageInputSchema> = {
   name: 'eos_cuelist_bank_page',
   config: {

--- a/src/tools/cues/cuelist_get_info.ts
+++ b/src/tools/cues/cuelist_get_info.ts
@@ -17,6 +17,15 @@ const cuelistInfoInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_cuelist_get_info
+ * @summary Informations de cuelist
+ * @description Recupere les attributs d'une liste de cues (modes, flags...).
+ * @arguments Voir docs/tools.md#eos-cuelist-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-cuelist-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-cuelist-get-info pour un exemple OSC.
+ */
 export const eosCuelistGetInfoTool: ToolDefinition<typeof cuelistInfoInputSchema> = {
   name: 'eos_cuelist_get_info',
   config: {

--- a/src/tools/cues/fire.ts
+++ b/src/tools/cues/fire.ts
@@ -23,6 +23,15 @@ const fireInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_cue_fire
+ * @summary Declenchement de cue
+ * @description Declenche immediatement une cue specifique dans une liste donnee.
+ * @arguments Voir docs/tools.md#eos-cue-fire pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-cue-fire pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-cue-fire pour un exemple OSC.
+ */
 export const eosCueFireTool: ToolDefinition<typeof fireInputSchema> = {
   name: 'eos_cue_fire',
   config: {

--- a/src/tools/cues/get_active_cue.ts
+++ b/src/tools/cues/get_active_cue.ts
@@ -23,6 +23,15 @@ function formatActiveText(identifier: CueIdentifier, progress: number | null): s
   return `Cue active ${formatCueDescription(identifier)} (${progressText})`;
 }
 
+/**
+ * @tool eos_get_active_cue
+ * @summary Cue active
+ * @description Recupere la cue actuellement en lecture sur la liste specifiee (ou principale).
+ * @arguments Voir docs/tools.md#eos-get-active-cue pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-get-active-cue pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-get-active-cue pour un exemple OSC.
+ */
 export const eosGetActiveCueTool: ToolDefinition<typeof getActiveCueInputSchema> = {
   name: 'eos_get_active_cue',
   config: {

--- a/src/tools/cues/get_info.ts
+++ b/src/tools/cues/get_info.ts
@@ -30,6 +30,15 @@ function formatCueInfoText(details: CueDetails): string {
   return `Cue ${formatCueDescription(details.identifier)} ${label} (Up ${up} / Down ${down})`;
 }
 
+/**
+ * @tool eos_cue_get_info
+ * @summary Informations de cue
+ * @description Recupere les informations detaillees d'une cue (timings, flags, notes...).
+ * @arguments Voir docs/tools.md#eos-cue-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-cue-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-cue-get-info pour un exemple OSC.
+ */
 export const eosCueGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
   name: 'eos_cue_get_info',
   config: {

--- a/src/tools/cues/get_pending_cue.ts
+++ b/src/tools/cues/get_pending_cue.ts
@@ -17,6 +17,15 @@ const getPendingCueInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_get_pending_cue
+ * @summary Cue en attente
+ * @description Recupere la prochaine cue en attente sur la liste specifiee (ou principale).
+ * @arguments Voir docs/tools.md#eos-get-pending-cue pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-get-pending-cue pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-get-pending-cue pour un exemple OSC.
+ */
 export const eosGetPendingCueTool: ToolDefinition<typeof getPendingCueInputSchema> = {
   name: 'eos_get_pending_cue',
   config: {

--- a/src/tools/cues/go.ts
+++ b/src/tools/cues/go.ts
@@ -22,6 +22,15 @@ const goInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_cue_go
+ * @summary GO sur liste de cues
+ * @description Declenche un GO sur la liste de cues cible, optionnellement vers une cue precise.
+ * @arguments Voir docs/tools.md#eos-cue-go pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-cue-go pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-cue-go pour un exemple OSC.
+ */
 export const eosCueGoTool: ToolDefinition<typeof goInputSchema> = {
   name: 'eos_cue_go',
   config: {

--- a/src/tools/cues/list_all.ts
+++ b/src/tools/cues/list_all.ts
@@ -17,6 +17,15 @@ const listAllInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_cue_list_all
+ * @summary Liste des cues
+ * @description Recupere toutes les cues d'une liste avec leurs labels.
+ * @arguments Voir docs/tools.md#eos-cue-list-all pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-cue-list-all pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-cue-list-all pour un exemple OSC.
+ */
 export const eosCueListAllTool: ToolDefinition<typeof listAllInputSchema> = {
   name: 'eos_cue_list_all',
   config: {

--- a/src/tools/cues/select.ts
+++ b/src/tools/cues/select.ts
@@ -22,6 +22,15 @@ const selectInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_cue_select
+ * @summary Selection de cue
+ * @description Selectionne une cue dans la liste sans la declencher.
+ * @arguments Voir docs/tools.md#eos-cue-select pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-cue-select pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-cue-select pour un exemple OSC.
+ */
 export const eosCueSelectTool: ToolDefinition<typeof selectInputSchema> = {
   name: 'eos_cue_select',
   config: {

--- a/src/tools/cues/stop_back.ts
+++ b/src/tools/cues/stop_back.ts
@@ -19,6 +19,15 @@ const stopBackInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_cue_stop_back
+ * @summary Stop ou Back sur liste de cues
+ * @description Stoppe la lecture de la liste ou effectue un back selon l'option fournie.
+ * @arguments Voir docs/tools.md#eos-cue-stop-back pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-cue-stop-back pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-cue-stop-back pour un exemple OSC.
+ */
 export const eosCueStopBackTool: ToolDefinition<typeof stopBackInputSchema> = {
   name: 'eos_cue_stop_back',
   config: {

--- a/src/tools/curves/index.ts
+++ b/src/tools/curves/index.ts
@@ -344,6 +344,15 @@ function buildCurveInfoResult(
   } as ToolExecutionResult;
 }
 
+/**
+ * @tool eos_curve_select
+ * @summary Selection de courbe
+ * @description Selectionne une courbe en envoyant son numero a la console.
+ * @arguments Voir docs/tools.md#eos-curve-select pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-curve-select pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-curve-select pour un exemple OSC.
+ */
 export const eosCurveSelectTool: ToolDefinition<typeof selectInputSchema> = {
   name: 'eos_curve_select',
   config: {
@@ -369,6 +378,15 @@ export const eosCurveSelectTool: ToolDefinition<typeof selectInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_curve_get_info
+ * @summary Lecture des informations de courbe
+ * @description Recupere les informations d'une courbe, incluant label et points.
+ * @arguments Voir docs/tools.md#eos-curve-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-curve-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-curve-get-info pour un exemple OSC.
+ */
 export const eosCurveGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
   name: 'eos_curve_get_info',
   config: {

--- a/src/tools/diagnostics/index.ts
+++ b/src/tools/diagnostics/index.ts
@@ -73,6 +73,15 @@ const formatDiagnostics = (diagnostics: OscDiagnostics): string => {
   return lines.join('\n');
 };
 
+/**
+ * @tool eos_enable_logging
+ * @summary Basculer le logging OSC
+ * @description Active ou desactive la journalisation des messages OSC entrants et sortants.
+ * @arguments Voir docs/tools.md#eos-enable-logging pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-enable-logging pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-enable-logging pour un exemple OSC.
+ */
 export const eosEnableLoggingTool: ToolDefinition<typeof loggingInputSchema> = {
   name: 'eos_enable_logging',
   config: {
@@ -102,6 +111,15 @@ export const eosEnableLoggingTool: ToolDefinition<typeof loggingInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_get_diagnostics
+ * @summary Diagnostics OSC
+ * @description Recupere les informations de diagnostic du service OSC.
+ * @arguments Voir docs/tools.md#eos-get-diagnostics pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-get-diagnostics pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-get-diagnostics pour un exemple OSC.
+ */
 export const eosGetDiagnosticsTool: ToolDefinition<typeof emptyInputSchema> = {
   name: 'eos_get_diagnostics',
   config: {

--- a/src/tools/directSelects/index.ts
+++ b/src/tools/directSelects/index.ts
@@ -208,6 +208,15 @@ const pressSchema = z.object(pressInputSchema).strict();
 
 const pageSchema = z.object(pageInputSchema).strict();
 
+/**
+ * @tool eos_direct_select_bank_create
+ * @summary Creation de bank de direct selects
+ * @description Cree un bank de direct selects OSC avec configuration de cible et pagination.
+ * @arguments Voir docs/tools.md#eos-direct-select-bank-create pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-direct-select-bank-create pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-direct-select-bank-create pour un exemple OSC.
+ */
 export const eosDirectSelectBankCreateTool: ToolDefinition<typeof bankCreateInputSchema> = {
   name: 'eos_direct_select_bank_create',
   config: {
@@ -276,6 +285,15 @@ export const eosDirectSelectBankCreateTool: ToolDefinition<typeof bankCreateInpu
   }
 };
 
+/**
+ * @tool eos_direct_select_press
+ * @summary Appui de direct select
+ * @description Simule un appui ou relachement sur un bouton de direct select.
+ * @arguments Voir docs/tools.md#eos-direct-select-press pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-direct-select-press pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-direct-select-press pour un exemple OSC.
+ */
 export const eosDirectSelectPressTool: ToolDefinition<typeof pressInputSchema> = {
   name: 'eos_direct_select_press',
   config: {
@@ -319,6 +337,15 @@ export const eosDirectSelectPressTool: ToolDefinition<typeof pressInputSchema> =
   }
 };
 
+/**
+ * @tool eos_direct_select_page
+ * @summary Navigation de direct select
+ * @description Change la page active dans un bank de direct selects.
+ * @arguments Voir docs/tools.md#eos-direct-select-page pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-direct-select-page pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-direct-select-page pour un exemple OSC.
+ */
 export const eosDirectSelectPageTool: ToolDefinition<typeof pageInputSchema> = {
   name: 'eos_direct_select_page',
   config: {

--- a/src/tools/dmx/index.ts
+++ b/src/tools/dmx/index.ts
@@ -174,6 +174,15 @@ const addressSetDmxInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_address_select
+ * @summary Selection d'adresse DMX
+ * @description Selectionne une adresse DMX specifique sur la console.
+ * @arguments Voir docs/tools.md#eos-address-select pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-address-select pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-address-select pour un exemple OSC.
+ */
 export const eosAddressSelectTool: ToolDefinition<typeof addressSelectInputSchema> = {
   name: 'eos_address_select',
   config: {
@@ -207,6 +216,15 @@ export const eosAddressSelectTool: ToolDefinition<typeof addressSelectInputSchem
   }
 };
 
+/**
+ * @tool eos_address_set_level
+ * @summary Reglage de niveau d'adresse DMX
+ * @description Ajuste le niveau (0-100) pour une adresse DMX donnee.
+ * @arguments Voir docs/tools.md#eos-address-set-level pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-address-set-level pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-address-set-level pour un exemple OSC.
+ */
 export const eosAddressSetLevelTool: ToolDefinition<typeof addressSetLevelInputSchema> = {
   name: 'eos_address_set_level',
   config: {
@@ -242,6 +260,15 @@ export const eosAddressSetLevelTool: ToolDefinition<typeof addressSetLevelInputS
   }
 };
 
+/**
+ * @tool eos_address_set_dmx
+ * @summary Reglage DMX brut
+ * @description Fixe une valeur DMX brute (0-255) pour une adresse DMX.
+ * @arguments Voir docs/tools.md#eos-address-set-dmx pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-address-set-dmx pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-address-set-dmx pour un exemple OSC.
+ */
 export const eosAddressSetDmxTool: ToolDefinition<typeof addressSetDmxInputSchema> = {
   name: 'eos_address_set_dmx',
   config: {

--- a/src/tools/effects/index.ts
+++ b/src/tools/effects/index.ts
@@ -521,6 +521,15 @@ function buildEffectInfoResult(
   } as ToolExecutionResult;
 }
 
+/**
+ * @tool eos_effect_select
+ * @summary Selection d'effet
+ * @description Selectionne un effet sans le lancer.
+ * @arguments Voir docs/tools.md#eos-effect-select pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-effect-select pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-effect-select pour un exemple OSC.
+ */
 export const eosEffectSelectTool: ToolDefinition<typeof selectInputSchema> = {
   name: 'eos_effect_select',
   config: {
@@ -560,6 +569,15 @@ export const eosEffectSelectTool: ToolDefinition<typeof selectInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_effect_stop
+ * @summary Arret d'effet
+ * @description Stoppe un effet actif sur la selection.
+ * @arguments Voir docs/tools.md#eos-effect-stop pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-effect-stop pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-effect-stop pour un exemple OSC.
+ */
 export const eosEffectStopTool: ToolDefinition<typeof stopInputSchema> = {
   name: 'eos_effect_stop',
   config: {
@@ -604,6 +622,15 @@ export const eosEffectStopTool: ToolDefinition<typeof stopInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_effect_get_info
+ * @summary Informations d'effet
+ * @description Recupere les informations detaillees d'un effet.
+ * @arguments Voir docs/tools.md#eos-effect-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-effect-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-effect-get-info pour un exemple OSC.
+ */
 export const eosEffectGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
   name: 'eos_effect_get_info',
   config: {

--- a/src/tools/faders/index.ts
+++ b/src/tools/faders/index.ts
@@ -189,6 +189,15 @@ function formatPercent(level: number): string {
   return Number.isInteger(percent) ? `${percent}%` : `${percent.toFixed(1)}%`;
 }
 
+/**
+ * @tool eos_fader_bank_create
+ * @summary Creation de bank de faders
+ * @description Cree un bank de faders OSC avec pagination optionnelle.
+ * @arguments Voir docs/tools.md#eos-fader-bank-create pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-fader-bank-create pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-fader-bank-create pour un exemple OSC.
+ */
 export const eosFaderBankCreateTool: ToolDefinition<typeof bankCreateInputSchema> = {
   name: 'eos_fader_bank_create',
   config: {
@@ -233,6 +242,15 @@ export const eosFaderBankCreateTool: ToolDefinition<typeof bankCreateInputSchema
   }
 };
 
+/**
+ * @tool eos_fader_set_level
+ * @summary Reglage de niveau de fader
+ * @description Definit le niveau (0-1 ou 0-100%) du fader cible.
+ * @arguments Voir docs/tools.md#eos-fader-set-level pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-fader-set-level pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-fader-set-level pour un exemple OSC.
+ */
 export const eosFaderSetLevelTool: ToolDefinition<typeof setLevelInputSchema> = {
   name: 'eos_fader_set_level',
   config: {
@@ -268,6 +286,15 @@ export const eosFaderSetLevelTool: ToolDefinition<typeof setLevelInputSchema> = 
   }
 };
 
+/**
+ * @tool eos_fader_load
+ * @summary Chargement de fader
+ * @description Charge le contenu courant sur le fader specifie.
+ * @arguments Voir docs/tools.md#eos-fader-load pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-fader-load pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-fader-load pour un exemple OSC.
+ */
 export const eosFaderLoadTool: ToolDefinition<typeof loadInputSchema> = {
   name: 'eos_fader_load',
   config: {
@@ -301,6 +328,15 @@ export const eosFaderLoadTool: ToolDefinition<typeof loadInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_fader_unload
+ * @summary Dechargement de fader
+ * @description Decharge le contenu du fader specifie.
+ * @arguments Voir docs/tools.md#eos-fader-unload pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-fader-unload pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-fader-unload pour un exemple OSC.
+ */
 export const eosFaderUnloadTool: ToolDefinition<typeof loadInputSchema> = {
   name: 'eos_fader_unload',
   config: {
@@ -334,6 +370,15 @@ export const eosFaderUnloadTool: ToolDefinition<typeof loadInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_fader_page
+ * @summary Navigation de bank de faders
+ * @description Change de page dans le bank en ajoutant le delta specifie.
+ * @arguments Voir docs/tools.md#eos-fader-page pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-fader-page pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-fader-page pour un exemple OSC.
+ */
 export const eosFaderPageTool: ToolDefinition<typeof pageInputSchema> = {
   name: 'eos_fader_page',
   config: {

--- a/src/tools/fpe/index.ts
+++ b/src/tools/fpe/index.ts
@@ -661,6 +661,15 @@ function extractTargetOptions(options: { targetAddress?: string; targetPort?: nu
   return target;
 }
 
+/**
+ * @tool eos_fpe_get_set_count
+ * @summary Compter les sets FPE
+ * @description Recupere le nombre total de sets Focus Palette Encoder.
+ * @arguments Voir docs/tools.md#eos-fpe-get-set-count pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-fpe-get-set-count pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-fpe-get-set-count pour un exemple OSC.
+ */
 export const eosFpeGetSetCountTool: ToolDefinition<typeof getSetCountInputSchema> = {
   name: 'eos_fpe_get_set_count',
   config: {
@@ -683,6 +692,15 @@ export const eosFpeGetSetCountTool: ToolDefinition<typeof getSetCountInputSchema
   }
 };
 
+/**
+ * @tool eos_fpe_get_set_info
+ * @summary Informations set FPE
+ * @description Recupere les informations detaillees pour un set Focus Palette Encoder.
+ * @arguments Voir docs/tools.md#eos-fpe-get-set-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-fpe-get-set-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-fpe-get-set-info pour un exemple OSC.
+ */
 export const eosFpeGetSetInfoTool: ToolDefinition<typeof getSetInfoInputSchema> = {
   name: 'eos_fpe_get_set_info',
   config: {
@@ -707,6 +725,15 @@ export const eosFpeGetSetInfoTool: ToolDefinition<typeof getSetInfoInputSchema> 
   }
 };
 
+/**
+ * @tool eos_fpe_get_point_info
+ * @summary Informations point FPE
+ * @description Recupere les informations detaillees pour un point Focus Palette Encoder.
+ * @arguments Voir docs/tools.md#eos-fpe-get-point-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-fpe-get-point-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-fpe-get-point-info pour un exemple OSC.
+ */
 export const eosFpeGetPointInfoTool: ToolDefinition<typeof getPointInfoInputSchema> = {
   name: 'eos_fpe_get_point_info',
   config: {

--- a/src/tools/groups/index.ts
+++ b/src/tools/groups/index.ts
@@ -217,6 +217,15 @@ const listAllInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_group_select
+ * @summary Selection de groupe
+ * @description Selectionne un groupe sur la console Eos.
+ * @arguments Voir docs/tools.md#eos-group-select pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-group-select pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-group-select pour un exemple OSC.
+ */
 export const eosGroupSelectTool: ToolDefinition<typeof selectInputSchema> = {
   name: 'eos_group_select',
   config: {
@@ -253,6 +262,15 @@ export const eosGroupSelectTool: ToolDefinition<typeof selectInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_group_set_level
+ * @summary Reglage de niveau de groupe
+ * @description Ajuste le niveau d'un groupe sur une echelle de 0 a 100.
+ * @arguments Voir docs/tools.md#eos-group-set-level pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-group-set-level pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-group-set-level pour un exemple OSC.
+ */
 export const eosGroupSetLevelTool: ToolDefinition<typeof setLevelInputSchema> = {
   name: 'eos_group_set_level',
   config: {
@@ -297,6 +315,15 @@ export const eosGroupSetLevelTool: ToolDefinition<typeof setLevelInputSchema> = 
   }
 };
 
+/**
+ * @tool eos_group_get_info
+ * @summary Informations sur un groupe
+ * @description Recupere les informations detaillees pour un groupe donne.
+ * @arguments Voir docs/tools.md#eos-group-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-group-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-group-get-info pour un exemple OSC.
+ */
 export const eosGroupGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
   name: 'eos_group_get_info',
   config: {
@@ -355,6 +382,15 @@ export const eosGroupGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_group_list_all
+ * @summary Liste des groupes
+ * @description Recupere la liste des groupes disponibles avec leurs membres.
+ * @arguments Voir docs/tools.md#eos-group-list-all pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-group-list-all pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-group-list-all pour un exemple OSC.
+ */
 export const eosGroupListAllTool: ToolDefinition<typeof listAllInputSchema> = {
   name: 'eos_group_list_all',
   config: {

--- a/src/tools/keys/index.ts
+++ b/src/tools/keys/index.ts
@@ -183,6 +183,15 @@ function buildSoftkeyLabelsResult(
   });
 }
 
+/**
+ * @tool eos_key_press
+ * @summary Appui sur touche
+ * @description Simule l'appui ou le relachement d'une touche du clavier EOS.
+ * @arguments Voir docs/tools.md#eos-key-press pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-key-press pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-key-press pour un exemple OSC.
+ */
 export const eosKeyPressTool: ToolDefinition<typeof keyPressInputSchema> = {
   name: 'eos_key_press',
   config: {
@@ -222,6 +231,15 @@ export const eosKeyPressTool: ToolDefinition<typeof keyPressInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_softkey_press
+ * @summary Appui sur softkey
+ * @description Simule l'appui ou le relachement d'une softkey (1-12).
+ * @arguments Voir docs/tools.md#eos-softkey-press pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-softkey-press pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-softkey-press pour un exemple OSC.
+ */
 export const eosSoftkeyPressTool: ToolDefinition<typeof softkeyPressInputSchema> = {
   name: 'eos_softkey_press',
   config: {
@@ -259,6 +277,15 @@ export const eosSoftkeyPressTool: ToolDefinition<typeof softkeyPressInputSchema>
   }
 };
 
+/**
+ * @tool eos_get_softkey_labels
+ * @summary Libelles des softkeys
+ * @description Recupere les libelles affiches des softkeys 1-12.
+ * @arguments Voir docs/tools.md#eos-get-softkey-labels pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-get-softkey-labels pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-get-softkey-labels pour un exemple OSC.
+ */
 export const eosGetSoftkeyLabelsTool: ToolDefinition<typeof softkeyLabelsInputSchema> = {
   name: 'eos_get_softkey_labels',
   config: {

--- a/src/tools/macros/index.ts
+++ b/src/tools/macros/index.ts
@@ -333,6 +333,15 @@ function buildMacroInfoResult(
   } as ToolExecutionResult;
 }
 
+/**
+ * @tool eos_macro_fire
+ * @summary Declenchement de macro
+ * @description Declenche une macro en envoyant son numero a la console.
+ * @arguments Voir docs/tools.md#eos-macro-fire pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-macro-fire pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-macro-fire pour un exemple OSC.
+ */
 export const eosMacroFireTool: ToolDefinition<typeof fireInputSchema> = {
   name: 'eos_macro_fire',
   config: {
@@ -372,6 +381,15 @@ export const eosMacroFireTool: ToolDefinition<typeof fireInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_macro_select
+ * @summary Selection de macro
+ * @description Selectionne une macro sans l'executer.
+ * @arguments Voir docs/tools.md#eos-macro-select pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-macro-select pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-macro-select pour un exemple OSC.
+ */
 export const eosMacroSelectTool: ToolDefinition<typeof selectInputSchema> = {
   name: 'eos_macro_select',
   config: {
@@ -411,6 +429,15 @@ export const eosMacroSelectTool: ToolDefinition<typeof selectInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_macro_get_info
+ * @summary Informations de macro
+ * @description Recupere le libelle et le script d'une macro.
+ * @arguments Voir docs/tools.md#eos-macro-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-macro-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-macro-get-info pour un exemple OSC.
+ */
 export const eosMacroGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
   name: 'eos_macro_get_info',
   config: {

--- a/src/tools/magicSheets/index.ts
+++ b/src/tools/magicSheets/index.ts
@@ -293,6 +293,15 @@ function extractRole(extra: unknown): string | null {
   return null;
 }
 
+/**
+ * @tool eos_magic_sheet_open
+ * @summary Ouverture de magic sheet
+ * @description Ouvre un magic sheet specifique sur la console.
+ * @arguments Voir docs/tools.md#eos-magic-sheet-open pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-magic-sheet-open pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-magic-sheet-open pour un exemple OSC.
+ */
 export const eosMagicSheetOpenTool: ToolDefinition<typeof openInputSchema> = {
   name: 'eos_magic_sheet_open',
   config: {
@@ -337,6 +346,15 @@ export const eosMagicSheetOpenTool: ToolDefinition<typeof openInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_magic_sheet_send_string
+ * @summary Envoi de commande via magic sheet
+ * @description Envoie une commande OSC via la fonctionnalite Magic Sheet.
+ * @arguments Voir docs/tools.md#eos-magic-sheet-send-string pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-magic-sheet-send-string pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-magic-sheet-send-string pour un exemple OSC.
+ */
 export const eosMagicSheetSendStringTool: ToolDefinition<typeof sendStringInputSchema> = {
   name: 'eos_magic_sheet_send_string',
   config: {
@@ -392,6 +410,15 @@ export const eosMagicSheetSendStringTool: ToolDefinition<typeof sendStringInputS
   }
 };
 
+/**
+ * @tool eos_magic_sheet_get_info
+ * @summary Informations de magic sheet
+ * @description Recupere le label et l'UID d'un magic sheet.
+ * @arguments Voir docs/tools.md#eos-magic-sheet-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-magic-sheet-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-magic-sheet-get-info pour un exemple OSC.
+ */
 export const eosMagicSheetGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
   name: 'eos_magic_sheet_get_info',
   config: {

--- a/src/tools/palettes/index.ts
+++ b/src/tools/palettes/index.ts
@@ -381,6 +381,15 @@ function getInfoMappingForType(type: PaletteType): string {
   }
 }
 
+/**
+ * @tool eos_intensity_palette_fire
+ * @summary eos_intensity_palette_fire
+ * @description Declenche une palette d'intensite sur la console Eos.
+ * @arguments Voir docs/tools.md#eos-intensity-palette-fire pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-intensity-palette-fire pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-intensity-palette-fire pour un exemple OSC.
+ */
 export const eosIntensityPaletteFireTool = createPaletteFireTool({
   type: 'ip',
   name: 'eos_intensity_palette_fire',
@@ -389,6 +398,15 @@ export const eosIntensityPaletteFireTool = createPaletteFireTool({
   mapping: oscMappings.palettes.intensity.fire
 });
 
+/**
+ * @tool eos_focus_palette_fire
+ * @summary eos_focus_palette_fire
+ * @description Declenche une palette de focus sur la console Eos.
+ * @arguments Voir docs/tools.md#eos-focus-palette-fire pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-focus-palette-fire pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-focus-palette-fire pour un exemple OSC.
+ */
 export const eosFocusPaletteFireTool = createPaletteFireTool({
   type: 'fp',
   name: 'eos_focus_palette_fire',
@@ -397,6 +415,15 @@ export const eosFocusPaletteFireTool = createPaletteFireTool({
   mapping: oscMappings.palettes.focus.fire
 });
 
+/**
+ * @tool eos_color_palette_fire
+ * @summary eos_color_palette_fire
+ * @description Declenche une palette de couleur sur la console Eos.
+ * @arguments Voir docs/tools.md#eos-color-palette-fire pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-color-palette-fire pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-color-palette-fire pour un exemple OSC.
+ */
 export const eosColorPaletteFireTool = createPaletteFireTool({
   type: 'cp',
   name: 'eos_color_palette_fire',
@@ -405,6 +432,15 @@ export const eosColorPaletteFireTool = createPaletteFireTool({
   mapping: oscMappings.palettes.color.fire
 });
 
+/**
+ * @tool eos_beam_palette_fire
+ * @summary eos_beam_palette_fire
+ * @description Declenche une palette de beam sur la console Eos.
+ * @arguments Voir docs/tools.md#eos-beam-palette-fire pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-beam-palette-fire pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-beam-palette-fire pour un exemple OSC.
+ */
 export const eosBeamPaletteFireTool = createPaletteFireTool({
   type: 'bp',
   name: 'eos_beam_palette_fire',
@@ -413,6 +449,15 @@ export const eosBeamPaletteFireTool = createPaletteFireTool({
   mapping: oscMappings.palettes.beam.fire
 });
 
+/**
+ * @tool eos_palette_get_info
+ * @summary Informations de palette
+ * @description Recupere les informations detaillees pour une palette donnee.
+ * @arguments Voir docs/tools.md#eos-palette-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-palette-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-palette-get-info pour un exemple OSC.
+ */
 export const eosPaletteGetInfoTool: ToolDefinition<typeof paletteGetInfoInputSchema> = {
   name: 'eos_palette_get_info',
   config: {

--- a/src/tools/parameters/index.ts
+++ b/src/tools/parameters/index.ts
@@ -348,6 +348,15 @@ const getActiveWheelsSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_wheel_tick
+ * @summary Rotation d'encodeur
+ * @description Simule une rotation d'encodeur pour un parametre donne.
+ * @arguments Voir docs/tools.md#eos-wheel-tick pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-wheel-tick pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-wheel-tick pour un exemple OSC.
+ */
 export const eosWheelTickTool: ToolDefinition<typeof wheelTickInputSchema> = {
   name: 'eos_wheel_tick',
   config: {
@@ -388,6 +397,15 @@ export const eosWheelTickTool: ToolDefinition<typeof wheelTickInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_switch_continuous
+ * @summary Mouvement continu
+ * @description Active un mouvement continu d'encodeur sur un parametre.
+ * @arguments Voir docs/tools.md#eos-switch-continuous pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-switch-continuous pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-switch-continuous pour un exemple OSC.
+ */
 export const eosWheelSwitchContinuousTool: ToolDefinition<typeof wheelRateInputSchema> = {
   name: 'eos_switch_continuous',
   config: {
@@ -425,6 +443,15 @@ export const eosWheelSwitchContinuousTool: ToolDefinition<typeof wheelRateInputS
   }
 };
 
+/**
+ * @tool eos_set_color_hs
+ * @summary Couleur HS
+ * @description Definit une couleur via Hue/Saturation.
+ * @arguments Voir docs/tools.md#eos-set-color-hs pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-set-color-hs pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-set-color-hs pour un exemple OSC.
+ */
 export const eosSetColorHsTool: ToolDefinition<typeof colorHsInputSchema> = {
   name: 'eos_set_color_hs',
   config: {
@@ -460,6 +487,15 @@ export const eosSetColorHsTool: ToolDefinition<typeof colorHsInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_set_color_rgb
+ * @summary Couleur RGB
+ * @description Definit une couleur via valeurs RGB (0-1).
+ * @arguments Voir docs/tools.md#eos-set-color-rgb pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-set-color-rgb pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-set-color-rgb pour un exemple OSC.
+ */
 export const eosSetColorRgbTool: ToolDefinition<typeof colorRgbInputSchema> = {
   name: 'eos_set_color_rgb',
   config: {
@@ -495,6 +531,15 @@ export const eosSetColorRgbTool: ToolDefinition<typeof colorRgbInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_set_pantilt_xy
+ * @summary Position Pan/Tilt XY
+ * @description Definit une position normalisee sur le plan XY (0-1).
+ * @arguments Voir docs/tools.md#eos-set-pantilt-xy pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-set-pantilt-xy pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-set-pantilt-xy pour un exemple OSC.
+ */
 export const eosSetPanTiltXYTool: ToolDefinition<typeof panTiltInputSchema> = {
   name: 'eos_set_pantilt_xy',
   config: {
@@ -529,6 +574,15 @@ export const eosSetPanTiltXYTool: ToolDefinition<typeof panTiltInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_set_xyz_position
+ * @summary Position XYZ
+ * @description Definit une position XYZ en metres.
+ * @arguments Voir docs/tools.md#eos-set-xyz-position pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-set-xyz-position pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-set-xyz-position pour un exemple OSC.
+ */
 export const eosSetXYZPositionTool: ToolDefinition<typeof xyzInputSchema> = {
   name: 'eos_set_xyz_position',
   config: {
@@ -564,6 +618,15 @@ export const eosSetXYZPositionTool: ToolDefinition<typeof xyzInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_get_active_wheels
+ * @summary Encodeurs actifs
+ * @description Recupere et normalise la liste des encodeurs actifs.
+ * @arguments Voir docs/tools.md#eos-get-active-wheels pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-get-active-wheels pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-get-active-wheels pour un exemple OSC.
+ */
 export const eosGetActiveWheelsTool: ToolDefinition<typeof getActiveWheelsSchema> = {
   name: 'eos_get_active_wheels',
   config: {

--- a/src/tools/patch/index.ts
+++ b/src/tools/patch/index.ts
@@ -666,6 +666,15 @@ const augment3dInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_patch_get_channel_info
+ * @summary Informations de patch
+ * @description Recupere les informations de patch pour un canal donne.
+ * @arguments Voir docs/tools.md#eos-patch-get-channel-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-patch-get-channel-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-patch-get-channel-info pour un exemple OSC.
+ */
 export const eosPatchGetChannelInfoTool: ToolDefinition<typeof channelInfoInputSchema> = {
   name: 'eos_patch_get_channel_info',
   config: {
@@ -715,6 +724,15 @@ export const eosPatchGetChannelInfoTool: ToolDefinition<typeof channelInfoInputS
   }
 };
 
+/**
+ * @tool eos_patch_get_augment3d_position
+ * @summary Position Augment3d
+ * @description Recupere la position Augment3d d'une partie de canal.
+ * @arguments Voir docs/tools.md#eos-patch-get-augment3d-position pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-patch-get-augment3d-position pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-patch-get-augment3d-position pour un exemple OSC.
+ */
 export const eosPatchGetAugment3dPositionTool: ToolDefinition<typeof augment3dInputSchema> = {
   name: 'eos_patch_get_augment3d_position',
   config: {
@@ -764,6 +782,15 @@ export const eosPatchGetAugment3dPositionTool: ToolDefinition<typeof augment3dIn
   }
 };
 
+/**
+ * @tool eos_patch_get_augment3d_beam
+ * @summary Faisceau Augment3d
+ * @description Recupere les informations de faisceau Augment3d pour une partie de canal.
+ * @arguments Voir docs/tools.md#eos-patch-get-augment3d-beam pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-patch-get-augment3d-beam pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-patch-get-augment3d-beam pour un exemple OSC.
+ */
 export const eosPatchGetAugment3dBeamTool: ToolDefinition<typeof augment3dInputSchema> = {
   name: 'eos_patch_get_augment3d_beam',
   config: {

--- a/src/tools/ping.ts
+++ b/src/tools/ping.ts
@@ -13,6 +13,15 @@ const loggingMiddleware: ToolMiddleware = async (context, next) => {
   return next();
 };
 
+/**
+ * @tool ping
+ * @summary Ping tool
+ * @description Retourne un message de confirmation.
+ * @arguments Voir docs/tools.md#ping pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#ping pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#ping pour un exemple OSC.
+ */
 export const pingTool: ToolDefinition<typeof inputSchema> = {
   name: 'ping',
   config: {

--- a/src/tools/pixelMaps/index.ts
+++ b/src/tools/pixelMaps/index.ts
@@ -647,6 +647,15 @@ function normalisePixelMapInfo(raw: unknown, fallbackNumber: number): PixelMapIn
   return info;
 }
 
+/**
+ * @tool eos_pixmap_select
+ * @summary Selection de pixel map
+ * @description Selectionne un pixel map sur la console Eos.
+ * @arguments Voir docs/tools.md#eos-pixmap-select pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-pixmap-select pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-pixmap-select pour un exemple OSC.
+ */
 export const eosPixmapSelectTool: ToolDefinition<typeof selectInputSchema> = {
   name: 'eos_pixmap_select',
   config: {
@@ -683,6 +692,15 @@ export const eosPixmapSelectTool: ToolDefinition<typeof selectInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_pixmap_get_info
+ * @summary Informations sur un pixel map
+ * @description Recupere les informations detaillees pour un pixel map donne.
+ * @arguments Voir docs/tools.md#eos-pixmap-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-pixmap-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-pixmap-get-info pour un exemple OSC.
+ */
 export const eosPixmapGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
   name: 'eos_pixmap_get_info',
   config: {

--- a/src/tools/presets/index.ts
+++ b/src/tools/presets/index.ts
@@ -456,6 +456,15 @@ function formatPresetDescription(info: PresetInfo): string {
   return `Preset ${info.preset_number} ${label} (${mode}, ${lockState}, canaux: ${channels}, ${effectsSummary})`;
 }
 
+/**
+ * @tool eos_preset_fire
+ * @summary Declenchement de preset
+ * @description Declenche un preset sur la console Eos.
+ * @arguments Voir docs/tools.md#eos-preset-fire pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-preset-fire pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-preset-fire pour un exemple OSC.
+ */
 export const eosPresetFireTool: ToolDefinition<typeof presetFireInputSchema> = {
   name: 'eos_preset_fire',
   config: {
@@ -485,6 +494,15 @@ export const eosPresetFireTool: ToolDefinition<typeof presetFireInputSchema> = {
   }
 } satisfies ToolDefinition<typeof presetFireInputSchema>;
 
+/**
+ * @tool eos_preset_select
+ * @summary Selection de preset
+ * @description Selectionne un preset sur la console Eos.
+ * @arguments Voir docs/tools.md#eos-preset-select pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-preset-select pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-preset-select pour un exemple OSC.
+ */
 export const eosPresetSelectTool: ToolDefinition<typeof presetFireInputSchema> = {
   name: 'eos_preset_select',
   config: {
@@ -514,6 +532,15 @@ export const eosPresetSelectTool: ToolDefinition<typeof presetFireInputSchema> =
   }
 } satisfies ToolDefinition<typeof presetFireInputSchema>;
 
+/**
+ * @tool eos_preset_get_info
+ * @summary Informations de preset
+ * @description Recupere les informations detaillees pour un preset donne.
+ * @arguments Voir docs/tools.md#eos-preset-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-preset-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-preset-get-info pour un exemple OSC.
+ */
 export const eosPresetGetInfoTool: ToolDefinition<typeof presetGetInfoInputSchema> = {
   name: 'eos_preset_get_info',
   config: {

--- a/src/tools/queries/index.ts
+++ b/src/tools/queries/index.ts
@@ -182,6 +182,15 @@ const listOutputSchema = {
   })
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_get_count
+ * @summary Compter les elements
+ * @description Recupere le nombre total d'elements pour un type donne.
+ * @arguments Voir docs/tools.md#eos-get-count pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-get-count pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-get-count pour un exemple OSC.
+ */
 export const eosGetCountTool: ToolDefinition<typeof countInputSchema> = {
   name: 'eos_get_count',
   config: {
@@ -225,6 +234,15 @@ export const eosGetCountTool: ToolDefinition<typeof countInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_get_list_all
+ * @summary Lister tous les elements
+ * @description Recupere la liste complete des elements pour un type donne.
+ * @arguments Voir docs/tools.md#eos-get-list-all pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-get-list-all pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-get-list-all pour un exemple OSC.
+ */
 export const eosGetListAllTool: ToolDefinition<typeof listInputSchema> = {
   name: 'eos_get_list_all',
   config: {

--- a/src/tools/session/index.ts
+++ b/src/tools/session/index.ts
@@ -24,6 +24,15 @@ const setCurrentUserInputSchema = {
   user: z.number().int().min(0, "L'identifiant utilisateur doit etre positif")
 };
 
+/**
+ * @tool session_set_current_user
+ * @summary Definir utilisateur courant
+ * @description Stocke en local le numero utilisateur EOS a utiliser par defaut.
+ * @arguments Voir docs/tools.md#session-set-current-user pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#session-set-current-user pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#session-set-current-user pour un exemple OSC.
+ */
 export const sessionSetCurrentUserTool: ToolDefinition<typeof setCurrentUserInputSchema> = {
   name: 'session_set_current_user',
   config: {
@@ -54,6 +63,15 @@ export const sessionSetCurrentUserTool: ToolDefinition<typeof setCurrentUserInpu
   }
 };
 
+/**
+ * @tool session_get_current_user
+ * @summary Utilisateur courant
+ * @description Renvoie le numero utilisateur EOS memorise localement.
+ * @arguments Voir docs/tools.md#session-get-current-user pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#session-get-current-user pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#session-get-current-user pour un exemple OSC.
+ */
 export const sessionGetCurrentUserTool: ToolDefinition = {
   name: 'session_get_current_user',
   config: {

--- a/src/tools/showControl/index.ts
+++ b/src/tools/showControl/index.ts
@@ -207,6 +207,15 @@ const setCueReceiveStringInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+/**
+ * @tool eos_get_show_name
+ * @summary Nom du show
+ * @description Recupere le nom du show actuellement charge sur la console.
+ * @arguments Voir docs/tools.md#eos-get-show-name pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-get-show-name pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-get-show-name pour un exemple OSC.
+ */
 export const eosGetShowNameTool: ToolDefinition<typeof getShowNameInputSchema> = {
   name: 'eos_get_show_name',
   config: {
@@ -255,6 +264,15 @@ export const eosGetShowNameTool: ToolDefinition<typeof getShowNameInputSchema> =
   }
 };
 
+/**
+ * @tool eos_get_live_blind_state
+ * @summary Etat Live/Blind
+ * @description Indique si la console est en mode Live ou Blind.
+ * @arguments Voir docs/tools.md#eos-get-live-blind-state pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-get-live-blind-state pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-get-live-blind-state pour un exemple OSC.
+ */
 export const eosGetLiveBlindStateTool: ToolDefinition<typeof getLiveBlindStateInputSchema> = {
   name: 'eos_get_live_blind_state',
   config: {
@@ -306,6 +324,15 @@ export const eosGetLiveBlindStateTool: ToolDefinition<typeof getLiveBlindStateIn
   }
 };
 
+/**
+ * @tool eos_toggle_staging_mode
+ * @summary Toggle Staging Mode
+ * @description Active ou desactive le mode Staging de la console.
+ * @arguments Voir docs/tools.md#eos-toggle-staging-mode pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-toggle-staging-mode pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-toggle-staging-mode pour un exemple OSC.
+ */
 export const eosToggleStagingModeTool: ToolDefinition<typeof targetOptionsSchema> = {
   name: 'eos_toggle_staging_mode',
   config: {
@@ -339,6 +366,15 @@ export const eosToggleStagingModeTool: ToolDefinition<typeof targetOptionsSchema
   }
 };
 
+/**
+ * @tool eos_set_cue_send_string
+ * @summary Format d'envoi des cues
+ * @description Configure le format d'envoi OSC des cues (placeholders %1-%5).
+ * @arguments Voir docs/tools.md#eos-set-cue-send-string pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-set-cue-send-string pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-set-cue-send-string pour un exemple OSC.
+ */
 export const eosSetCueSendStringTool: ToolDefinition<typeof setCueSendStringInputSchema> = {
   name: 'eos_set_cue_send_string',
   config: {
@@ -376,6 +412,15 @@ export const eosSetCueSendStringTool: ToolDefinition<typeof setCueSendStringInpu
   }
 };
 
+/**
+ * @tool eos_set_cue_receive_string
+ * @summary Format de reception des cues
+ * @description Configure le format de reception OSC des cues (placeholders %1-%2).
+ * @arguments Voir docs/tools.md#eos-set-cue-receive-string pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-set-cue-receive-string pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-set-cue-receive-string pour un exemple OSC.
+ */
 export const eosSetCueReceiveStringTool: ToolDefinition<typeof setCueReceiveStringInputSchema> = {
   name: 'eos_set_cue_receive_string',
   config: {

--- a/src/tools/snapshots/index.ts
+++ b/src/tools/snapshots/index.ts
@@ -280,6 +280,15 @@ function buildSnapshotInfoResult(
   } as ToolExecutionResult;
 }
 
+/**
+ * @tool eos_snapshot_recall
+ * @summary Rappel de snapshot
+ * @description Rappelle un snapshot en envoyant son numero a la console.
+ * @arguments Voir docs/tools.md#eos-snapshot-recall pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-snapshot-recall pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-snapshot-recall pour un exemple OSC.
+ */
 export const eosSnapshotRecallTool: ToolDefinition<typeof recallInputSchema> = {
   name: 'eos_snapshot_recall',
   config: {
@@ -306,6 +315,15 @@ export const eosSnapshotRecallTool: ToolDefinition<typeof recallInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_snapshot_get_info
+ * @summary Lecture des informations de snapshot
+ * @description Recupere les informations d'un snapshot, incluant label et UID.
+ * @arguments Voir docs/tools.md#eos-snapshot-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-snapshot-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-snapshot-get-info pour un exemple OSC.
+ */
 export const eosSnapshotGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
   name: 'eos_snapshot_get_info',
   config: {

--- a/src/tools/submasters/index.ts
+++ b/src/tools/submasters/index.ts
@@ -362,6 +362,15 @@ function normaliseSubmasterInfo(raw: unknown, fallbackNumber: number): Submaster
   };
 }
 
+/**
+ * @tool eos_submaster_set_level
+ * @summary Reglage de submaster
+ * @description Ajuste le niveau d'un submaster sur une echelle de 0.0 a 1.0.
+ * @arguments Voir docs/tools.md#eos-submaster-set-level pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-submaster-set-level pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-submaster-set-level pour un exemple OSC.
+ */
 export const eosSubmasterSetLevelTool: ToolDefinition<typeof setLevelInputSchema> = {
   name: 'eos_submaster_set_level',
   config: {
@@ -391,6 +400,15 @@ export const eosSubmasterSetLevelTool: ToolDefinition<typeof setLevelInputSchema
   }
 };
 
+/**
+ * @tool eos_submaster_bump
+ * @summary Commande de bump
+ * @description Active ou desactive le bump d'un submaster.
+ * @arguments Voir docs/tools.md#eos-submaster-bump pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-submaster-bump pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-submaster-bump pour un exemple OSC.
+ */
 export const eosSubmasterBumpTool: ToolDefinition<typeof bumpInputSchema> = {
   name: 'eos_submaster_bump',
   config: {
@@ -421,6 +439,15 @@ export const eosSubmasterBumpTool: ToolDefinition<typeof bumpInputSchema> = {
   }
 };
 
+/**
+ * @tool eos_submaster_get_info
+ * @summary Informations sur un submaster
+ * @description Recupere et normalise les informations d'un submaster.
+ * @arguments Voir docs/tools.md#eos-submaster-get-info pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-submaster-get-info pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-submaster-get-info pour un exemple OSC.
+ */
 export const eosSubmasterGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
   name: 'eos_submaster_get_info',
   config: {


### PR DESCRIPTION
## Summary
- add a TypeScript utility that introspects tool definitions, updates JSDoc blocks, and builds docs/tools.md
- generate the full MCP tool catalogue under docs/tools.md and wire npm scripts to keep it in sync
- extend the README with usage guidance for the new documentation and CLI/OSC examples

## Testing
- npm run docs:check

------
https://chatgpt.com/codex/tasks/task_e_68f639c646e4832a8b8ab96d9c8ee960