### PR TITLE
Add environment example file and document defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+# Configuration MCP (Model Context Protocol)
+# Port TCP utilisé pour exposer la passerelle HTTP/WS du serveur MCP.
+# Supprimez ou commentez cette ligne pour désactiver la passerelle et n'utiliser que STDIO.
+MCP_TCP_PORT=3032
+
+# Configuration OSC (Open Sound Control)
+# Adresse IP de la console ETC Eos distante à laquelle envoyer les messages OSC sortants.
+OSC_REMOTE_ADDRESS=127.0.0.1
+# Port TCP utilisé pour la négociation OSC avec la console.
+OSC_TCP_PORT=3032
+# Port UDP distant vers lequel envoyer les commandes OSC.
+OSC_UDP_OUT_PORT=8001
+# Port UDP local sur lequel le serveur MCP écoute les messages OSC entrants.
+OSC_UDP_IN_PORT=8000
+# Adresse IP locale utilisée pour l'écoute des messages OSC (0.0.0.0 = toutes les interfaces).
+OSC_LOCAL_ADDRESS=0.0.0.0
+
+# Configuration du logging
+# Niveau minimal de logs (fatal, error, warn, info, debug, trace, silent).
+LOG_LEVEL=info
+# Liste des destinations de logs séparées par des virgules (stdout, file, transport).
+LOG_DESTINATIONS=file
+# Chemin du fichier de log lorsque la destination "file" est active.
+MCP_LOG_FILE=logs/mcp-server.log
+# Cible du transport distant lorsque la destination "transport" est configurée.
+# Laissez la valeur exemple ou supprimez la ligne si le transport n'est pas utilisé.
+LOG_TRANSPORT_TARGET=tcp://log-collector.local:9000
+# Options additionnelles sérialisées en JSON pour la destination "transport".
+# Utilisez un objet JSON ou supprimez la ligne si aucune option n'est requise.
+LOG_TRANSPORT_OPTIONS={"authToken":"change-me"}
+# Active l'affichage des logs en mode lisible (pretty). Mettre "false" en production pour du JSON compact.
+LOG_PRETTY=true

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ node --version
    npm install
    ```
 
-2. (Facultatif) Copiez le fichier `.env.example` vers `.env` et ajustez vos ports/paramètres réseau si nécessaire.
+2. (Facultatif) Le fichier `.env.example` reflète les valeurs par défaut validées par le serveur : copiez-le vers `.env` puis ajustez vos ports/paramètres réseau si nécessaire.
 
 ## Scripts npm utiles
 


### PR DESCRIPTION
## Summary
- add an `.env.example` file populated with default configuration values and inline explanations
- update the installation guide to mention copying the example file for environment setup

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68f91a897394832aba9a5cef70f9520a