### PR TITLE
Add health endpoint to HTTP gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ La procédure de mise à jour de version du serveur est documentée dans [`docs/
 
 | Protocole | Port | Description |
 |-----------|------|-------------|
-| TCP       | 3032 | Passerelle HTTP/WS MCP (POST `/tools/:name`, WebSocket `/ws`) activable via `MCP_TCP_PORT`. |
+| TCP       | 3032 | Passerelle HTTP/WS MCP (GET `/health`, GET `/tools`, POST `/tools/:name`, WebSocket `/ws`) activable via `MCP_TCP_PORT`. |
 | UDP       | 8000 | Port d'écoute OSC local (inbound). |
 | UDP       | 8001 | Port de sortie OSC par défaut (outbound). |
 
@@ -99,6 +99,25 @@ Définissez la variable d’environnement `MCP_TCP_PORT` pour exposer une API HT
 
 ```bash
 MCP_TCP_PORT=3032 npm run start:dev
+```
+
+#### Vérifier la santé de la passerelle
+
+Expose un court statut JSON utile pour les sondes de monitoring ou les systèmes d'alerte. L'endpoint renvoie le statut, le temps de fonctionnement et le nombre d'outils MCP enregistrés.
+
+```bash
+curl -X GET "http://localhost:3032/health"
+```
+
+Réponse attendue :
+
+```json
+{
+  "status": "ok",
+  "uptimeMs": 1234,
+  "toolCount": 5,
+  "transportActive": true
+}
 ```
 
 #### Lister les outils disponibles

--- a/src/server/__tests__/httpGateway.test.ts
+++ b/src/server/__tests__/httpGateway.test.ts
@@ -74,6 +74,21 @@ describe('HttpGateway integration', () => {
     });
   });
 
+  test('reports health status via HTTP GET', async () => {
+    const response = await fetch(`${baseUrl}/health`, {
+      headers: {
+        'content-type': 'application/json'
+      }
+    });
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as Record<string, unknown>;
+    expect(payload.status).toBe('ok');
+    expect(typeof payload.uptimeMs).toBe('number');
+    expect(payload.toolCount).toBe(1);
+    expect(payload.transportActive).toBe(true);
+  });
+
   test('execute tool via WebSocket', async () => {
     const address = new URL(baseUrl);
     const ws = new WebSocket(`ws://${address.host}/ws`);
@@ -174,6 +189,16 @@ describe('HttpGateway security options', () => {
     });
 
     expect(response.status).toBe(200);
+  });
+
+  test('rejects health endpoint without credentials', async () => {
+    const response = await fetch(`${baseUrl}/health`, {
+      headers: {
+        origin: 'http://localhost'
+      }
+    });
+
+    expect(response.status).toBe(401);
   });
 
   test('rejects HTTP request without API key', async () => {


### PR DESCRIPTION
## Summary
- track the HTTP gateway start time and expose the number of registered tools
- add a secured GET /health endpoint that reports status, uptime and transport availability
- document the health endpoint for monitoring use and extend gateway integration tests

## Testing
- npm test -- --runTestsByPath src/server/__tests__/httpGateway.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f91c46e7b8832ab88692deb61b1da9