### PR TITLE
feat: expose HTTP and WebSocket gateway for MCP tools

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -5,6 +5,8 @@
 
 Chaque outil expose son nom MCP, une description, la liste des arguments attendus ainsi qu'un exemple d'appel en CLI et par OSC.
 
+> Nouvelle passerelle HTTP/WS : définissez `MCP_TCP_PORT` pour appeler les outils via `POST /tools/:name` ou WebSocket (`/ws`).
+
 <a id="eos-address-select"></a>
 ## Selection d'adresse DMX (`eos_address_select`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,18 @@
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.1",
+        "express": "^5.1.0",
         "osc": "^2.4.5",
         "pino": "^10.1.0",
+        "ws": "^8.18.3",
         "zod": "^3.25.6",
         "zod-to-json-schema": "^3.24.6"
       },
       "devDependencies": {
+        "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.8.1",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.46.1",
         "@typescript-eslint/parser": "^8.46.1",
         "ajv": "^8.17.1",
@@ -1968,10 +1972,63 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
+      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
+      "integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2020,6 +2077,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.8.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
@@ -2030,12 +2094,69 @@
         "undici-types": "~7.14.0"
       }
     },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-zBF6vZJn1IaMpg3xUF25VK3gd3l8zwE0ZLRX7dsQyQi+jp4E8mMDJNGDYnYse+bQhYwWERTxVwHpi3dMOq7RKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.9.tgz",
+      "integrity": "sha512-dOTIuqpWLyl3BBXU3maNQsS4A3zuuoYRNIvYSxxhebPfXg2mzWQEPne/nlJ37yOse6uGgR386uTpdsx4D0QZWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -5751,6 +5872,27 @@
         "serialport": "12.0.0"
       }
     },
+    "node_modules/osc/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7552,9 +7694,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -22,14 +22,18 @@
   "type": "commonjs",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.20.1",
+    "express": "^5.1.0",
     "osc": "^2.4.5",
     "pino": "^10.1.0",
+    "ws": "^8.18.3",
     "zod": "^3.25.6",
     "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
+    "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.8.1",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.46.1",
     "@typescript-eslint/parser": "^8.46.1",
     "ajv": "^8.17.1",

--- a/src/server/__tests__/httpGateway.test.ts
+++ b/src/server/__tests__/httpGateway.test.ts
@@ -1,0 +1,123 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import WebSocket from 'ws';
+import { createHttpGateway, type HttpGateway } from '../httpGateway.js';
+import { ToolRegistry } from '../toolRegistry.js';
+import type { ToolDefinition } from '../../tools/types.js';
+
+describe('HttpGateway integration', () => {
+  let server: McpServer;
+  let registry: ToolRegistry;
+  let gateway: HttpGateway;
+  let baseUrl: string;
+
+  const tool: ToolDefinition = {
+    name: 'echo_test',
+    config: {
+      description: 'Echo test tool'
+    },
+    handler: async (args) => {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `echo:${JSON.stringify(args ?? {})}`
+          }
+        ]
+      };
+    }
+  };
+
+  beforeAll(async () => {
+    server = new McpServer({
+      name: 'test-server',
+      version: '0.0.0-test'
+    });
+    registry = new ToolRegistry(server);
+    registry.register(tool);
+    gateway = createHttpGateway(registry, { port: 0 });
+    await gateway.start();
+    const address = gateway.getAddress();
+    if (!address) {
+      throw new Error('Adresse de la passerelle introuvable');
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await gateway.stop();
+    await server.close();
+  });
+
+  test('execute tool via HTTP POST', async () => {
+    const response = await fetch(`${baseUrl}/tools/${tool.name}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        args: {
+          text: 'http'
+        }
+      })
+    });
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { tool: string; result: unknown };
+    expect(payload.tool).toBe(tool.name);
+    expect(payload.result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'echo:{"text":"http"}'
+        }
+      ]
+    });
+  });
+
+  test('execute tool via WebSocket', async () => {
+    const address = new URL(baseUrl);
+    const ws = new WebSocket(`ws://${address.host}/ws`);
+
+    const response = await new Promise<{ type: string; id?: string; tool?: string; result?: unknown }>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Timeout en attente de la reponse WebSocket'));
+      }, 5000);
+
+      ws.on('message', (raw) => {
+        const message = typeof raw === 'string' ? raw : raw.toString('utf-8');
+        const data = JSON.parse(message) as Record<string, unknown>;
+
+        if (data.type === 'ready') {
+          ws.send(
+            JSON.stringify({
+              id: 'ws-call',
+              tool: tool.name,
+              args: { text: 'ws' }
+            })
+          );
+          return;
+        }
+
+        clearTimeout(timeout);
+        resolve(data as { type: string; id?: string; tool?: string; result?: unknown });
+        ws.close();
+      });
+
+      ws.on('error', (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+    });
+
+    expect(response.type).toBe('result');
+    expect(response.tool).toBe(tool.name);
+    expect(response.result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'echo:{"text":"ws"}'
+        }
+      ]
+    });
+  });
+});

--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -1,0 +1,218 @@
+import type { AddressInfo } from 'node:net';
+import { createServer, type Server } from 'node:http';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { WebSocketServer, type WebSocket, type RawData } from 'ws';
+import { createLogger } from './logger.js';
+import { ToolNotFoundError, type ToolRegistry } from './toolRegistry.js';
+
+interface HttpGatewayOptions {
+  port: number;
+  host?: string;
+  websocketPath?: string;
+}
+
+interface InvokeRequestPayload {
+  id?: string;
+  tool: string;
+  args?: unknown;
+  extra?: unknown;
+}
+
+interface InvokeSuccessResponse {
+  type: 'result';
+  id?: string;
+  tool: string;
+  result: unknown;
+}
+
+interface InvokeErrorResponse {
+  type: 'error';
+  id?: string;
+  tool?: string;
+  error: { message: string };
+}
+
+const logger = createLogger('http-gateway');
+
+class HttpGateway {
+  private server?: Server;
+
+  private wss?: WebSocketServer;
+
+  private started = false;
+
+  constructor(
+    private readonly registry: ToolRegistry,
+    private readonly options: HttpGatewayOptions
+  ) {}
+
+  public async start(): Promise<void> {
+    if (this.started) {
+      return;
+    }
+
+    const app = express();
+    app.use(express.json());
+
+    app.post('/tools/:name', async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const toolName = req.params.name;
+        const body = req.body;
+        const isObjectPayload = typeof body === 'object' && body !== null;
+        const args = isObjectPayload && 'args' in (body as Record<string, unknown>) ? (body as { args?: unknown }).args : body;
+        const extra = isObjectPayload && 'extra' in (body as Record<string, unknown>) ? (body as { extra?: unknown }).extra : undefined;
+        const result = await this.registry.invoke(toolName, args, extra);
+        res.json({ tool: toolName, result });
+      } catch (error) {
+        next(error);
+      }
+    });
+
+    app.use(this.createErrorHandler());
+
+    const server = createServer(app);
+    const wss = new WebSocketServer({
+      server,
+      path: this.options.websocketPath ?? '/ws'
+    });
+
+    wss.on('connection', (socket: WebSocket) => {
+      socket.on('error', (error: Error) => {
+        logger.error({ error }, 'Erreur socket WebSocket');
+      });
+
+      socket.on('message', async (rawMessage: RawData) => {
+        const messageText =
+          typeof rawMessage === 'string' ? rawMessage : rawMessage.toString('utf-8');
+        let payload: InvokeRequestPayload | undefined;
+        try {
+          payload = JSON.parse(messageText) as InvokeRequestPayload;
+        } catch (error) {
+          logger.warn({ error }, 'Message WebSocket invalide: %s', messageText);
+          socket.send(
+            JSON.stringify({
+              type: 'error',
+              error: { message: 'Payload JSON invalide' }
+            } satisfies InvokeErrorResponse)
+          );
+          return;
+        }
+
+        if (!payload.tool) {
+          socket.send(
+            JSON.stringify({
+              type: 'error',
+              id: payload.id,
+              error: { message: 'Champ "tool" manquant' }
+            } satisfies InvokeErrorResponse)
+          );
+          return;
+        }
+
+        try {
+          const result = await this.registry.invoke(payload.tool, payload.args, payload.extra);
+          const response: InvokeSuccessResponse = {
+            type: 'result',
+            id: payload.id,
+            tool: payload.tool,
+            result
+          };
+          socket.send(JSON.stringify(response));
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error('Erreur inconnue');
+          const response: InvokeErrorResponse = {
+            type: 'error',
+            id: payload.id,
+            tool: payload.tool,
+            error: { message: err.message }
+          };
+          socket.send(JSON.stringify(response));
+        }
+      });
+
+      socket.send(JSON.stringify({ type: 'ready' }));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(this.options.port, this.options.host ?? '0.0.0.0', () => {
+        server.off('error', reject);
+        this.started = true;
+        this.server = server;
+        this.wss = wss;
+        logger.info({ address: this.getAddress() }, 'Passerelle HTTP/WS demarree');
+        resolve();
+      });
+    });
+  }
+
+  public async stop(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+
+    const closeWebSocket = async (): Promise<void> => {
+      if (!this.wss) {
+        return;
+      }
+      const clients = Array.from(this.wss.clients);
+      clients.forEach((client) => {
+        try {
+          client.close();
+        } catch (error) {
+          logger.warn({ error }, "Erreur lors de la fermeture d'une connexion WebSocket");
+        }
+      });
+
+      await new Promise<void>((resolve) => {
+        this.wss?.close(() => resolve());
+      });
+    };
+
+    await closeWebSocket();
+
+    await new Promise<void>((resolve, reject) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+      this.server.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+
+    this.started = false;
+    this.server = undefined;
+    this.wss = undefined;
+  }
+
+  public getAddress(): AddressInfo | undefined {
+    const address = this.server?.address();
+    if (!address || typeof address === 'string') {
+      return undefined;
+    }
+    return address;
+  }
+
+  private createErrorHandler() {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    return (error: unknown, _req: Request, res: Response, _next: NextFunction): void => {
+      const err = error instanceof Error ? error : new Error('Erreur inconnue');
+      logger.error({ error: err }, "Erreur HTTP lors de l'appel d'un outil");
+      const status = err instanceof ToolNotFoundError ? 404 : 500;
+      res.status(status).json({
+        error: err.message
+      });
+    };
+  }
+}
+
+function createHttpGateway(registry: ToolRegistry, options: HttpGatewayOptions): HttpGateway {
+  return new HttpGateway(registry, options);
+}
+
+export { createHttpGateway, HttpGateway };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,75 +1,16 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createOscServiceFromEnv, OscService } from '../services/osc/index.js';
 import { initializeOscClient } from '../services/osc/client.js';
 import { ErrorCode, describeError, toAppError } from './errors.js';
 import { createLogger } from './logger.js';
 import { toolDefinitions } from '../tools/index.js';
 import { registerToolSchemas } from '../schemas/index.js';
-import type {
-  ToolDefinition,
-  ToolExecutionResult,
-  ToolMiddleware,
-  ToolContext
-} from '../tools/types.js';
+import type { ToolDefinition } from '../tools/types.js';
+import { createHttpGateway, type HttpGateway } from './httpGateway.js';
+import { ToolRegistry } from './toolRegistry.js';
 
 const logger = createLogger('mcp-server');
-
-class ToolRegistry {
-  private readonly registeredTools = new Map<string, ToolDefinition>();
-
-  constructor(private readonly server: McpServer) {}
-
-  public register(tool: ToolDefinition): void {
-    const callback = this.attachMiddlewares(tool) as ToolCallback;
-    this.server.registerTool(tool.name, tool.config as never, callback as never);
-    this.registeredTools.set(tool.name, tool);
-  }
-
-  public registerMany(tools: ToolDefinition[]): void {
-    tools.forEach((tool) => this.register(tool));
-    this.server.sendToolListChanged();
-  }
-
-  private attachMiddlewares(tool: ToolDefinition): ToolCallback {
-    const middlewares = tool.middlewares ?? [];
-    if (middlewares.length === 0) {
-      return tool.handler as ToolCallback;
-    }
-
-    return (async (args: unknown, extra: unknown) => {
-      const context: ToolContext = { name: tool.name, args, extra };
-
-      const executeHandler = (): Promise<ToolExecutionResult> =>
-        Promise.resolve(tool.handler(args as never, extra as never));
-
-      return this.compose(middlewares, executeHandler)(context);
-    }) as ToolCallback;
-  }
-
-  private compose(
-    middlewares: ToolMiddleware[],
-    handler: () => Promise<ToolExecutionResult>
-  ): ((context: ToolContext) => Promise<ToolExecutionResult>) {
-    return async (context: ToolContext): Promise<ToolExecutionResult> => {
-      let index = -1;
-      const dispatch = async (i: number): Promise<ToolExecutionResult> => {
-        if (i <= index) {
-          throw new Error('Le middleware a appele next() plusieurs fois');
-        }
-        index = i;
-        const middleware = middlewares[i];
-        if (!middleware) {
-          return handler();
-        }
-        return middleware(context, () => dispatch(i + 1));
-      };
-
-      return dispatch(0);
-    };
-  }
-}
 
 async function loadToolDefinitions(): Promise<ToolDefinition[]> {
   return toolDefinitions;
@@ -79,10 +20,15 @@ interface BootstrapContext {
   server: McpServer;
   registry: ToolRegistry;
   oscService: OscService;
+  gateway?: HttpGateway;
 }
 
 async function bootstrap(): Promise<BootstrapContext> {
-  const tcpPort = Number.parseInt(process.env.MCP_TCP_PORT ?? '3032', 10);
+  const tcpPortEnv = process.env.MCP_TCP_PORT;
+  const tcpPort = tcpPortEnv ? Number.parseInt(tcpPortEnv, 10) : undefined;
+  if (tcpPortEnv && Number.isNaN(tcpPort)) {
+    throw new Error(`La variable d'environnement MCP_TCP_PORT est invalide: ${tcpPortEnv}`);
+  }
   const oscService = createOscServiceFromEnv(createLogger('osc-service'));
   initializeOscClient(oscService);
 
@@ -91,7 +37,11 @@ async function bootstrap(): Promise<BootstrapContext> {
     version: '0.1.0'
   });
 
-  logger.info({ tcpPort }, `Port TCP MCP reserve sur ${tcpPort}`);
+  if (tcpPort) {
+    logger.info({ tcpPort }, `Passerelle HTTP/WS MCP activee sur ${tcpPort}`);
+  } else {
+    logger.info('Passerelle HTTP/WS MCP desactivee (MCP_TCP_PORT non defini).');
+  }
 
   const registry = new ToolRegistry(server);
   registerToolSchemas(server);
@@ -99,7 +49,15 @@ async function bootstrap(): Promise<BootstrapContext> {
   registry.registerMany(tools);
 
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  const connections: Array<Promise<void>> = [server.connect(transport)];
+
+  let gateway: HttpGateway | undefined;
+  if (tcpPort) {
+    gateway = createHttpGateway(registry, { port: tcpPort });
+    connections.push(gateway.start());
+  }
+
+  await Promise.all(connections);
 
   const handleShutdown = async (signal: NodeJS.Signals): Promise<void> => {
     logger.info({ signal }, 'Signal %s recu, fermeture du serveur MCP', signal);
@@ -111,6 +69,18 @@ async function bootstrap(): Promise<BootstrapContext> {
         message: `Erreur lors de la fermeture du serveur MCP apres ${signal}`
       });
       logger.error({ error: describeError(appError) }, appError.message);
+    }
+
+    if (gateway) {
+      try {
+        await gateway.stop();
+      } catch (error) {
+        const appError = toAppError(error, {
+          code: ErrorCode.MCP_STARTUP_FAILURE,
+          message: `Erreur lors de la fermeture de la passerelle HTTP apres ${signal}`
+        });
+        logger.error({ error: describeError(appError) }, appError.message);
+      }
     }
 
     try {
@@ -135,7 +105,7 @@ async function bootstrap(): Promise<BootstrapContext> {
     void handleShutdown('SIGTERM');
   });
 
-  return { server, registry, oscService };
+  return { server, registry, oscService, gateway };
 }
 
 if (require.main === module) {

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -1,0 +1,96 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type {
+  ToolDefinition,
+  ToolExecutionResult,
+  ToolMiddleware,
+  ToolContext
+} from '../tools/types.js';
+
+class ToolNotFoundError extends Error {
+  constructor(toolName: string, available: string[]) {
+    const hint =
+      available.length > 0
+        ? `Outils disponibles: ${available.join(', ')}`
+        : 'Aucun outil disponible';
+    super(`Outil inconnu "${toolName}". ${hint}`);
+    this.name = 'ToolNotFoundError';
+  }
+}
+
+class ToolRegistry {
+  private readonly registeredTools = new Map<string, ToolDefinition>();
+
+  private readonly registeredCallbacks = new Map<string, ToolCallback>();
+
+  constructor(private readonly server: McpServer) {}
+
+  public register(tool: ToolDefinition): void {
+    const callback = this.attachMiddlewares(tool) as ToolCallback;
+    this.server.registerTool(tool.name, tool.config as never, callback as never);
+    this.registeredTools.set(tool.name, tool);
+    this.registeredCallbacks.set(tool.name, callback);
+  }
+
+  public registerMany(tools: ToolDefinition[]): void {
+    tools.forEach((tool) => this.register(tool));
+    this.server.sendToolListChanged();
+  }
+
+  public listTools(): string[] {
+    return Array.from(this.registeredTools.keys());
+  }
+
+  public async invoke(
+    name: string,
+    args: unknown,
+    extra?: unknown
+  ): Promise<ToolExecutionResult> {
+    const callback = this.registeredCallbacks.get(name);
+    if (!callback) {
+      throw new ToolNotFoundError(name, this.listTools());
+    }
+
+    return (await callback(args as never, extra as never)) as ToolExecutionResult;
+  }
+
+  private attachMiddlewares(tool: ToolDefinition): ToolCallback {
+    const middlewares = tool.middlewares ?? [];
+    if (middlewares.length === 0) {
+      return tool.handler as ToolCallback;
+    }
+
+    return (async (args: unknown, extra: unknown) => {
+      const context: ToolContext = { name: tool.name, args, extra };
+
+      const executeHandler = (): Promise<ToolExecutionResult> =>
+        Promise.resolve(tool.handler(args as never, extra as never));
+
+      return this.compose(middlewares, executeHandler)(context);
+    }) as ToolCallback;
+  }
+
+  private compose(
+    middlewares: ToolMiddleware[],
+    handler: () => Promise<ToolExecutionResult>
+  ): ((context: ToolContext) => Promise<ToolExecutionResult>) {
+    return async (context: ToolContext): Promise<ToolExecutionResult> => {
+      let index = -1;
+      const dispatch = async (i: number): Promise<ToolExecutionResult> => {
+        if (i <= index) {
+          throw new Error('Le middleware a appele next() plusieurs fois');
+        }
+        index = i;
+        const middleware = middlewares[i];
+        if (!middleware) {
+          return handler();
+        }
+        return middleware(context, () => dispatch(i + 1));
+      };
+
+      return dispatch(0);
+    };
+  }
+}
+
+export { ToolRegistry, ToolNotFoundError };


### PR DESCRIPTION
## Summary
- add an optional HTTP and WebSocket gateway that forwards requests to the MCP ToolRegistry
- start the gateway when MCP_TCP_PORT is configured and shut it down gracefully with the server
- cover the gateway with integration tests and document the REST/WebSocket usage in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f66a43db34832ab1c354c62082c2df