### PR TITLE
Add transport-aware OSC gateway with dynamic failover

### DIFF
--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -1,6 +1,6 @@
 import { ErrorCode } from '../../../server/errors';
 import { OscClient, type ConnectResult } from '../client';
-import type { OscGateway } from '../client';
+import type { OscGateway, OscGatewaySendOptions } from '../client';
 import type { OscMessage } from '../index';
 
 describe('OscClient', () => {
@@ -15,7 +15,7 @@ describe('OscClient', () => {
 
     public maxActiveSends = 0;
 
-    public async send(message: OscMessage, _targetAddress?: string, _targetPort?: number): Promise<void> {
+    public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
       this.activeSends += 1;
       this.maxActiveSends = Math.max(this.maxActiveSends, this.activeSends);
       this.sentMessages.push(message);

--- a/src/services/osc/gateway.ts
+++ b/src/services/osc/gateway.ts
@@ -1,0 +1,360 @@
+import osc from 'osc';
+import { createLogger } from '../../server/logger.js';
+import type {
+  OscDiagnostics,
+  OscLoggingOptions,
+  OscLoggingState,
+  OscMessage,
+  OscMessageArgument,
+  OscMessageSummary
+} from './index.js';
+import {
+  OscConnectionManager,
+  type OscConnectionManagerOptions,
+  type ToolTransportPreference,
+  type TransportStatus
+} from './connectionManager.js';
+import type { OscGateway, OscGatewaySendOptions } from './client.js';
+
+type Direction = 'incoming' | 'outgoing';
+
+interface DirectionStats {
+  count: number;
+  bytes: number;
+  lastTimestamp: number | null;
+  lastMessage: OscMessageSummary | null;
+  addresses: Map<string, { count: number; lastTimestamp: number | null }>;
+}
+
+export interface OscConnectionGatewayOptions extends OscConnectionManagerOptions {
+  metadata?: boolean;
+  localAddress?: string;
+  localPort?: number;
+}
+
+type StatusListener = (status: TransportStatus) => void;
+
+const DEFAULT_METADATA = true;
+
+function normaliseToolId(candidate: string | undefined, message: OscMessage): string {
+  if (candidate && candidate.trim().length > 0) {
+    return candidate;
+  }
+  return message.address;
+}
+
+function cloneArgs(args: OscMessageArgument[] | undefined): OscMessageArgument[] {
+  if (!Array.isArray(args)) {
+    return [];
+  }
+  return args.map((arg) => ({ ...arg }));
+}
+
+export class OscConnectionGateway implements OscGateway {
+  private manager: OscConnectionManager;
+
+  private readonly logger = createLogger('osc-gateway');
+
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  private readonly statusListeners = new Set<StatusListener>();
+
+  private readonly loggingState: OscLoggingState = { incoming: false, outgoing: false };
+
+  private readonly stats: Record<Direction, DirectionStats> = {
+    incoming: { count: 0, bytes: 0, lastTimestamp: null, lastMessage: null, addresses: new Map() },
+    outgoing: { count: 0, bytes: 0, lastTimestamp: null, lastMessage: null, addresses: new Map() }
+  };
+
+  private readonly startedAt = Date.now();
+
+  private metadata: boolean;
+
+  private readonly config: {
+    host: string;
+    tcpPort: number;
+    udpPort: number;
+    localAddress: string;
+    localPort: number;
+  };
+
+  constructor(options: OscConnectionGatewayOptions) {
+    this.metadata = options.metadata ?? DEFAULT_METADATA;
+    this.config = {
+      host: options.host,
+      tcpPort: options.tcpPort,
+      udpPort: options.udpPort,
+      localAddress: options.localAddress ?? '0.0.0.0',
+      localPort: options.localPort ?? 0
+    };
+
+    this.manager = this.createManager(options);
+    this.attachManagerEvents(this.manager);
+  }
+
+  public async send(message: OscMessage, options: OscGatewaySendOptions = {}): Promise<void> {
+    const toolId = normaliseToolId(options.toolId, message);
+    const encoded = this.encodeMessage(message);
+
+    if (options.transportPreference) {
+      this.setToolPreference(toolId, options.transportPreference);
+    }
+
+    try {
+      const transport = this.manager.send(toolId, encoded);
+      this.updateStats('outgoing', message, encoded.byteLength);
+      if (this.loggingState.outgoing) {
+        this.logger.debug(`[OSC][${transport}] -> ${message.address}`, message.args ?? []);
+      }
+    } catch (error) {
+      this.logger.error({ address: message.address }, "Erreur lors de l'envoi OSC", error);
+      throw error;
+    }
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public onStatus(listener: StatusListener): () => void {
+    this.statusListeners.add(listener);
+    return () => {
+      this.statusListeners.delete(listener);
+    };
+  }
+
+  public setLoggingOptions(options: OscLoggingOptions): OscLoggingState {
+    if (typeof options.incoming === 'boolean') {
+      this.loggingState.incoming = options.incoming;
+    }
+    if (typeof options.outgoing === 'boolean') {
+      this.loggingState.outgoing = options.outgoing;
+    }
+
+    this.logger.info(
+      `Logging mis a jour - entrant: ${this.loggingState.incoming ? 'active' : 'inactive'}, sortant: ${
+        this.loggingState.outgoing ? 'active' : 'inactive'
+      }`
+    );
+
+    return { ...this.loggingState };
+  }
+
+  public getDiagnostics(): OscDiagnostics {
+    const now = Date.now();
+    return {
+      config: {
+        localAddress: this.config.localAddress,
+        localPort: this.config.localPort,
+        remoteAddress: this.config.host,
+        remotePort: this.config.udpPort
+      },
+      logging: { ...this.loggingState },
+      stats: {
+        incoming: this.serialiseDirectionStats(this.stats.incoming),
+        outgoing: this.serialiseDirectionStats(this.stats.outgoing)
+      },
+      listeners: {
+        active: this.listeners.size
+      },
+      startedAt: this.startedAt,
+      uptimeMs: now - this.startedAt
+    };
+  }
+
+  public setToolPreference(toolId: string, preference: ToolTransportPreference): void {
+    this.manager.setToolPreference(toolId, preference);
+  }
+
+  public getToolPreference(toolId: string): ToolTransportPreference {
+    return this.manager.getToolPreference(toolId);
+  }
+
+  public removeTool(toolId: string): void {
+    this.manager.removeTool(toolId);
+  }
+
+  public close(): void {
+    this.detachManagerEvents(this.manager);
+    this.manager.stop();
+    this.listeners.clear();
+    this.statusListeners.clear();
+  }
+
+  public reconfigure(options: OscConnectionGatewayOptions): void {
+    this.close();
+    this.config.host = options.host;
+    this.config.tcpPort = options.tcpPort;
+    this.config.udpPort = options.udpPort;
+    this.config.localAddress = options.localAddress ?? this.config.localAddress;
+    this.config.localPort = options.localPort ?? this.config.localPort;
+    this.metadata = options.metadata ?? this.metadata;
+
+    this.manager = this.createManager(options);
+    this.attachManagerEvents(this.manager);
+  }
+
+  private createManager(options: OscConnectionGatewayOptions): OscConnectionManager {
+    const { metadata: _metadata, localAddress: _localAddress, localPort: _localPort, ...rest } = options;
+    return new OscConnectionManager(rest);
+  }
+
+  private attachManagerEvents(manager: OscConnectionManager): void {
+    manager.on('message', ({ type, data }) => {
+      const message = this.decodeMessage(data);
+      if (!message) {
+        this.logger.error('[OSC] Message recu dans un format inattendu');
+        return;
+      }
+
+      this.updateStats('incoming', message, data.byteLength ?? data.length ?? 0);
+      if (this.loggingState.incoming) {
+        this.logger.debug(`[OSC][${type}] <- ${message.address}`, message.args ?? []);
+      }
+
+      this.listeners.forEach((listener) => {
+        try {
+          listener(message);
+        } catch (error) {
+          this.logger.error('[OSC] Erreur lors du traitement du message', error);
+        }
+      });
+    });
+
+    manager.on('status', (status) => {
+      this.statusListeners.forEach((listener) => {
+        try {
+          listener(status);
+        } catch (error) {
+          this.logger.error('[OSC] Erreur lors de la notification de statut', error);
+        }
+      });
+    });
+  }
+
+  private detachManagerEvents(manager: OscConnectionManager): void {
+    manager.removeAllListeners('message');
+    manager.removeAllListeners('status');
+  }
+
+  private encodeMessage(message: OscMessage): Buffer {
+    const packet = {
+      address: message.address,
+      args: cloneArgs(message.args)
+    };
+
+    const encoded = osc.writePacket(packet, { metadata: this.metadata }) as Uint8Array;
+    return Buffer.from(encoded);
+  }
+
+  private decodeMessage(data: Buffer): OscMessage | null {
+    let packet: unknown;
+    try {
+      packet = osc.readPacket(data, { metadata: this.metadata });
+    } catch (error) {
+      this.logger.error('[OSC] Impossible de decoder le paquet OSC', error);
+      return null;
+    }
+
+    if (!packet || typeof packet !== 'object') {
+      return null;
+    }
+
+    const message = packet as Partial<OscMessage> & { packets?: unknown[]; type?: string };
+    if (typeof message.address !== 'string') {
+      if (Array.isArray(message.packets) && message.packets.length > 0) {
+        const first = message.packets[0] as Partial<OscMessage>;
+        if (first && typeof first.address === 'string') {
+          return {
+            address: first.address,
+            args: cloneArgs(first.args ?? [])
+          };
+        }
+      }
+      return null;
+    }
+
+    return {
+      address: message.address,
+      args: cloneArgs(message.args ?? [])
+    };
+  }
+
+  private updateStats(direction: Direction, message: OscMessage, bytes: number): void {
+    const stats = this.stats[direction];
+    stats.count += 1;
+    stats.lastTimestamp = Date.now();
+    stats.lastMessage = this.createMessageSummary(message);
+    stats.bytes += bytes;
+
+    const addressStats = stats.addresses.get(message.address) ?? { count: 0, lastTimestamp: null };
+    addressStats.count += 1;
+    addressStats.lastTimestamp = stats.lastTimestamp;
+    stats.addresses.set(message.address, addressStats);
+  }
+
+  private createMessageSummary(message: OscMessage): OscMessageSummary {
+    return {
+      address: message.address,
+      args: cloneArgs(message.args)
+    };
+  }
+
+  private serialiseDirectionStats(stats: DirectionStats) {
+    const addresses = Array.from(stats.addresses.entries())
+      .map(([address, data]) => ({
+        address,
+        count: data.count,
+        lastTimestamp: data.lastTimestamp
+      }))
+      .sort((a, b) => b.count - a.count || (b.lastTimestamp ?? 0) - (a.lastTimestamp ?? 0));
+
+    return {
+      count: stats.count,
+      bytes: stats.bytes,
+      lastTimestamp: stats.lastTimestamp,
+      lastMessage: stats.lastMessage,
+      addresses
+    };
+  }
+}
+
+export function createOscConnectionGateway(options: OscConnectionGatewayOptions): OscConnectionGateway {
+  return new OscConnectionGateway(options);
+}
+
+function parsePort(value: string | undefined, fallback: number, label: string): number {
+  const parsed = Number.parseInt(value ?? String(fallback), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`La valeur du port ${label} est invalide: ${value}`);
+  }
+  return parsed;
+}
+
+export function createOscGatewayFromEnv(
+  options: Partial<
+    Pick<
+      OscConnectionManagerOptions,
+      'logger' | 'heartbeatIntervalMs' | 'reconnectDelayMs' | 'connectionTimeoutMs'
+    >
+  > = {}
+): OscConnectionGateway {
+  const host = process.env.OSC_REMOTE_ADDRESS ?? '127.0.0.1';
+  const tcpPort = parsePort(process.env.OSC_TCP_PORT, 3032, 'OSC_TCP_PORT');
+  const udpPort = parsePort(process.env.OSC_UDP_OUT_PORT, 8001, 'OSC_UDP_OUT_PORT');
+  const localPort = parsePort(process.env.OSC_UDP_IN_PORT, 8000, 'OSC_UDP_IN_PORT');
+
+  return createOscConnectionGateway({
+    host,
+    tcpPort,
+    udpPort,
+    localPort,
+    logger: options.logger,
+    heartbeatIntervalMs: options.heartbeatIntervalMs,
+    reconnectDelayMs: options.reconnectDelayMs,
+    connectionTimeoutMs: options.connectionTimeoutMs
+  });
+}

--- a/src/services/osc/index.ts
+++ b/src/services/osc/index.ts
@@ -331,3 +331,9 @@ export {
   type TransportStatus,
   type TransportType
 } from './connectionManager.js';
+export {
+  OscConnectionGateway,
+  createOscConnectionGateway,
+  type OscConnectionGatewayOptions,
+  createOscGatewayFromEnv
+} from './gateway.js';

--- a/src/tools/channels/__tests__/channels.test.ts
+++ b/src/tools/channels/__tests__/channels.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosChannelSetLevelTool,
@@ -12,7 +12,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/commands/__tests__/command_tools.test.ts
+++ b/src/tools/commands/__tests__/command_tools.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import {
   eosCommandTool,
   eosNewCommandTool,
@@ -14,7 +14,7 @@ describe('command tools', () => {
 
     private readonly listeners = new Set<(message: OscMessage) => void>();
 
-    public async send(message: OscMessage, _targetAddress?: string, _targetPort?: number): Promise<void> {
+    public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
       this.sentMessages.push(message);
     }
 

--- a/src/tools/connection/eos_connect.ts
+++ b/src/tools/connection/eos_connect.ts
@@ -8,7 +8,8 @@ const inputSchema = {
   preferredProtocols: z.array(z.string().min(1)).min(1).optional(),
   handshakeTimeoutMs: z.number().int().positive().optional(),
   protocolTimeoutMs: z.number().int().positive().optional(),
-  clientId: z.string().min(1).optional()
+  clientId: z.string().min(1).optional(),
+  transportPreference: z.enum(['reliability', 'speed', 'auto']).optional()
 };
 
 /**
@@ -31,7 +32,12 @@ export const eosConnectTool: ToolDefinition<typeof inputSchema> = {
     const schema = z.object(inputSchema).strict();
     const options = schema.parse(args ?? {});
     const client = getOscClient();
-    const result = await client.connect(options);
+    const { transportPreference, ...connectOptions } = options;
+    const result = await client.connect({
+      ...connectOptions,
+      toolId: 'eos_connect',
+      transportPreference
+    });
 
     const summaryParts = [
       `Handshake: ${result.status}`,

--- a/src/tools/connection/eos_ping.ts
+++ b/src/tools/connection/eos_ping.ts
@@ -7,7 +7,8 @@ const inputSchema = {
   message: z.string().min(1).optional(),
   timeoutMs: optionalTimeoutMsSchema,
   targetAddress: z.string().min(1).optional(),
-  targetPort: optionalPortSchema
+  targetPort: optionalPortSchema,
+  transportPreference: z.enum(['reliability', 'speed', 'auto']).optional()
 };
 
 /**
@@ -30,7 +31,12 @@ export const eosPingTool: ToolDefinition<typeof inputSchema> = {
     const schema = z.object(inputSchema).strict();
     const options = schema.parse(args ?? {});
     const client = getOscClient();
-    const result = await client.ping(options);
+    const { transportPreference, ...pingOptions } = options;
+    const result = await client.ping({
+      ...pingOptions,
+      toolId: 'eos_ping',
+      transportPreference
+    });
 
     const lines = [
       `Ping: ${result.status}`,

--- a/src/tools/connection/eos_reset.ts
+++ b/src/tools/connection/eos_reset.ts
@@ -6,7 +6,8 @@ const inputSchema = {
   full: z.boolean().optional(),
   timeoutMs: z.number().int().positive().optional(),
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.number().int().min(1).max(65535).optional(),
+  transportPreference: z.enum(['reliability', 'speed', 'auto']).optional()
 };
 
 /**
@@ -29,7 +30,12 @@ export const eosResetTool: ToolDefinition<typeof inputSchema> = {
     const schema = z.object(inputSchema).strict();
     const options = schema.parse(args ?? {});
     const client = getOscClient();
-    const result = await client.reset(options);
+    const { transportPreference, ...resetOptions } = options;
+    const result = await client.reset({
+      ...resetOptions,
+      toolId: 'eos_reset',
+      transportPreference
+    });
 
     const lines = [`Reset: ${result.status}`];
     if (options.full) {

--- a/src/tools/connection/eos_subscribe.ts
+++ b/src/tools/connection/eos_subscribe.ts
@@ -8,7 +8,8 @@ const inputSchema = {
   rateHz: z.number().positive().optional(),
   timeoutMs: z.number().int().positive().optional(),
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.number().int().min(1).max(65535).optional(),
+  transportPreference: z.enum(['reliability', 'speed', 'auto']).optional()
 };
 
 /**
@@ -31,7 +32,12 @@ export const eosSubscribeTool: ToolDefinition<typeof inputSchema> = {
     const schema = z.object(inputSchema).strict();
     const options = schema.parse(args ?? {});
     const client = getOscClient();
-    const result = await client.subscribe(options);
+    const { transportPreference, ...subscribeOptions } = options;
+    const result = await client.subscribe({
+      ...subscribeOptions,
+      toolId: 'eos_subscribe',
+      transportPreference
+    });
 
     const lines = [
       `Souscription: ${result.status}`,

--- a/src/tools/cues/__tests__/cues.test.ts
+++ b/src/tools/cues/__tests__/cues.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosCueGoTool,
@@ -14,7 +14,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/curves/__tests__/curves.test.ts
+++ b/src/tools/curves/__tests__/curves.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosCurveGetInfoTool, eosCurveSelectTool } from '../index';
 
@@ -10,7 +10,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/directSelects/__tests__/directSelects.test.ts
+++ b/src/tools/directSelects/__tests__/directSelects.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   __resetDirectSelectBankCacheForTests,
@@ -13,7 +13,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/dmx/__tests__/dmx.test.ts
+++ b/src/tools/dmx/__tests__/dmx.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosAddressSelectTool,
@@ -14,7 +14,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/effects/__tests__/effects.test.ts
+++ b/src/tools/effects/__tests__/effects.test.ts
@@ -1,6 +1,6 @@
 import { ZodError } from 'zod';
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosEffectGetInfoTool,
@@ -15,7 +15,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/faders/__tests__/faders.test.ts
+++ b/src/tools/faders/__tests__/faders.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   __resetFaderBankCacheForTests,
@@ -15,7 +15,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/fpe/__tests__/fpe.test.ts
+++ b/src/tools/fpe/__tests__/fpe.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosFpeGetSetCountTool,
@@ -16,7 +16,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/groups/__tests__/groups.test.ts
+++ b/src/tools/groups/__tests__/groups.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { getResourceCache } from '../../../services/cache/index';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
@@ -14,7 +14,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/keys/__tests__/keys.test.ts
+++ b/src/tools/keys/__tests__/keys.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import {
   eosGetSoftkeyLabelsTool,
   eosKeyPressTool,
@@ -12,7 +12,7 @@ describe('key tools', () => {
 
     private readonly listeners = new Set<(message: OscMessage) => void>();
 
-    public async send(message: OscMessage): Promise<void> {
+    public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
       this.sentMessages.push(message);
     }
 

--- a/src/tools/macros/__tests__/macros.test.ts
+++ b/src/tools/macros/__tests__/macros.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosMacroFireTool,
@@ -14,7 +14,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/magicSheets/__tests__/magicSheets.test.ts
+++ b/src/tools/magicSheets/__tests__/magicSheets.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosMagicSheetGetInfoTool,
@@ -14,7 +14,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/palettes/__tests__/palettes.test.ts
+++ b/src/tools/palettes/__tests__/palettes.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosBeamPaletteFireTool,
@@ -16,7 +16,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/parameters/__tests__/parameters.test.ts
+++ b/src/tools/parameters/__tests__/parameters.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosGetActiveWheelsTool,
@@ -18,7 +18,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/patch/__tests__/patch.test.ts
+++ b/src/tools/patch/__tests__/patch.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosPatchGetAugment3dBeamTool,
@@ -16,7 +16,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/pixelMaps/__tests__/pixelMaps.test.ts
+++ b/src/tools/pixelMaps/__tests__/pixelMaps.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosPixmapGetInfoTool, eosPixmapSelectTool } from '../index';
 import largePixmapFixture from './fixtures/pixmap-large.json';
@@ -13,7 +13,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/presets/__tests__/presets.test.ts
+++ b/src/tools/presets/__tests__/presets.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosPresetFireTool,
@@ -12,7 +12,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/queries/__tests__/queries.test.ts
+++ b/src/tools/queries/__tests__/queries.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosGetCountTool, eosGetListAllTool } from '../index';
 
@@ -8,7 +8,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/showControl/__tests__/showControl.test.ts
+++ b/src/tools/showControl/__tests__/showControl.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosGetShowNameTool,
@@ -16,7 +16,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/snapshots/__tests__/snapshots.test.ts
+++ b/src/tools/snapshots/__tests__/snapshots.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosSnapshotGetInfoTool, eosSnapshotRecallTool } from '../index';
 
@@ -10,7 +10,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 

--- a/src/tools/submasters/__tests__/submasters.test.ts
+++ b/src/tools/submasters/__tests__/submasters.test.ts
@@ -1,5 +1,5 @@
 import type { OscMessage } from '../../../services/osc/index';
-import { OscClient, setOscClient, type OscGateway } from '../../../services/osc/client';
+import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosSubmasterSetLevelTool,
@@ -12,7 +12,7 @@ class FakeOscService implements OscGateway {
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
-  public async send(message: OscMessage): Promise<void> {
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
     this.sentMessages.push(message);
   }
 


### PR DESCRIPTION
## Summary
- add an OSC connection gateway that wraps the connection manager to encode/decode packets and expose status events
- update the OSC client initialization, connection tools, and shared test fakes to support transport preferences and the new gateway
- add integration coverage for transport failover while keeping the existing suite green

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f670c61ad4832a87392f8f6171863e