### PR TITLE
Add zod-based configuration validation

### DIFF
--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -1,0 +1,63 @@
+import { resolve } from 'node:path';
+import { loadConfig, type AppConfig } from '../../config/index.js';
+
+describe('configuration', () => {
+  it('fournit des valeurs par défaut cohérentes lorsque aucune variable est définie', () => {
+    const config = loadConfig({} as NodeJS.ProcessEnv);
+
+    const expected: AppConfig = {
+      mcp: {
+        tcpPort: undefined
+      },
+      osc: {
+        remoteAddress: '127.0.0.1',
+        tcpPort: 3032,
+        udpOutPort: 8001,
+        udpInPort: 8000,
+        localAddress: '0.0.0.0'
+      },
+      logging: {
+        level: 'info',
+        filePath: resolve(process.cwd(), 'logs/mcp-server.log')
+      }
+    };
+
+    expect(config).toEqual(expected);
+  });
+
+  it('valide et normalise les variables fournies', () => {
+    const env: NodeJS.ProcessEnv = {
+      MCP_TCP_PORT: '9000',
+      OSC_REMOTE_ADDRESS: '192.168.1.10',
+      OSC_TCP_PORT: '4000',
+      OSC_UDP_OUT_PORT: '4001',
+      OSC_UDP_IN_PORT: '4002',
+      OSC_LOCAL_ADDRESS: '192.168.1.2',
+      LOG_LEVEL: 'DEBUG',
+      MCP_LOG_FILE: 'var/log/eos-mcp.log'
+    };
+
+    const config = loadConfig(env);
+
+    expect(config.mcp.tcpPort).toBe(9000);
+    expect(config.osc).toEqual({
+      remoteAddress: '192.168.1.10',
+      tcpPort: 4000,
+      udpOutPort: 4001,
+      udpInPort: 4002,
+      localAddress: '192.168.1.2'
+    });
+    expect(config.logging.level).toBe('debug');
+    expect(config.logging.filePath).toBe(resolve(process.cwd(), 'var/log/eos-mcp.log'));
+  });
+
+  it('rejette les ports invalides avec un message explicite', () => {
+    const env: NodeJS.ProcessEnv = {
+      OSC_TCP_PORT: 'not-a-number'
+    };
+
+    expect(() => loadConfig(env)).toThrow(
+      /OSC_TCP_PORT doit être un entier entre 1 et 65535/
+    );
+  });
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,239 @@
+import { resolve } from 'node:path';
+import { z } from 'zod';
+
+const DEFAULT_LOG_FILE = 'logs/mcp-server.log';
+const DEFAULT_OSC_REMOTE_ADDRESS = '127.0.0.1';
+const DEFAULT_OSC_LOCAL_ADDRESS = '0.0.0.0';
+const DEFAULT_OSC_TCP_PORT = 3032;
+const DEFAULT_OSC_UDP_OUT_PORT = 8001;
+const DEFAULT_OSC_UDP_IN_PORT = 8000;
+const DEFAULT_LOG_LEVEL = 'info';
+
+const LOG_LEVELS = ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'] as const;
+
+export type LogLevel = (typeof LOG_LEVELS)[number];
+
+/**
+ * Configuration spécifique au serveur MCP.
+ */
+export interface McpConfig {
+  /**
+   * Port TCP utilisé par le serveur MCP. Lorsque non défini, seule la communication stdio est active.
+   */
+  readonly tcpPort?: number;
+}
+
+/**
+ * Configuration des connexions OSC sortantes et entrantes.
+ */
+export interface OscConfig {
+  /** Adresse distante du serveur OSC. */
+  readonly remoteAddress: string;
+  /** Port TCP distant utilisé pour la négociation avec le serveur OSC. */
+  readonly tcpPort: number;
+  /** Port UDP distant utilisé pour l'envoi des messages OSC. */
+  readonly udpOutPort: number;
+  /** Port UDP local utilisé pour recevoir les messages OSC. */
+  readonly udpInPort: number;
+  /** Adresse locale à laquelle écouter pour les messages OSC entrants. */
+  readonly localAddress: string;
+}
+
+/**
+ * Configuration du système de logs applicatif.
+ */
+export interface LoggingConfig {
+  /** Niveau de log conforme aux niveaux supportés par Pino. */
+  readonly level: LogLevel;
+  /** Chemin absolu du fichier de log MCP. */
+  readonly filePath: string;
+}
+
+/**
+ * Configuration applicative complète, validée et normalisée.
+ */
+export interface AppConfig {
+  readonly mcp: McpConfig;
+  readonly osc: OscConfig;
+  readonly logging: LoggingConfig;
+}
+
+interface PortSchemaOptions {
+  readonly defaultValue?: number;
+  readonly optional?: boolean;
+}
+
+function createPortSchema(
+  variableName: string,
+  { defaultValue, optional = false }: PortSchemaOptions
+): z.ZodEffects<z.ZodUnknown, number | undefined, unknown> {
+  return z.unknown().transform((value, ctx) => {
+    if (value === undefined || value === null) {
+      if (defaultValue !== undefined) {
+        return defaultValue;
+      }
+      if (optional) {
+        return undefined;
+      }
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `La variable d'environnement ${variableName} est requise.`
+      });
+      return z.NEVER;
+    }
+
+    const raw = typeof value === 'string' ? value.trim() : String(value);
+    if (raw.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `La variable d'environnement ${variableName} ne peut pas être vide.`
+      });
+      return z.NEVER;
+    }
+
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 1 || parsed > 65535) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `La variable d'environnement ${variableName} doit être un entier entre 1 et 65535 (reçu: ${raw}).`
+      });
+      return z.NEVER;
+    }
+
+    return parsed;
+  });
+}
+
+function createAddressSchema(
+  variableName: string,
+  defaultValue: string
+): z.ZodEffects<z.ZodUnknown, string, unknown> {
+  return z.unknown().transform((value, ctx) => {
+    if (value === undefined || value === null) {
+      return defaultValue;
+    }
+
+    const raw = typeof value === 'string' ? value.trim() : String(value).trim();
+    if (raw.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `La variable d'environnement ${variableName} ne peut pas être vide.`
+      });
+      return z.NEVER;
+    }
+
+    return raw;
+  });
+}
+
+function createLogLevelSchema(
+  variableName: string,
+  defaultValue: LogLevel
+): z.ZodEffects<z.ZodUnknown, LogLevel, unknown> {
+  return z.unknown().transform((value, ctx) => {
+    if (value === undefined || value === null) {
+      return defaultValue;
+    }
+
+    const raw = typeof value === 'string' ? value.trim() : String(value).trim();
+    if (raw.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `La variable d'environnement ${variableName} ne peut pas être vide.`
+      });
+      return z.NEVER;
+    }
+
+    const normalised = raw.toLowerCase() as LogLevel;
+    if (!LOG_LEVELS.includes(normalised)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `La variable d'environnement ${variableName} doit être l'une des valeurs suivantes: ${LOG_LEVELS.join(', ')}.`
+      });
+      return z.NEVER;
+    }
+
+    return normalised;
+  });
+}
+
+function createLogFileSchema(
+  variableName: string,
+  defaultValue: string
+): z.ZodEffects<z.ZodUnknown, string, unknown> {
+  return z.unknown().transform((value, ctx) => {
+    if (value === undefined || value === null) {
+      return resolve(process.cwd(), defaultValue);
+    }
+
+    const raw = typeof value === 'string' ? value.trim() : String(value).trim();
+    if (raw.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `La variable d'environnement ${variableName} ne peut pas être vide.`
+      });
+      return z.NEVER;
+    }
+
+    return resolve(process.cwd(), raw);
+  });
+}
+
+const configSchema = z
+  .object({
+    mcpTcpPort: createPortSchema('MCP_TCP_PORT', { optional: true }),
+    oscTcpPort: createPortSchema('OSC_TCP_PORT', { defaultValue: DEFAULT_OSC_TCP_PORT }),
+    oscUdpOutPort: createPortSchema('OSC_UDP_OUT_PORT', { defaultValue: DEFAULT_OSC_UDP_OUT_PORT }),
+    oscUdpInPort: createPortSchema('OSC_UDP_IN_PORT', { defaultValue: DEFAULT_OSC_UDP_IN_PORT }),
+    oscRemoteAddress: createAddressSchema('OSC_REMOTE_ADDRESS', DEFAULT_OSC_REMOTE_ADDRESS),
+    oscLocalAddress: createAddressSchema('OSC_LOCAL_ADDRESS', DEFAULT_OSC_LOCAL_ADDRESS),
+    logLevel: createLogLevelSchema('LOG_LEVEL', DEFAULT_LOG_LEVEL),
+    logFilePath: createLogFileSchema('MCP_LOG_FILE', DEFAULT_LOG_FILE)
+  })
+  .transform((values): AppConfig => ({
+    mcp: {
+      tcpPort: values.mcpTcpPort
+    },
+    osc: {
+      remoteAddress: values.oscRemoteAddress,
+      tcpPort: values.oscTcpPort,
+      udpOutPort: values.oscUdpOutPort,
+      udpInPort: values.oscUdpInPort,
+      localAddress: values.oscLocalAddress
+    },
+    logging: {
+      level: values.logLevel,
+      filePath: values.logFilePath
+    }
+  } satisfies AppConfig));
+
+/**
+ * Valide et normalise la configuration de l'application à partir des variables d'environnement.
+ * @param env Variables d'environnement à valider. Utilise `process.env` par défaut.
+ * @throws {Error} Lorsque une ou plusieurs variables sont invalides.
+ */
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
+  const result = configSchema.safeParse({
+    mcpTcpPort: env.MCP_TCP_PORT,
+    oscTcpPort: env.OSC_TCP_PORT,
+    oscUdpOutPort: env.OSC_UDP_OUT_PORT,
+    oscUdpInPort: env.OSC_UDP_IN_PORT,
+    oscRemoteAddress: env.OSC_REMOTE_ADDRESS,
+    oscLocalAddress: env.OSC_LOCAL_ADDRESS,
+    logLevel: env.LOG_LEVEL,
+    logFilePath: env.MCP_LOG_FILE
+  });
+
+  if (!result.success) {
+    const message = result.error.errors.map((issue) => `- ${issue.message}`).join('\n');
+    throw new Error(`Configuration invalide:\n${message}`);
+  }
+
+  return result.data;
+}
+
+/**
+ * Configuration applicative validée et prête à l'emploi.
+ * Les valeurs sont évaluées une seule fois au chargement du module.
+ */
+export const config: AppConfig = loadConfig();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { config } from '../config/index.js';
 import { createOscGatewayFromEnv, OscConnectionGateway } from '../services/osc/index.js';
 import { initializeOscClient } from '../services/osc/client.js';
 import { ErrorCode, describeError, toAppError } from './errors.js';
@@ -24,11 +25,7 @@ interface BootstrapContext {
 }
 
 async function bootstrap(): Promise<BootstrapContext> {
-  const tcpPortEnv = process.env.MCP_TCP_PORT;
-  const tcpPort = tcpPortEnv ? Number.parseInt(tcpPortEnv, 10) : undefined;
-  if (tcpPortEnv && Number.isNaN(tcpPort)) {
-    throw new Error(`La variable d'environnement MCP_TCP_PORT est invalide: ${tcpPortEnv}`);
-  }
+  const tcpPort = config.mcp.tcpPort;
   const oscGateway = createOscGatewayFromEnv({ logger: createLogger('osc-gateway') });
   initializeOscClient(oscGateway);
 

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -1,15 +1,14 @@
 import { mkdirSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname } from 'node:path';
 import pino, { stdTimeFunctions, type Logger } from 'pino';
+import { config } from '../config/index.js';
 
-const DEFAULT_LOG_FILE = 'logs/mcp-server.log';
-
-const logFilePath = resolve(process.cwd(), process.env.MCP_LOG_FILE ?? DEFAULT_LOG_FILE);
+const logFilePath = config.logging.filePath;
 mkdirSync(dirname(logFilePath), { recursive: true });
 
 const baseLogger: Logger = pino(
   {
-    level: process.env.LOG_LEVEL ?? 'info',
+    level: config.logging.level,
     base: undefined,
     timestamp: stdTimeFunctions.isoTime
   },

--- a/src/services/osc/index.ts
+++ b/src/services/osc/index.ts
@@ -1,5 +1,6 @@
 import { UDPPort } from 'osc';
 import type { Logger } from 'pino';
+import { config, type OscConfig as ResolvedOscConfig } from '../../config/index.js';
 import { createLogger } from '../../server/logger.js';
 
 export interface OscMessageArgument {
@@ -311,17 +312,18 @@ export class OscService {
   }
 }
 
-export function createOscServiceFromEnv(logger?: OscLogger): OscService {
-  const localPort = Number.parseInt(process.env.OSC_UDP_IN_PORT ?? '8000', 10);
-  const remotePort = Number.parseInt(process.env.OSC_UDP_OUT_PORT ?? '8001', 10);
-  const remoteAddress = process.env.OSC_REMOTE_ADDRESS ?? '127.0.0.1';
-
+export function createOscServiceFromConfig(oscConfig: ResolvedOscConfig, logger?: OscLogger): OscService {
   return new OscService({
-    localPort,
-    remotePort,
-    remoteAddress,
+    localAddress: oscConfig.localAddress,
+    localPort: oscConfig.udpInPort,
+    remoteAddress: oscConfig.remoteAddress,
+    remotePort: oscConfig.udpOutPort,
     logger
   });
+}
+
+export function createOscServiceFromEnv(logger?: OscLogger): OscService {
+  return createOscServiceFromConfig(config.osc, logger);
 }
 
 export {
@@ -334,6 +336,7 @@ export {
 export {
   OscConnectionGateway,
   createOscConnectionGateway,
+  createOscGatewayFromConfig,
   type OscConnectionGatewayOptions,
   createOscGatewayFromEnv
 } from './gateway.js';


### PR DESCRIPTION
## Summary
- introduce a typed configuration module backed by zod to validate MCP, OSC and logging environment variables
- update the server bootstrap, OSC services and logger to consume the shared configuration values
- add unit coverage to verify default values and validation failures for the configuration module

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f67a71aba0832ab2d06f52898558ae