### PR TITLE
Implement cache with TTL for info/list tools

### DIFF
--- a/src/services/cache/__tests__/cache.test.ts
+++ b/src/services/cache/__tests__/cache.test.ts
@@ -1,0 +1,127 @@
+import {
+  createCacheKey,
+  createOscPrefixTag,
+  createResourceTag,
+  getResourceCache
+} from '../index';
+
+describe('ResourceCache', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    const cache = getResourceCache();
+    cache.clearAll();
+    cache.setDefaultTtl(1500);
+  });
+
+  afterEach(() => {
+    const cache = getResourceCache();
+    cache.clearAll();
+    cache.setDefaultTtl(1500);
+    cache.setResourceTtl('groups', null);
+    jest.useRealTimers();
+  });
+
+  it('cache les valeurs et met a jour les statistiques hits/misses', async () => {
+    const cache = getResourceCache();
+    const fetcher = jest.fn(async () => 'value');
+    const key = createCacheKey({ address: '/test', payload: {} });
+
+    const first = await cache.fetch({ resourceType: 'groups', key, fetcher });
+    const second = await cache.fetch({ resourceType: 'groups', key, fetcher });
+
+    expect(first).toBe('value');
+    expect(second).toBe('value');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    const stats = cache.getStats('groups');
+    expect(stats.misses).toBe(1);
+    expect(stats.hits).toBe(1);
+    expect(stats.entries).toBe(1);
+  });
+
+  it('expire les entrees apres la duree TTL configuree', async () => {
+    const cache = getResourceCache();
+    cache.setResourceTtl('groups', 100);
+    const key = createCacheKey({ address: '/ttl', payload: {} });
+    const fetcher = jest.fn(async () => Date.now());
+
+    const initial = await cache.fetch({ resourceType: 'groups', key, fetcher });
+    jest.advanceTimersByTime(200);
+    const refreshed = await cache.fetch({ resourceType: 'groups', key, fetcher });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(refreshed).not.toBe(initial);
+    const stats = cache.getStats('groups');
+    expect(stats.misses).toBe(2);
+    expect(stats.hits).toBe(0);
+  });
+
+  it('invalide les entrees lors de la reception de messages OSC avec prefixe', async () => {
+    const cache = getResourceCache();
+    const key = createCacheKey({ address: '/resource', payload: {} });
+    const fetcher = jest.fn(async () => 'initial');
+
+    await cache.fetch({
+      resourceType: 'groups',
+      key,
+      fetcher,
+      prefixTags: [createOscPrefixTag('/eos/out/group')]
+    });
+
+    await cache.fetch({
+      resourceType: 'groups',
+      key,
+      fetcher,
+      prefixTags: [createOscPrefixTag('/eos/out/group')]
+    });
+
+    cache.handleOscMessage({ address: '/eos/out/group/1', args: [] });
+
+    const newFetcher = jest.fn(async () => 'after');
+    const value = await cache.fetch({
+      resourceType: 'groups',
+      key,
+      fetcher: newFetcher,
+      prefixTags: [createOscPrefixTag('/eos/out/group')]
+    });
+
+    expect(newFetcher).toHaveBeenCalledTimes(1);
+    expect(value).toBe('after');
+
+    const stats = cache.getStats('groups');
+    expect(stats.misses).toBe(2);
+    expect(stats.hits).toBe(1);
+  });
+
+  it('notifie les changements de ressource et invalide les entrees concernees', async () => {
+    const cache = getResourceCache();
+    const key = createCacheKey({ address: '/resource', payload: { id: 5 } });
+    const fetcher = jest.fn(async () => 'snapshot');
+
+    await cache.fetch({
+      resourceType: 'groups',
+      key,
+      fetcher,
+      tags: [
+        createResourceTag('groups'),
+        createResourceTag('groups', '5')
+      ]
+    });
+
+    cache.notifyResourceChange('groups', '5');
+
+    const newFetcher = jest.fn(async () => 'updated');
+    const value = await cache.fetch({
+      resourceType: 'groups',
+      key,
+      fetcher: newFetcher,
+      tags: [
+        createResourceTag('groups'),
+        createResourceTag('groups', '5')
+      ]
+    });
+
+    expect(newFetcher).toHaveBeenCalledTimes(1);
+    expect(value).toBe('updated');
+  });
+});

--- a/src/services/cache/index.ts
+++ b/src/services/cache/index.ts
@@ -1,0 +1,357 @@
+import type { OscMessage } from '../osc/index.js';
+
+export type ResourceType =
+  | 'channels'
+  | 'patch'
+  | 'groups'
+  | 'palettes'
+  | 'presets'
+  | 'macros'
+  | 'snapshots'
+  | 'curves'
+  | 'effects'
+  | 'pixelMaps'
+  | 'magicSheets'
+  | 'submasters'
+  | 'cues'
+  | 'cuelists'
+  | 'queries';
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+  tags: string[];
+  prefixTags: string[];
+}
+
+interface CacheStats {
+  hits: number;
+  misses: number;
+}
+
+export interface FetchOptions<T> {
+  resourceType: ResourceType;
+  key: string;
+  fetcher: () => Promise<T>;
+  ttlMs?: number;
+  tags?: string[];
+  prefixTags?: string[];
+}
+
+export interface CacheStatsSnapshot extends CacheStats {
+  entries: number;
+}
+
+interface CacheKeyParts {
+  address: string;
+  payload?: Record<string, unknown>;
+  targetAddress?: string;
+  targetPort?: number;
+  extra?: unknown;
+}
+
+type EntryId = string;
+
+type ResourceCacheMap = Map<string, CacheEntry<unknown>>;
+
+function sanitise(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitise(item));
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => typeof v !== 'undefined')
+      .map(([key, val]) => [key, sanitise(val as unknown)]);
+
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of entries) {
+      result[key] = val;
+    }
+    return result;
+  }
+
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+
+  return `{${entries
+    .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`)
+    .join(',')}}`;
+}
+
+function getEntryId(resourceType: ResourceType, key: string): EntryId {
+  return `${resourceType}::${key}`;
+}
+
+function parseEntryId(entryId: EntryId): { resourceType: ResourceType; key: string } {
+  const [resourceType, key] = entryId.split('::');
+  return { resourceType: resourceType as ResourceType, key };
+}
+
+function extractPrefixKey(prefixTag: string): string {
+  return prefixTag.startsWith('osc-prefix:') ? prefixTag.slice('osc-prefix:'.length) : prefixTag;
+}
+
+export function createCacheKey(parts: CacheKeyParts): string {
+  const payload = sanitise(parts.payload ?? {});
+  const extra = typeof parts.extra === 'undefined' ? null : sanitise(parts.extra);
+  const segments = [
+    parts.address,
+    parts.targetAddress ?? 'default',
+    typeof parts.targetPort === 'number' ? String(parts.targetPort) : 'default',
+    stableStringify(payload),
+    stableStringify(extra)
+  ];
+  return segments.join('|');
+}
+
+export function createOscAddressTag(address: string): string {
+  return `osc:${address}`;
+}
+
+export function createOscPrefixTag(prefix: string): string {
+  return `osc-prefix:${prefix}`;
+}
+
+export function createResourceTag(resourceType: ResourceType, key?: string): string {
+  return typeof key === 'string' ? `resource:${resourceType}:${key}` : `resource:${resourceType}`;
+}
+
+class ResourceCache {
+  private readonly caches = new Map<ResourceType, ResourceCacheMap>();
+
+  private readonly stats = new Map<ResourceType, CacheStats>();
+
+  private readonly tagIndex = new Map<string, Set<EntryId>>();
+
+  private readonly prefixIndex = new Map<string, Set<EntryId>>();
+
+  private defaultTtlMs = 1500;
+
+  private readonly resourceTtls = new Map<ResourceType, number>();
+
+  public async fetch<T>({
+    resourceType,
+    key,
+    fetcher,
+    ttlMs,
+    tags = [],
+    prefixTags = []
+  }: FetchOptions<T>): Promise<T> {
+    const cache = this.getCache(resourceType);
+    const entry = cache.get(key) as CacheEntry<T> | undefined;
+    const now = Date.now();
+
+    if (entry && entry.expiresAt > now) {
+      this.incrementHit(resourceType);
+      return entry.value;
+    }
+
+    if (entry) {
+      this.removeEntry(resourceType, key);
+    }
+
+    this.incrementMiss(resourceType);
+
+    const value = await fetcher();
+    const ttl = ttlMs ?? this.resourceTtls.get(resourceType) ?? this.defaultTtlMs;
+    const expiresAt = ttl > 0 ? now + ttl : now;
+    const newEntry: CacheEntry<T> = {
+      value,
+      expiresAt,
+      tags: [...tags],
+      prefixTags: [...prefixTags]
+    };
+
+    cache.set(key, newEntry);
+    this.registerEntry(resourceType, key, newEntry);
+
+    return value;
+  }
+
+  public invalidateResourceType(resourceType: ResourceType): void {
+    const cache = this.caches.get(resourceType);
+    if (!cache) {
+      return;
+    }
+
+    for (const key of Array.from(cache.keys())) {
+      this.removeEntry(resourceType, key);
+    }
+  }
+
+  public invalidateEntry(resourceType: ResourceType, key: string): void {
+    this.removeEntry(resourceType, key);
+  }
+
+  public invalidateByTag(tag: string): void {
+    const refs = this.tagIndex.get(tag);
+    if (!refs || refs.size === 0) {
+      return;
+    }
+
+    for (const entryId of Array.from(refs)) {
+      const { resourceType, key } = parseEntryId(entryId);
+      this.removeEntry(resourceType, key);
+    }
+  }
+
+  public invalidateByPrefix(prefixTag: string): void {
+    const refs = this.prefixIndex.get(prefixTag);
+    if (!refs || refs.size === 0) {
+      return;
+    }
+
+    for (const entryId of Array.from(refs)) {
+      const { resourceType, key } = parseEntryId(entryId);
+      this.removeEntry(resourceType, key);
+    }
+  }
+
+  public invalidateByOscAddress(address: string): void {
+    this.invalidateByTag(createOscAddressTag(address));
+
+    for (const prefixTag of Array.from(this.prefixIndex.keys())) {
+      const prefix = extractPrefixKey(prefixTag);
+      if (address.startsWith(prefix)) {
+        this.invalidateByPrefix(prefixTag);
+      }
+    }
+  }
+
+  public notifyResourceChange(resourceType: ResourceType, key?: string): void {
+    this.invalidateByTag(createResourceTag(resourceType));
+    if (typeof key === 'string') {
+      this.invalidateByTag(createResourceTag(resourceType, key));
+    }
+  }
+
+  public handleOscMessage(message: OscMessage): void {
+    if (message.address.startsWith('/eos/out/')) {
+      this.invalidateByOscAddress(message.address);
+    }
+  }
+
+  public clearAll(): void {
+    for (const resourceType of Array.from(this.caches.keys())) {
+      this.invalidateResourceType(resourceType);
+    }
+    this.stats.clear();
+  }
+
+  public setDefaultTtl(ttlMs: number): void {
+    this.defaultTtlMs = Math.max(0, ttlMs);
+  }
+
+  public setResourceTtl(resourceType: ResourceType, ttlMs: number | null): void {
+    if (ttlMs === null) {
+      this.resourceTtls.delete(resourceType);
+      return;
+    }
+    this.resourceTtls.set(resourceType, Math.max(0, ttlMs));
+  }
+
+  public getStats(resourceType: ResourceType): CacheStatsSnapshot {
+    const cache = this.caches.get(resourceType);
+    const stats = this.stats.get(resourceType) ?? { hits: 0, misses: 0 };
+    return {
+      hits: stats.hits,
+      misses: stats.misses,
+      entries: cache?.size ?? 0
+    };
+  }
+
+  private getCache(resourceType: ResourceType): ResourceCacheMap {
+    let cache = this.caches.get(resourceType);
+    if (!cache) {
+      cache = new Map();
+      this.caches.set(resourceType, cache);
+    }
+    return cache;
+  }
+
+  private incrementHit(resourceType: ResourceType): void {
+    const stats = this.stats.get(resourceType) ?? { hits: 0, misses: 0 };
+    stats.hits += 1;
+    this.stats.set(resourceType, stats);
+  }
+
+  private incrementMiss(resourceType: ResourceType): void {
+    const stats = this.stats.get(resourceType) ?? { hits: 0, misses: 0 };
+    stats.misses += 1;
+    this.stats.set(resourceType, stats);
+  }
+
+  private registerEntry(resourceType: ResourceType, key: string, entry: CacheEntry<unknown>): void {
+    const entryId = getEntryId(resourceType, key);
+
+    entry.tags.forEach((tag) => {
+      const bucket = this.tagIndex.get(tag) ?? new Set<EntryId>();
+      bucket.add(entryId);
+      this.tagIndex.set(tag, bucket);
+    });
+
+    entry.prefixTags.forEach((prefixTag) => {
+      const bucket = this.prefixIndex.get(prefixTag) ?? new Set<EntryId>();
+      bucket.add(entryId);
+      this.prefixIndex.set(prefixTag, bucket);
+    });
+  }
+
+  private removeEntry(resourceType: ResourceType, key: string): void {
+    const cache = this.caches.get(resourceType);
+    if (!cache) {
+      return;
+    }
+
+    const entry = cache.get(key);
+    if (!entry) {
+      return;
+    }
+
+    cache.delete(key);
+    const entryId = getEntryId(resourceType, key);
+
+    entry.tags.forEach((tag) => {
+      const bucket = this.tagIndex.get(tag);
+      if (!bucket) {
+        return;
+      }
+      bucket.delete(entryId);
+      if (bucket.size === 0) {
+        this.tagIndex.delete(tag);
+      }
+    });
+
+    entry.prefixTags.forEach((prefixTag) => {
+      const bucket = this.prefixIndex.get(prefixTag);
+      if (!bucket) {
+        return;
+      }
+      bucket.delete(entryId);
+      if (bucket.size === 0) {
+        this.prefixIndex.delete(prefixTag);
+      }
+    });
+  }
+}
+
+const sharedCache = new ResourceCache();
+
+export function getResourceCache(): ResourceCache {
+  return sharedCache;
+}
+

--- a/src/tools/patch/index.ts
+++ b/src/tools/patch/index.ts
@@ -1,4 +1,10 @@
 import { z, type ZodRawShape } from 'zod';
+import {
+  createCacheKey,
+  createOscPrefixTag,
+  createResourceTag,
+  getResourceCache
+} from '../../services/cache/index';
 import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
 import type { OscMessageArgument } from '../../services/osc/index';
 import { oscMappings } from '../../services/osc/mappings';
@@ -692,33 +698,51 @@ export const eosPatchGetChannelInfoTool: ToolDefinition<typeof channelInfoInputS
       channel: options.channel_number,
       part: options.part_number ?? 0
     };
-
-    const response: OscJsonResponse = await client.requestJson(oscMappings.patch.channelInfo, {
+    const cacheKey = createCacheKey({
+      address: oscMappings.patch.channelInfo,
       payload,
-      timeoutMs: options.timeoutMs,
       targetAddress: options.targetAddress,
       targetPort: options.targetPort
     });
+    const cache = getResourceCache();
 
-    const channelData = normaliseChannelInfo(
-      (response.data as Record<string, unknown> | null)?.channel ?? response.data,
-      options.channel_number,
-      options.part_number ?? null
-    );
+    return cache.fetch<ToolExecutionResult>({
+      resourceType: 'patch',
+      key: cacheKey,
+      tags: [
+        createResourceTag('patch'),
+        createResourceTag('patch', `channel:${options.channel_number}`)
+      ],
+      prefixTags: [createOscPrefixTag('/eos/out/')],
+      fetcher: async () => {
+        const response: OscJsonResponse = await client.requestJson(oscMappings.patch.channelInfo, {
+          payload,
+          timeoutMs: options.timeoutMs,
+          targetAddress: options.targetAddress,
+          targetPort: options.targetPort
+        });
 
-    const validatedChannel = patchChannelInfoOutputSchema.parse(channelData);
+        const channelData = normaliseChannelInfo(
+          (response.data as Record<string, unknown> | null)?.channel ?? response.data,
+          options.channel_number,
+          options.part_number ?? null
+        );
 
-    const baseText =
-      response.status === 'ok'
-        ? `Informations recues pour le canal ${validatedChannel.channel_number}.`
-        : `Lecture des informations du canal ${validatedChannel.channel_number} terminee avec le statut ${response.status}.`;
+        const validatedChannel = patchChannelInfoOutputSchema.parse(channelData);
 
-    return createResult(baseText, {
-      status: response.status,
-      channel: validatedChannel,
-      osc: {
-        address: oscMappings.patch.channelInfo,
-        args: payload
+        const baseText =
+          response.status === 'ok'
+            ? `Informations recues pour le canal ${validatedChannel.channel_number}.`
+            : `Lecture des informations du canal ${validatedChannel.channel_number} terminee avec le statut ${response.status}.`;
+
+        return createResult(baseText, {
+          status: response.status,
+          channel: validatedChannel,
+          osc: {
+            address: oscMappings.patch.channelInfo,
+            args: payload
+          }
+        });
       }
     });
   }
@@ -750,33 +774,48 @@ export const eosPatchGetAugment3dPositionTool: ToolDefinition<typeof augment3dIn
       channel: options.channel_number,
       part: options.part_number
     };
-
-    const response: OscJsonResponse = await client.requestJson(oscMappings.patch.augment3dPosition, {
+    const cacheKey = createCacheKey({
+      address: oscMappings.patch.augment3dPosition,
       payload,
-      timeoutMs: options.timeoutMs,
       targetAddress: options.targetAddress,
       targetPort: options.targetPort
     });
+    const cache = getResourceCache();
 
-    const positionData = normaliseAugment3dPosition(
-      (response.data as Record<string, unknown> | null)?.augment3d ?? response.data,
-      options.channel_number,
-      options.part_number
-    );
+    return cache.fetch<ToolExecutionResult>({
+      resourceType: 'patch',
+      key: cacheKey,
+      tags: [createResourceTag('patch')],
+      prefixTags: [createOscPrefixTag('/eos/out/')],
+      fetcher: async () => {
+        const response: OscJsonResponse = await client.requestJson(oscMappings.patch.augment3dPosition, {
+          payload,
+          timeoutMs: options.timeoutMs,
+          targetAddress: options.targetAddress,
+          targetPort: options.targetPort
+        });
 
-    const validatedPosition = augment3dPositionOutputSchema.parse(positionData);
+        const positionData = normaliseAugment3dPosition(
+          (response.data as Record<string, unknown> | null)?.augment3d ?? response.data,
+          options.channel_number,
+          options.part_number
+        );
 
-    const baseText =
-      response.status === 'ok'
-        ? `Position Augment3d recue pour le canal ${validatedPosition.channel_number} partie ${validatedPosition.part_number}.`
-        : `Lecture de la position Augment3d du canal ${validatedPosition.channel_number} partie ${validatedPosition.part_number} terminee avec le statut ${response.status}.`;
+        const validatedPosition = augment3dPositionOutputSchema.parse(positionData);
 
-    return createResult(baseText, {
-      status: response.status,
-      augment3d: validatedPosition,
-      osc: {
-        address: oscMappings.patch.augment3dPosition,
-        args: payload
+        const baseText =
+          response.status === 'ok'
+            ? `Position Augment3d recue pour le canal ${validatedPosition.channel_number} partie ${validatedPosition.part_number}.`
+            : `Lecture de la position Augment3d du canal ${validatedPosition.channel_number} partie ${validatedPosition.part_number} terminee avec le statut ${response.status}.`;
+
+        return createResult(baseText, {
+          status: response.status,
+          augment3d: validatedPosition,
+          osc: {
+            address: oscMappings.patch.augment3dPosition,
+            args: payload
+          }
+        });
       }
     });
   }
@@ -808,33 +847,48 @@ export const eosPatchGetAugment3dBeamTool: ToolDefinition<typeof augment3dInputS
       channel: options.channel_number,
       part: options.part_number
     };
-
-    const response: OscJsonResponse = await client.requestJson(oscMappings.patch.augment3dBeam, {
+    const cacheKey = createCacheKey({
+      address: oscMappings.patch.augment3dBeam,
       payload,
-      timeoutMs: options.timeoutMs,
       targetAddress: options.targetAddress,
       targetPort: options.targetPort
     });
+    const cache = getResourceCache();
 
-    const beamData = normaliseAugment3dBeam(
-      (response.data as Record<string, unknown> | null)?.augment3d ?? response.data,
-      options.channel_number,
-      options.part_number
-    );
+    return cache.fetch<ToolExecutionResult>({
+      resourceType: 'patch',
+      key: cacheKey,
+      tags: [createResourceTag('patch')],
+      prefixTags: [createOscPrefixTag('/eos/out/')],
+      fetcher: async () => {
+        const response: OscJsonResponse = await client.requestJson(oscMappings.patch.augment3dBeam, {
+          payload,
+          timeoutMs: options.timeoutMs,
+          targetAddress: options.targetAddress,
+          targetPort: options.targetPort
+        });
 
-    const validatedBeam = augment3dBeamOutputSchema.parse(beamData);
+        const beamData = normaliseAugment3dBeam(
+          (response.data as Record<string, unknown> | null)?.augment3d ?? response.data,
+          options.channel_number,
+          options.part_number
+        );
 
-    const baseText =
-      response.status === 'ok'
-        ? `Faisceau Augment3d recu pour le canal ${validatedBeam.channel_number} partie ${validatedBeam.part_number}.`
-        : `Lecture du faisceau Augment3d du canal ${validatedBeam.channel_number} partie ${validatedBeam.part_number} terminee avec le statut ${response.status}.`;
+        const validatedBeam = augment3dBeamOutputSchema.parse(beamData);
 
-    return createResult(baseText, {
-      status: response.status,
-      augment3d: validatedBeam,
-      osc: {
-        address: oscMappings.patch.augment3dBeam,
-        args: payload
+        const baseText =
+          response.status === 'ok'
+            ? `Faisceau Augment3d recu pour le canal ${validatedBeam.channel_number} partie ${validatedBeam.part_number}.`
+            : `Lecture du faisceau Augment3d du canal ${validatedBeam.channel_number} partie ${validatedBeam.part_number} terminee avec le statut ${response.status}.`;
+
+        return createResult(baseText, {
+          status: response.status,
+          augment3d: validatedBeam,
+          osc: {
+            address: oscMappings.patch.augment3dBeam,
+            args: payload
+          }
+        });
       }
     });
   }


### PR DESCRIPTION
## Summary
- add a reusable resource cache service with TTL support, tag-based invalidation, and OSC subscription handling
- integrate cached fetch logic into the various get_info and list_all tool handlers and notify cache invalidation on state changes
- cover caching behaviour with new unit tests and update existing group tests to assert cache usage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f647b9b8ac832a93a5c110618874d1