### PR TITLE
Expose registered tools via HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,42 @@ Le serveur écoute sur STDIO pour les clients MCP et initialise un service OSC a
 
 ### Passerelle HTTP/WS optionnelle
 
-Définissez la variable d’environnement `MCP_TCP_PORT` pour exposer une API HTTP REST (`POST /tools/:name`) et un WebSocket (`/ws`) au-dessus du registre d’outils MCP. Exemple :
+Définissez la variable d’environnement `MCP_TCP_PORT` pour exposer une API HTTP REST (`GET /tools`, `POST /tools/:name`) et un WebSocket (`/ws`) au-dessus du registre d’outils MCP. Exemple :
 
 ```bash
 MCP_TCP_PORT=3032 npm run start:dev
 ```
+
+#### Lister les outils disponibles
+
+```bash
+curl -X GET "http://localhost:3032/tools"
+```
+
+Réponse attendue :
+
+```json
+{
+  "tools": [
+    {
+      "name": "ping",
+      "config": {
+        "title": "Ping tool",
+        "description": "Retourne un message de confirmation."
+      },
+      "metadata": {
+        "hasInputSchema": true,
+        "inputSchemaResourceUri": "schema://tools/ping",
+        "hasOutputSchema": false,
+        "hasMiddlewares": true,
+        "middlewareCount": 1
+      }
+    }
+  ]
+}
+```
+
+Les outils munis d’un schéma Zod exposent le pointeur MCP correspondant dans `metadata.inputSchemaResourceUri` (`schema://tools/<nom>`).
 
 #### Appel REST
 

--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -85,6 +85,11 @@ class HttpGateway {
 
     this.applySecurityMiddlewares(app);
 
+    app.get('/tools', (_req: Request, res: Response) => {
+      const tools = this.registry.getRegisteredSummaries();
+      res.json({ tools });
+    });
+
     app.post('/tools/:name', async (req: Request, res: Response, next: NextFunction) => {
       try {
         const toolName = req.params.name;


### PR DESCRIPTION
## Summary
- add a registry helper that returns JSON-safe tool definitions and metadata
- expose a secured GET /tools endpoint in the HTTP gateway
- document the new endpoint and sample response in the optional HTTP/WS section

## Testing
- npm run lint *(fails: pre-existing lint configuration complaints about multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68f91b4c8b94832ab19c164cdb8ac48b