### PR TITLE
Add OSC reconfiguration tooling

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -5,8 +5,6 @@
 
 Chaque outil expose son nom MCP, une description, la liste des arguments attendus ainsi qu'un exemple d'appel en CLI et par OSC.
 
-> Nouvelle passerelle HTTP/WS : définissez `MCP_TCP_PORT` pour appeler les outils via `POST /tools/:name` ou WebSocket (`/ws`).
-
 <a id="eos-address-select"></a>
 ## Selection d'adresse DMX (`eos_address_select`)
 
@@ -350,6 +348,33 @@ _OSC_
 # Exemple d'envoi OSC via oscsend
 oscsend 127.0.0.1 8001 /eos/cmd s:'{"template":"exemple"}'
 ```
+
+<a id="eos-configure"></a>
+## Reconfiguration OSC EOS (`eos_configure`)
+
+**Description :** Met a jour la configuration reseau OSC (ports, adresse) et recree le client partage.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `localPort` | number | Oui | — |
+| `remoteAddress` | string | Oui | — |
+| `remotePort` | number | Oui | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_configure --args '{"remoteAddress":"exemple","remotePort":1,"localPort":1}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
 
 <a id="eos-connect"></a>
 ## Connexion OSC EOS (`eos_connect`)

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -1070,10 +1070,15 @@ export class OscClient {
 }
 
 let sharedClient: OscClient | null = null;
+let sharedService: OscService | null = null;
+let sharedClientConfig: OscClientConfig = {};
 let cacheListenerDispose: (() => void) | null = null;
 
 export function initializeOscClient(service: OscService, config: OscClientConfig = {}): OscClient {
   cacheListenerDispose?.();
+  sharedService = service;
+  sharedClientConfig = { ...config };
+
   cacheListenerDispose = service.onMessage((message) => {
     getResourceCache().handleOscMessage(message);
   });
@@ -1082,12 +1087,29 @@ export function initializeOscClient(service: OscService, config: OscClientConfig
   return sharedClient;
 }
 
+export function resetOscClient(
+  service: OscService,
+  config: OscClientConfig = sharedClientConfig
+): OscClient {
+  setOscClient(null);
+  return initializeOscClient(service, config);
+}
+
 export function setOscClient(client: OscClient | null): void {
   sharedClient = client;
   if (client === null && cacheListenerDispose) {
     cacheListenerDispose();
     cacheListenerDispose = null;
   }
+}
+
+export function getOscService(): OscService {
+  if (!sharedService) {
+    throw new Error(
+      "Le service OSC n'est pas initialise. Appelez initializeOscClient avant d'utiliser les outils."
+    );
+  }
+  return sharedService;
 }
 
 export function getOscClient(): OscClient {

--- a/src/tools/connection/__tests__/eos_configure.test.ts
+++ b/src/tools/connection/__tests__/eos_configure.test.ts
@@ -1,0 +1,88 @@
+import { eosConfigureTool } from '../eos_configure';
+
+const mockReconfigure = jest.fn();
+const mockGetDiagnostics = jest.fn();
+
+jest.mock('../../../services/osc/client.js', () => ({
+  getOscService: jest.fn(() => ({
+    reconfigure: mockReconfigure
+  })),
+  resetOscClient: jest.fn(() => ({
+    getDiagnostics: mockGetDiagnostics
+  }))
+}));
+
+describe('eos_configure tool', () => {
+  const clientModule = jest.requireMock('../../../services/osc/client.js') as {
+    getOscService: jest.Mock;
+    resetOscClient: jest.Mock;
+  };
+
+  const serviceInstance = { reconfigure: mockReconfigure };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReconfigure.mockReset();
+    mockGetDiagnostics.mockReset();
+    clientModule.getOscService.mockReturnValue(serviceInstance);
+    clientModule.resetOscClient.mockReturnValue({
+      getDiagnostics: mockGetDiagnostics
+    });
+  });
+
+  it('valide les arguments, reconfigure le service et renvoie un resume', async () => {
+    mockReconfigure.mockResolvedValue(undefined);
+    const diagnostics = {
+      config: {
+        localAddress: '0.0.0.0',
+        localPort: 7001,
+        remoteAddress: '10.1.0.5',
+        remotePort: 9002
+      },
+      logging: { incoming: true, outgoing: false },
+      stats: {
+        incoming: { count: 1, bytes: 20, lastTimestamp: 1, lastMessage: null, addresses: [] },
+        outgoing: { count: 2, bytes: 40, lastTimestamp: 2, lastMessage: null, addresses: [] }
+      },
+      listeners: { active: 3 },
+      startedAt: 0,
+      uptimeMs: 1234
+    };
+    mockGetDiagnostics.mockReturnValue(diagnostics);
+
+    const result = await eosConfigureTool.handler({
+      remoteAddress: '10.1.0.5',
+      remotePort: 9002,
+      localPort: 7001
+    });
+
+    expect(clientModule.getOscService).toHaveBeenCalledTimes(1);
+    expect(mockReconfigure).toHaveBeenCalledWith({
+      remoteAddress: '10.1.0.5',
+      remotePort: 9002,
+      localPort: 7001
+    });
+    expect(clientModule.resetOscClient).toHaveBeenCalledWith(serviceInstance);
+    expect(clientModule.resetOscClient).toHaveBeenCalledTimes(1);
+    expect(mockGetDiagnostics).toHaveBeenCalledTimes(1);
+
+    expect(result.content).toHaveLength(2);
+    const [textContent, objectContent] = result.content;
+    if (textContent.type !== 'text') {
+      throw new Error('Le premier contenu doit etre du texte');
+    }
+    expect(textContent.text).toContain('10.1.0.5:9002');
+    expect(textContent.text).toContain('Local : 0.0.0.0:7001');
+
+    if (objectContent.type !== 'object') {
+      throw new Error('Le second contenu doit etre un objet');
+    }
+    expect(objectContent.data).toEqual({ diagnostics });
+  });
+
+  it('rejette les configurations invalides', async () => {
+    await expect(
+      eosConfigureTool.handler({ remoteAddress: '', remotePort: 0, localPort: 0 })
+    ).rejects.toThrow();
+  });
+});

--- a/src/tools/connection/eos_configure.ts
+++ b/src/tools/connection/eos_configure.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { getOscService, resetOscClient } from '../../services/osc/client.js';
+import type { ToolDefinition } from '../types.js';
+
+const inputSchema = {
+  remoteAddress: z.string().min(1, 'remoteAddress doit etre une adresse valide.'),
+  remotePort: z.number().int().min(1).max(65535),
+  localPort: z.number().int().min(1).max(65535)
+};
+
+/**
+ * @tool eos_configure
+ * @summary Reconfiguration OSC EOS
+ * @description Met a jour la configuration reseau OSC (ports, adresse) et recree le client partage.
+ * @arguments Voir docs/tools.md#eos-configure pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-configure pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-configure pour un exemple OSC.
+ */
+export const eosConfigureTool: ToolDefinition<typeof inputSchema> = {
+  name: 'eos_configure',
+  config: {
+    title: 'Reconfiguration OSC EOS',
+    description: 'Met a jour la configuration reseau OSC (ports, adresse) et recree le client partage.',
+    inputSchema
+  },
+  handler: async (args) => {
+    const schema = z.object(inputSchema).strict();
+    const options = schema.parse(args ?? {});
+
+    const service = getOscService();
+    await service.reconfigure(options);
+    const client = resetOscClient(service);
+    const diagnostics = client.getDiagnostics();
+
+    const remoteAddress = diagnostics.config.remoteAddress ?? 'non defini';
+    const remotePort = diagnostics.config.remotePort ?? 'non defini';
+
+    const summary = [
+      'Configuration OSC mise a jour :',
+      `  Local : ${diagnostics.config.localAddress}:${diagnostics.config.localPort}`,
+      `  Distant : ${remoteAddress}:${remotePort}`,
+      `  Journalisation : entrant ${diagnostics.logging.incoming ? 'active' : 'inactive'}, sortant ${
+        diagnostics.logging.outgoing ? 'active' : 'inactive'
+      }`,
+      `  Ecouteurs actifs : ${diagnostics.listeners.active}`
+    ].join('\n');
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: summary
+        },
+        {
+          type: 'object',
+          data: { diagnostics }
+        }
+      ]
+    };
+  }
+};
+
+export default eosConfigureTool;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 import eosConnectTool from './connection/eos_connect.js';
+import eosConfigureTool from './connection/eos_configure.js';
 import eosPingTool from './connection/eos_ping.js';
 import eosResetTool from './connection/eos_reset.js';
 import eosSubscribeTool from './connection/eos_subscribe.js';
@@ -32,6 +33,7 @@ import type { ToolDefinition } from './types.js';
 const definitions = [
   pingTool,
   eosConnectTool,
+  eosConfigureTool,
   eosPingTool,
   eosResetTool,
   eosSubscribeTool,


### PR DESCRIPTION
## Summary
- extend the OSC service with a reconfiguration routine that rebuilds the UDP port using new endpoints
- expose helpers to refresh the shared OSC client and add the `eos_configure` tool that validates input before reconfiguring
- document the new tool and add unit/functional tests covering service reconfiguration and the tool handler

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68f66d0e1a34832aa3fddaf95c899346