### PR TITLE
feat(osc): queue OSC requests and await tool sends

### DIFF
--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -1,3 +1,4 @@
+import { ErrorCode } from '../../../server/errors';
 import { OscClient, type ConnectResult } from '../client';
 import type { OscGateway } from '../client';
 import type { OscMessage } from '../index';
@@ -8,8 +9,20 @@ describe('OscClient', () => {
 
     private readonly listeners = new Set<(message: OscMessage) => void>();
 
-    public send(message: OscMessage, _targetAddress?: string, _targetPort?: number): void {
+    public delayMs = 0;
+
+    public activeSends = 0;
+
+    public maxActiveSends = 0;
+
+    public async send(message: OscMessage, _targetAddress?: string, _targetPort?: number): Promise<void> {
+      this.activeSends += 1;
+      this.maxActiveSends = Math.max(this.maxActiveSends, this.activeSends);
       this.sentMessages.push(message);
+      if (this.delayMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, this.delayMs));
+      }
+      this.activeSends -= 1;
     }
 
     public onMessage(listener: (message: OscMessage) => void): () => void {
@@ -165,5 +178,50 @@ describe('OscClient', () => {
     expect(result.status).toBe('ok');
     expect(result.path).toBe('/eos/out/ping');
     expect(service.sentMessages[0]?.address).toBe('/eos/subscribe');
+  });
+
+  it('gere les envois simultanes via la file', async () => {
+    const service = new FakeOscService();
+    service.delayMs = 10;
+    const client = new OscClient(service, { requestConcurrency: 1, queueTimeoutMs: 100 });
+
+    await Promise.all([
+      client.sendMessage('/test/1'),
+      client.sendMessage('/test/2'),
+      client.sendMessage('/test/3')
+    ]);
+
+    expect(service.sentMessages.map((message) => message.address)).toEqual([
+      '/test/1',
+      '/test/2',
+      '/test/3'
+    ]);
+    expect(service.maxActiveSends).toBe(1);
+  });
+
+  it('respecte la limite de concurrence configuree', async () => {
+    const service = new FakeOscService();
+    service.delayMs = 10;
+    const client = new OscClient(service, { requestConcurrency: 2, queueTimeoutMs: 100 });
+
+    await Promise.all([
+      client.sendMessage('/test/a'),
+      client.sendMessage('/test/b'),
+      client.sendMessage('/test/c'),
+      client.sendMessage('/test/d')
+    ]);
+
+    expect(service.sentMessages).toHaveLength(4);
+    expect(service.maxActiveSends).toBeLessThanOrEqual(2);
+  });
+
+  it('declenche un timeout si la console ne repond pas avant la limite', async () => {
+    const service = new FakeOscService();
+    service.delayMs = 50;
+    const client = new OscClient(service, { requestConcurrency: 1, queueTimeoutMs: 10 });
+
+    await expect(client.sendMessage('/test/timeout')).rejects.toMatchObject({
+      code: ErrorCode.OSC_TIMEOUT
+    });
   });
 });

--- a/src/services/osc/__tests__/requestQueue.test.ts
+++ b/src/services/osc/__tests__/requestQueue.test.ts
@@ -1,0 +1,49 @@
+import { ErrorCode } from '../../../server/errors';
+import { RequestQueue } from '../requestQueue';
+
+describe('RequestQueue', () => {
+  it('limite le nombre de taches actives', async () => {
+    const queue = new RequestQueue({ concurrency: 2 });
+    let active = 0;
+    let maxActive = 0;
+
+    const tasks = Array.from({ length: 6 }, (_, index) =>
+      queue.run(`task-${index}`, async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise<void>((resolve) => setTimeout(resolve, 5));
+        active -= 1;
+        return index;
+      })
+    );
+
+    const results = await Promise.all(tasks);
+    expect(results).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+
+  it('propage les erreurs des taches', async () => {
+    const queue = new RequestQueue({ concurrency: 1 });
+    const error = new Error('failure');
+
+    await expect(
+      queue.run('task-error', async () => {
+        throw error;
+      })
+    ).rejects.toBe(error);
+  });
+
+  it('declenche un timeout personnalise', async () => {
+    const queue = new RequestQueue({ concurrency: 1 });
+
+    await expect(
+      queue.run(
+        'operation lente',
+        async () => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 20));
+        },
+        { timeoutMs: 5 }
+      )
+    ).rejects.toMatchObject({ code: ErrorCode.OSC_TIMEOUT });
+  });
+});

--- a/src/services/osc/index.ts
+++ b/src/services/osc/index.ts
@@ -138,7 +138,7 @@ export class OscService {
     this.port.open();
   }
 
-  public send(message: OscMessage, targetAddress?: string, targetPort?: number): void {
+  public async send(message: OscMessage, targetAddress?: string, targetPort?: number): Promise<void> {
     const summary = this.createMessageSummary(message);
     this.updateStats('outgoing', summary);
 
@@ -146,7 +146,19 @@ export class OscService {
       this.logger.debug(`[OSC] -> ${summary.address}`, summary.args);
     }
 
-    this.port.send(message, targetAddress ?? this.config.remoteAddress, targetPort ?? this.config.remotePort);
+    return new Promise<void>((resolve, reject) => {
+      try {
+        this.port.send(
+          message,
+          targetAddress ?? this.config.remoteAddress,
+          targetPort ?? this.config.remotePort
+        );
+        resolve();
+      } catch (error) {
+        this.logger.error('[OSC] Erreur lors de l\'envoi du message', error);
+        reject(error);
+      }
+    });
   }
 
   public onMessage(listener: OscMessageListener): () => void {

--- a/src/services/osc/requestQueue.ts
+++ b/src/services/osc/requestQueue.ts
@@ -1,0 +1,112 @@
+import { createTimeoutError } from '../../server/errors.js';
+
+export interface RequestQueueOptions {
+  concurrency?: number;
+}
+
+export interface RequestQueueRunOptions {
+  timeoutMs?: number;
+  timeoutMessage?: string;
+  details?: Record<string, unknown>;
+}
+
+interface QueueTask<T> {
+  readonly operation: string;
+  readonly execute: () => Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (reason?: unknown) => void;
+  readonly options: RequestQueueRunOptions;
+}
+
+function normaliseConcurrency(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return 1;
+  }
+  return Math.max(1, Math.trunc(value));
+}
+
+export class RequestQueue {
+  private readonly concurrency: number;
+
+  private readonly pending: QueueTask<unknown>[] = [];
+
+  private activeCount = 0;
+
+  constructor(options: RequestQueueOptions = {}) {
+    this.concurrency = normaliseConcurrency(options.concurrency);
+  }
+
+  public async run<T>(
+    operation: string,
+    task: () => Promise<T>,
+    options: RequestQueueRunOptions = {}
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const queueTask: QueueTask<T> = {
+        operation,
+        execute: task,
+        resolve,
+        reject,
+        options
+      };
+      this.pending.push(queueTask as QueueTask<unknown>);
+      this.process();
+    });
+  }
+
+  private process(): void {
+    while (this.activeCount < this.concurrency) {
+      const next = this.pending.shift();
+      if (!next) {
+        return;
+      }
+
+      this.activeCount += 1;
+      this.execute(next).finally(() => {
+        this.activeCount -= 1;
+        this.process();
+      });
+    }
+  }
+
+  private async execute<T>(task: QueueTask<T>): Promise<void> {
+    const { execute, resolve, reject, options, operation } = task;
+    let timeoutHandle: NodeJS.Timeout | null = null;
+
+    const timeoutMs = options.timeoutMs;
+    const timeoutPromise =
+      typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0
+        ? new Promise<never>((_resolve, rejectTimeout) => {
+            timeoutHandle = setTimeout(() => {
+              rejectTimeout(
+                createTimeoutError(operation, timeoutMs, options.timeoutMessage, options.details)
+              );
+            }, timeoutMs);
+          })
+        : null;
+
+    let executionPromise: Promise<T>;
+    try {
+      executionPromise = Promise.resolve(execute());
+    } catch (error) {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      reject(error);
+      return;
+    }
+
+    try {
+      const result = timeoutPromise
+        ? await Promise.race([executionPromise, timeoutPromise])
+        : await executionPromise;
+      resolve(result as T);
+    } catch (error) {
+      reject(error);
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+  }
+}

--- a/src/tools/channels/__tests__/channels.test.ts
+++ b/src/tools/channels/__tests__/channels.test.ts
@@ -12,7 +12,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/channels/index.ts
+++ b/src/tools/channels/index.ts
@@ -202,7 +202,7 @@ export const eosChannelSelectTool: ToolDefinition<typeof selectInputSchema> = {
       exclusive: options.exclusive ?? false
     };
 
-    client.sendMessage(oscMappings.channels.select, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.channels.select, buildJsonArgs(payload), extractTargetOptions(options));
 
     return createResult(`Canaux selectionnes: ${channels.join(', ')}`, {
       action: 'select',
@@ -245,7 +245,7 @@ export const eosChannelSetLevelTool: ToolDefinition<typeof setLevelSchema> = {
       snap: options.snap ?? false
     };
 
-    client.sendMessage(oscMappings.channels.level, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.channels.level, buildJsonArgs(payload), extractTargetOptions(options));
 
     return createResult(`Niveau regle a ${level}% pour les canaux ${channels.join(', ')}`, {
       action: 'set_level',
@@ -288,7 +288,7 @@ export const eosSetDmxTool: ToolDefinition<typeof setDmxSchema> = {
       value
     };
 
-    client.sendMessage(oscMappings.channels.dmx, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.channels.dmx, buildJsonArgs(payload), extractTargetOptions(options));
 
     return createResult(`Valeur DMX ${value} envoyee sur les adresses ${addresses.join(', ')}`, {
       action: 'set_dmx',
@@ -331,7 +331,7 @@ export const eosChannelSetParameterTool: ToolDefinition<typeof setParameterSchem
       value
     };
 
-    client.sendMessage(oscMappings.channels.parameter, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.channels.parameter, buildJsonArgs(payload), extractTargetOptions(options));
 
     return createResult(`Parametre ${options.parameter} regle a ${value} pour les canaux ${channels.join(', ')}`, {
       action: 'set_parameter',

--- a/src/tools/commands/__tests__/command_tools.test.ts
+++ b/src/tools/commands/__tests__/command_tools.test.ts
@@ -14,7 +14,7 @@ describe('command tools', () => {
 
     private readonly listeners = new Set<(message: OscMessage) => void>();
 
-    public send(message: OscMessage, _targetAddress?: string, _targetPort?: number): void {
+    public async send(message: OscMessage, _targetAddress?: string, _targetPort?: number): Promise<void> {
       this.sentMessages.push(message);
     }
 

--- a/src/tools/commands/command_tools.ts
+++ b/src/tools/commands/command_tools.ts
@@ -139,7 +139,7 @@ export const eosCommandTool: ToolDefinition<typeof commandInputSchema> = {
 
     const user = resolveUserId(options.user);
 
-    client.sendCommand(command, {
+    await client.sendCommand(command, {
       user,
       targetAddress: options.targetAddress,
       targetPort: options.targetPort
@@ -186,7 +186,7 @@ export const eosNewCommandTool: ToolDefinition<typeof newCommandInputSchema> = {
     const user = resolveUserId(options.user);
 
     if (shouldClear) {
-      client.sendNewCommand(command, {
+      await client.sendNewCommand(command, {
         user,
         targetAddress: options.targetAddress,
         targetPort: options.targetPort
@@ -194,7 +194,7 @@ export const eosNewCommandTool: ToolDefinition<typeof newCommandInputSchema> = {
       return formatSendResult(command, user ?? null, '/eos/newcmd');
     }
 
-    client.sendCommand(command, {
+    await client.sendCommand(command, {
       user,
       targetAddress: options.targetAddress,
       targetPort: options.targetPort
@@ -238,7 +238,7 @@ export const eosCommandWithSubstitutionTool: ToolDefinition<typeof substitutionC
 
     const user = resolveUserId(options.user);
 
-    client.sendCommand(command, {
+    await client.sendCommand(command, {
       user,
       targetAddress: options.targetAddress,
       targetPort: options.targetPort

--- a/src/tools/cues/__tests__/cues.test.ts
+++ b/src/tools/cues/__tests__/cues.test.ts
@@ -14,7 +14,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/cues/cuelist_bank_create.ts
+++ b/src/tools/cues/cuelist_bank_create.ts
@@ -62,7 +62,7 @@ export const eosCuelistBankCreateTool: ToolDefinition<typeof bankCreateInputSche
       payload.offset = Math.trunc(options.offset);
     }
 
-    client.sendMessage(oscMappings.cues.bankCreate, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.cues.bankCreate, buildJsonArgs(payload), extractTargetOptions(options));
 
     const text = `Bank ${options.bank_index} assigne a ${formatCueDescription({
       ...identifier,

--- a/src/tools/cues/cuelist_bank_page.ts
+++ b/src/tools/cues/cuelist_bank_page.ts
@@ -40,7 +40,7 @@ export const eosCuelistBankPageTool: ToolDefinition<typeof bankPageInputSchema> 
       delta: options.delta
     };
 
-    client.sendMessage(oscMappings.cues.bankPage, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.cues.bankPage, buildJsonArgs(payload), extractTargetOptions(options));
 
     const text = `Bank ${options.bank_index}: changement de page (${options.delta >= 0 ? '+' : ''}${options.delta})`;
 

--- a/src/tools/cues/fire.ts
+++ b/src/tools/cues/fire.ts
@@ -57,7 +57,7 @@ export const eosCueFireTool: ToolDefinition<typeof fireInputSchema> = {
 
     const payload = buildCueCommandPayload(identifier, { defaultPart: 0 });
 
-    client.sendMessage(oscMappings.cues.fire, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.cues.fire, buildJsonArgs(payload), extractTargetOptions(options));
 
     return createCueCommandResult(
       'cue_fire',

--- a/src/tools/cues/go.ts
+++ b/src/tools/cues/go.ts
@@ -50,7 +50,7 @@ export const eosCueGoTool: ToolDefinition<typeof goInputSchema> = {
     const identifier = createCueIdentifierFromOptions(options);
     const payload = buildCueCommandPayload(identifier);
 
-    client.sendMessage(oscMappings.cues.go, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.cues.go, buildJsonArgs(payload), extractTargetOptions(options));
 
     return createCueCommandResult(
       'cue_go',

--- a/src/tools/cues/select.ts
+++ b/src/tools/cues/select.ts
@@ -50,7 +50,7 @@ export const eosCueSelectTool: ToolDefinition<typeof selectInputSchema> = {
     const identifier = createCueIdentifierFromOptions(options);
     const payload = buildCueCommandPayload(identifier, { defaultPart: 0 });
 
-    client.sendMessage(oscMappings.cues.select, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.cues.select, buildJsonArgs(payload), extractTargetOptions(options));
 
     return createCueCommandResult(
       'cue_select',

--- a/src/tools/cues/stop_back.ts
+++ b/src/tools/cues/stop_back.ts
@@ -51,7 +51,7 @@ export const eosCueStopBackTool: ToolDefinition<typeof stopBackInputSchema> = {
       payload.back = true;
     }
 
-    client.sendMessage(oscMappings.cues.stopBack, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.cues.stopBack, buildJsonArgs(payload), extractTargetOptions(options));
 
     return createCueCommandResult(
       options.back ? 'cue_back' : 'cue_stop',

--- a/src/tools/curves/__tests__/curves.test.ts
+++ b/src/tools/curves/__tests__/curves.test.ts
@@ -10,7 +10,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/curves/index.ts
+++ b/src/tools/curves/index.ts
@@ -375,7 +375,7 @@ export const eosCurveSelectTool: ToolDefinition<typeof selectInputSchema> = {
       curve: options.curve_number
     };
 
-    client.sendMessage(oscMappings.curves.select, buildJsonArgs(payload), {
+    await client.sendMessage(oscMappings.curves.select, buildJsonArgs(payload), {
       targetAddress: options.targetAddress,
       targetPort: options.targetPort
     });

--- a/src/tools/directSelects/__tests__/directSelects.test.ts
+++ b/src/tools/directSelects/__tests__/directSelects.test.ts
@@ -13,7 +13,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/directSelects/index.ts
+++ b/src/tools/directSelects/index.ts
@@ -253,7 +253,7 @@ export const eosDirectSelectBankCreateTool: ToolDefinition<typeof bankCreateInpu
 
     setBankState(options.bank_index, state);
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.directSelects.bankCreate,
       buildJsonArgs(payload),
       extractTargetOptions(options)
@@ -315,7 +315,7 @@ export const eosDirectSelectPressTool: ToolDefinition<typeof pressInputSchema> =
     const address = `${oscMappings.directSelects.base}/${options.bank_index}/${state.page}/${options.button_index}`;
     const stateValue: number = options.state;
 
-    client.sendMessage(address, buildFloatArgs(stateValue), extractTargetOptions(options));
+    await client.sendMessage(address, buildFloatArgs(stateValue), extractTargetOptions(options));
 
     const actionText = stateValue >= 1 ? 'enfonce' : stateValue <= 0 ? 'relache' : `etat ${stateValue}`;
     const text = `Bank ${options.bank_index} page ${state.page}: bouton ${options.button_index} ${actionText}.`;
@@ -369,7 +369,7 @@ export const eosDirectSelectPageTool: ToolDefinition<typeof pageInputSchema> = {
       delta: options.delta
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.directSelects.bankPage,
       buildJsonArgs(payload),
       extractTargetOptions(options)

--- a/src/tools/dmx/__tests__/dmx.test.ts
+++ b/src/tools/dmx/__tests__/dmx.test.ts
@@ -14,7 +14,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/effects/__tests__/effects.test.ts
+++ b/src/tools/effects/__tests__/effects.test.ts
@@ -15,7 +15,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/effects/index.ts
+++ b/src/tools/effects/index.ts
@@ -556,7 +556,7 @@ export const eosEffectSelectTool: ToolDefinition<typeof selectInputSchema> = {
       effect: options.effect_number
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.effects.select,
       buildJsonArgs(payload),
       {
@@ -605,7 +605,7 @@ export const eosEffectStopTool: ToolDefinition<typeof stopInputSchema> = {
       payload.effect = options.effect_number;
     }
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.effects.stop,
       buildJsonArgs(payload),
       {

--- a/src/tools/faders/__tests__/faders.test.ts
+++ b/src/tools/faders/__tests__/faders.test.ts
@@ -15,7 +15,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/faders/index.ts
+++ b/src/tools/faders/index.ts
@@ -220,7 +220,7 @@ export const eosFaderBankCreateTool: ToolDefinition<typeof bankCreateInputSchema
       payload.page = page;
     }
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.faders.bankCreate,
       buildJsonArgs(payload),
       extractTargetOptions(options)
@@ -267,7 +267,7 @@ export const eosFaderSetLevelTool: ToolDefinition<typeof setLevelInputSchema> = 
     const level = resolveLevelValue(options.level);
     const address = `${oscMappings.faders.base}/${options.bank_index}/${state.page}/${options.fader_index}`;
 
-    client.sendMessage(address, buildFloatArgs(level), extractTargetOptions(options));
+    await client.sendMessage(address, buildFloatArgs(level), extractTargetOptions(options));
 
     return createResult(
       `Fader ${options.bank_index}.${state.page}.${options.fader_index} regle a ${formatPercent(level)}.`,
@@ -310,7 +310,7 @@ export const eosFaderLoadTool: ToolDefinition<typeof loadInputSchema> = {
     const state = getBankState(options.bank_index);
     const address = `${oscMappings.faders.base}/${options.bank_index}/${state.page}/${options.fader_index}/load`;
 
-    client.sendMessage(address, [], extractTargetOptions(options));
+    await client.sendMessage(address, [], extractTargetOptions(options));
 
     return createResult(
       `Fader ${options.bank_index}.${state.page}.${options.fader_index} charge.`,
@@ -352,7 +352,7 @@ export const eosFaderUnloadTool: ToolDefinition<typeof loadInputSchema> = {
     const state = getBankState(options.bank_index);
     const address = `${oscMappings.faders.base}/${options.bank_index}/${state.page}/${options.fader_index}/unload`;
 
-    client.sendMessage(address, [], extractTargetOptions(options));
+    await client.sendMessage(address, [], extractTargetOptions(options));
 
     return createResult(
       `Fader ${options.bank_index}.${state.page}.${options.fader_index} decharge.`,
@@ -398,7 +398,7 @@ export const eosFaderPageTool: ToolDefinition<typeof pageInputSchema> = {
       delta: options.delta
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.faders.bankPage,
       buildJsonArgs(payload),
       extractTargetOptions(options)

--- a/src/tools/fpe/__tests__/fpe.test.ts
+++ b/src/tools/fpe/__tests__/fpe.test.ts
@@ -16,7 +16,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/groups/__tests__/groups.test.ts
+++ b/src/tools/groups/__tests__/groups.test.ts
@@ -14,7 +14,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/groups/index.ts
+++ b/src/tools/groups/index.ts
@@ -248,7 +248,7 @@ export const eosGroupSelectTool: ToolDefinition<typeof selectInputSchema> = {
       group: options.group_number
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.groups.select,
       buildJsonArgs(payload),
       {
@@ -299,7 +299,7 @@ export const eosGroupSetLevelTool: ToolDefinition<typeof setLevelInputSchema> = 
       payload.snap = options.snap;
     }
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.groups.level,
       buildJsonArgs(payload),
       {

--- a/src/tools/keys/__tests__/keys.test.ts
+++ b/src/tools/keys/__tests__/keys.test.ts
@@ -12,7 +12,7 @@ describe('key tools', () => {
 
     private readonly listeners = new Set<(message: OscMessage) => void>();
 
-    public send(message: OscMessage): void {
+    public async send(message: OscMessage): Promise<void> {
       this.sentMessages.push(message);
     }
 

--- a/src/tools/keys/index.ts
+++ b/src/tools/keys/index.ts
@@ -213,7 +213,7 @@ export const eosKeyPressTool: ToolDefinition<typeof keyPressInputSchema> = {
     const address = `/eos/key/${identifier}`;
     const client = getOscClient();
 
-    client.sendMessage(address, createOscArgs(state), {
+    await client.sendMessage(address, createOscArgs(state), {
       targetAddress: options.targetAddress,
       targetPort: options.targetPort
     });
@@ -260,7 +260,7 @@ export const eosSoftkeyPressTool: ToolDefinition<typeof softkeyPressInputSchema>
     const address = `/eos/key/softkey${softkeyNumber}`;
     const client = getOscClient();
 
-    client.sendMessage(address, createOscArgs(state), {
+    await client.sendMessage(address, createOscArgs(state), {
       targetAddress: options.targetAddress,
       targetPort: options.targetPort
     });

--- a/src/tools/macros/__tests__/macros.test.ts
+++ b/src/tools/macros/__tests__/macros.test.ts
@@ -14,7 +14,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/macros/index.ts
+++ b/src/tools/macros/index.ts
@@ -368,7 +368,7 @@ export const eosMacroFireTool: ToolDefinition<typeof fireInputSchema> = {
       macro: options.macro_number
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.macros.fire,
       buildJsonArgs(payload),
       {
@@ -416,7 +416,7 @@ export const eosMacroSelectTool: ToolDefinition<typeof selectInputSchema> = {
       macro: options.macro_number
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.macros.select,
       buildJsonArgs(payload),
       {

--- a/src/tools/magicSheets/__tests__/magicSheets.test.ts
+++ b/src/tools/magicSheets/__tests__/magicSheets.test.ts
@@ -14,7 +14,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/magicSheets/index.ts
+++ b/src/tools/magicSheets/index.ts
@@ -332,7 +332,7 @@ export const eosMagicSheetOpenTool: ToolDefinition<typeof openInputSchema> = {
       payload.view = options.view_number;
     }
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.magicSheets.open,
       buildJsonArgs(payload),
       extractTargetOptions(options)
@@ -393,7 +393,7 @@ export const eosMagicSheetSendStringTool: ToolDefinition<typeof sendStringInputS
 
     const client = getOscClient();
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.magicSheets.sendString,
       [
         {

--- a/src/tools/palettes/__tests__/palettes.test.ts
+++ b/src/tools/palettes/__tests__/palettes.test.ts
@@ -16,7 +16,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/palettes/index.ts
+++ b/src/tools/palettes/index.ts
@@ -357,7 +357,7 @@ function createPaletteFireTool({ type, name, title, description, mapping }: Pale
         palette: options.palette_number
       };
 
-      client.sendMessage(mapping, buildJsonArgs(payload), extractTargetOptions(options));
+      await client.sendMessage(mapping, buildJsonArgs(payload), extractTargetOptions(options));
 
       return createResult(`Palette ${paletteTypeLabels[type]} ${options.palette_number} declenchee`, {
         action: 'palette_fire',

--- a/src/tools/parameters/__tests__/parameters.test.ts
+++ b/src/tools/parameters/__tests__/parameters.test.ts
@@ -18,7 +18,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/parameters/index.ts
+++ b/src/tools/parameters/index.ts
@@ -379,7 +379,7 @@ export const eosWheelTickTool: ToolDefinition<typeof wheelTickInputSchema> = {
       mode
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.parameters.wheelTick,
       buildJsonArgs(payload),
       extractTargetOptions(options)
@@ -426,7 +426,7 @@ export const eosWheelSwitchContinuousTool: ToolDefinition<typeof wheelRateInputS
       rate
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.parameters.wheelRate,
       buildJsonArgs(payload),
       extractTargetOptions(options)
@@ -470,7 +470,7 @@ export const eosSetColorHsTool: ToolDefinition<typeof colorHsInputSchema> = {
       saturation: normalisePercentage(options.saturation, 'la saturation') * 100
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.parameters.colorHs,
       buildJsonArgs(payload),
       extractTargetOptions(options)
@@ -515,7 +515,7 @@ export const eosSetColorRgbTool: ToolDefinition<typeof colorRgbInputSchema> = {
       blue: normalisePercentage(options.blue, 'le bleu')
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.parameters.colorRgb,
       buildJsonArgs(payload),
       extractTargetOptions(options)
@@ -558,7 +558,7 @@ export const eosSetPanTiltXYTool: ToolDefinition<typeof panTiltInputSchema> = {
       y: normalisePercentage(options.y, 'y')
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.parameters.positionXY,
       buildJsonArgs(payload),
       extractTargetOptions(options)
@@ -602,7 +602,7 @@ export const eosSetXYZPositionTool: ToolDefinition<typeof xyzInputSchema> = {
       z: normaliseCoordinate(options.z, 'z')
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.parameters.positionXYZ,
       buildJsonArgs(payload),
       extractTargetOptions(options)

--- a/src/tools/patch/__tests__/patch.test.ts
+++ b/src/tools/patch/__tests__/patch.test.ts
@@ -16,7 +16,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/pixelMaps/__tests__/pixelMaps.test.ts
+++ b/src/tools/pixelMaps/__tests__/pixelMaps.test.ts
@@ -13,7 +13,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/pixelMaps/index.ts
+++ b/src/tools/pixelMaps/index.ts
@@ -678,7 +678,7 @@ export const eosPixmapSelectTool: ToolDefinition<typeof selectInputSchema> = {
       pixmap: options.pixmap_number
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.pixelMaps.select,
       buildJsonArgs(payload),
       {

--- a/src/tools/presets/__tests__/presets.test.ts
+++ b/src/tools/presets/__tests__/presets.test.ts
@@ -12,7 +12,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/presets/index.ts
+++ b/src/tools/presets/index.ts
@@ -487,7 +487,7 @@ export const eosPresetFireTool: ToolDefinition<typeof presetFireInputSchema> = {
       preset: options.preset_number
     };
 
-    client.sendMessage(oscMappings.presets.fire, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.presets.fire, buildJsonArgs(payload), extractTargetOptions(options));
 
     return createResult(`Preset ${options.preset_number} declenche`, {
       action: 'preset_fire',
@@ -525,7 +525,7 @@ export const eosPresetSelectTool: ToolDefinition<typeof presetFireInputSchema> =
       preset: options.preset_number
     };
 
-    client.sendMessage(oscMappings.presets.select, buildJsonArgs(payload), extractTargetOptions(options));
+    await client.sendMessage(oscMappings.presets.select, buildJsonArgs(payload), extractTargetOptions(options));
 
     return createResult(`Preset ${options.preset_number} selectionne`, {
       action: 'preset_select',

--- a/src/tools/queries/__tests__/queries.test.ts
+++ b/src/tools/queries/__tests__/queries.test.ts
@@ -8,7 +8,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/showControl/__tests__/showControl.test.ts
+++ b/src/tools/showControl/__tests__/showControl.test.ts
@@ -16,7 +16,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/snapshots/__tests__/snapshots.test.ts
+++ b/src/tools/snapshots/__tests__/snapshots.test.ts
@@ -10,7 +10,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/snapshots/index.ts
+++ b/src/tools/snapshots/index.ts
@@ -311,7 +311,7 @@ export const eosSnapshotRecallTool: ToolDefinition<typeof recallInputSchema> = {
       snapshot: options.snapshot_number
     };
 
-    client.sendMessage(
+    await client.sendMessage(
       oscMappings.snapshots.recall,
       buildJsonArgs(payload),
       extractTargetOptions(options)

--- a/src/tools/submasters/__tests__/submasters.test.ts
+++ b/src/tools/submasters/__tests__/submasters.test.ts
@@ -12,7 +12,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public send(message: OscMessage): void {
+  public async send(message: OscMessage): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/submasters/index.ts
+++ b/src/tools/submasters/index.ts
@@ -392,7 +392,7 @@ export const eosSubmasterSetLevelTool: ToolDefinition<typeof setLevelInputSchema
     const level = resolveLevelValue(options.level);
     const address = `${oscMappings.submasters.base}/${options.submaster_number}`;
 
-    client.sendMessage(address, buildFloatArgs(level), extractTargetOptions(options));
+    await client.sendMessage(address, buildFloatArgs(level), extractTargetOptions(options));
 
     return createResult(`Niveau du submaster ${options.submaster_number} regle a ${Math.round(level * 100)}%`, {
       action: 'submaster_set_level',
@@ -431,7 +431,7 @@ export const eosSubmasterBumpTool: ToolDefinition<typeof bumpInputSchema> = {
     const address = `${oscMappings.submasters.base}/${options.submaster_number}/bump`;
     const value = state ? 1 : 0;
 
-    client.sendMessage(address, buildFloatArgs(value), extractTargetOptions(options));
+    await client.sendMessage(address, buildFloatArgs(value), extractTargetOptions(options));
 
     return createResult(`Bump du submaster ${options.submaster_number} ${state ? 'active' : 'desactive'}`, {
       action: 'submaster_bump',


### PR DESCRIPTION
## Summary
- introduce an asynchronous RequestQueue to coordinate OSC requests with concurrency limits and timeout handling
- update OscClient and OscService to await queued sends, attach response listeners before dispatch, and expose configurable queue options
- ensure all tools/tests await OSC sends and add coverage for concurrent workloads and queue behaviour

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f6552da9f8832ab1b885b4f979ec9e