### PR TITLE
feat(server): expose package version and document bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ node --version
 
 La description détaillée de chaque outil est disponible dans [`docs/tools.md`](docs/tools.md). Le fichier est généré automatiquement à partir des schémas Zod déclarés dans `src/tools/**`.
 
+La procédure de mise à jour de version du serveur est documentée dans [`docs/versioning.md`](docs/versioning.md).
+
 ## Configuration réseau et de la console Eos
 
 | Protocole | Port | Description |

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,15 @@
+# Gestion des versions du serveur MCP
+
+Le serveur MCP expose désormais sa version directement depuis le `package.json` grâce à l'utilitaire `getPackageVersion`. Cela garantit que les clients reçoivent la même valeur que celle publiée sur npm.
+
+## Mettre à jour la version
+
+1. Utiliser `npm version <patch|minor|major>` (ou mettre à jour la clé `version` du `package.json` manuellement si besoin).
+2. Vérifier que la modification est cohérente avec le changelog ou les notes de version associées.
+3. Lancer la suite de tests pour s'assurer que l'initialisation du serveur continue de fonctionner :
+   ```bash
+   npm test
+   ```
+4. Commiter les changements (`package.json`, `package-lock.json`, documentation, etc.) et publier la nouvelle version si nécessaire.
+
+Aucune autre mise à jour de code n'est requise : le serveur lira automatiquement la nouvelle version lors du démarrage.

--- a/src/server/__tests__/serverVersion.test.ts
+++ b/src/server/__tests__/serverVersion.test.ts
@@ -1,0 +1,87 @@
+import { jest } from '@jest/globals';
+import { getPackageVersion } from '../../utils/version.js';
+
+const mockConnect = jest.fn().mockResolvedValue(undefined);
+const mockClose = jest.fn().mockResolvedValue(undefined);
+const mockRegisterTool = jest.fn();
+const mockSendToolListChanged = jest.fn();
+
+const MockMcpServer = jest.fn().mockImplementation(() => ({
+  connect: mockConnect,
+  close: mockClose,
+  registerTool: mockRegisterTool,
+  sendToolListChanged: mockSendToolListChanged
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: MockMcpServer
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock('../../config/index.js', () => ({
+  config: {
+    mcp: {},
+    osc: {
+      remoteAddress: '127.0.0.1',
+      tcpPort: 3032,
+      udpOutPort: 8001,
+      udpInPort: 8000,
+      localAddress: '0.0.0.0'
+    },
+    logging: {
+      level: 'info',
+      format: 'json',
+      destinations: []
+    }
+  }
+}));
+
+const mockOscGateway = { close: jest.fn() };
+
+jest.mock('../../services/osc/index.js', () => ({
+  createOscGatewayFromEnv: jest.fn(() => mockOscGateway)
+}));
+
+jest.mock('../../services/osc/client.js', () => ({
+  initializeOscClient: jest.fn()
+}));
+
+jest.mock('../../schemas/index.js', () => ({
+  registerToolSchemas: jest.fn()
+}));
+
+jest.mock('../../tools/index.js', () => ({
+  toolDefinitions: []
+}));
+
+jest.mock('../httpGateway.js', () => ({
+  createHttpGateway: jest.fn().mockReturnValue({
+    start: jest.fn().mockResolvedValue(undefined),
+    stop: jest.fn().mockResolvedValue(undefined),
+    getAddress: jest.fn()
+  })
+}));
+
+describe('bootstrap version', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('initialise le serveur avec la version du package', async () => {
+    const expectedVersion = getPackageVersion();
+
+    const { bootstrap } = await import('../index.js');
+    const context = await bootstrap();
+
+    expect(MockMcpServer).toHaveBeenCalledWith({
+      name: 'eos-mcp-server',
+      version: expectedVersion
+    });
+
+    await context.server.close();
+    context.oscGateway.close?.();
+  });
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,6 +10,7 @@ import { registerToolSchemas } from '../schemas/index.js';
 import type { ToolDefinition } from '../tools/types.js';
 import { createHttpGateway, type HttpGateway } from './httpGateway.js';
 import { ToolRegistry } from './toolRegistry.js';
+import { getPackageVersion } from '../utils/version.js';
 
 const logger = createLogger('mcp-server');
 
@@ -31,7 +32,7 @@ async function bootstrap(): Promise<BootstrapContext> {
 
   const server = new McpServer({
     name: 'eos-mcp-server',
-    version: '0.1.0'
+    version: getPackageVersion()
   });
 
   if (tcpPort) {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+let cachedVersion: string | undefined;
+
+const PACKAGE_JSON_PATH = resolve(__dirname, '../../package.json');
+
+function readPackageJsonVersion(): string {
+  const packageJsonPath = PACKAGE_JSON_PATH;
+  const raw = readFileSync(packageJsonPath, 'utf-8');
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw) as { version?: unknown };
+  } catch (error) {
+    throw new Error(`Impossible de lire la version depuis ${packageJsonPath}: ${(error as Error).message}`);
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`Le contenu de ${packageJsonPath} est invalide (objet attendu).`);
+  }
+
+  const version = (parsed as { version?: unknown }).version;
+  if (typeof version !== 'string' || version.length === 0) {
+    throw new Error(`La cle "version" est absente ou invalide dans ${packageJsonPath}.`);
+  }
+
+  return version;
+}
+
+export function getPackageVersion(): string {
+  if (!cachedVersion) {
+    cachedVersion = readPackageJsonVersion();
+  }
+  return cachedVersion;
+}
+
+export function clearPackageVersionCache(): void {
+  cachedVersion = undefined;
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to read and cache the package version from package.json
- initialize the MCP server with the package version and guard it with a regression test
- document the version bump procedure for future releases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f6cefc2154832a889b73dd467e95ea