### PR TITLE
Log startup transport state at boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,13 @@ npm run build
 npm start
 ```
 
-Le serveur écoute sur STDIO pour les clients MCP et initialise un service OSC avec la configuration précédente. Le journal de démarrage vous indique les ports surveillés.
+Le serveur écoute sur STDIO pour les clients MCP et initialise un service OSC avec la configuration précédente. Le journal de démarrage vous indique les ports surveillés. Un message dédié confirme désormais le nombre d’outils chargés, l’état de la passerelle HTTP/WS et la disponibilité du transport STDIO :
+
+```text
+{"toolCount":5,"httpGateway":{"address":"0.0.0.0","family":"IPv4","port":3032},"stdioTransport":"listening"} Serveur MCP demarre : 5 outil(s) disponibles. Passerelle HTTP/WS active sur le port 3032. Transport STDIO en ecoute.
+```
+
+Si la passerelle HTTP/WS n’est pas configurée ou ne peut pas démarrer, le message précise que seule la communication STDIO est active, ce qui permet aux opérateurs d’identifier rapidement la configuration effective au lancement du service.
 
 ### Passerelle HTTP/WS optionnelle
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -57,6 +57,33 @@ async function bootstrap(): Promise<BootstrapContext> {
 
   await Promise.all(connections);
 
+  const toolCount = registry.listTools().length;
+  const httpAddress = gateway?.getAddress();
+
+  if (httpAddress) {
+    logger.info(
+      {
+        toolCount,
+        httpGateway: {
+          address: httpAddress.address,
+          family: httpAddress.family,
+          port: httpAddress.port
+        },
+        stdioTransport: 'listening'
+      },
+      `Serveur MCP demarre : ${toolCount} outil(s) disponibles. Passerelle HTTP/WS active sur le port ${httpAddress.port}. Transport STDIO en ecoute.`
+    );
+  } else {
+    logger.info(
+      {
+        toolCount,
+        httpGateway: 'inactive',
+        stdioTransport: 'listening'
+      },
+      `Serveur MCP demarre : ${toolCount} outil(s) disponibles. Communication STDIO uniquement (aucune passerelle HTTP/WS active).`
+    );
+  }
+
   const handleShutdown = async (signal: NodeJS.Signals): Promise<void> => {
     logger.info({ signal }, 'Signal %s recu, fermeture du serveur MCP', signal);
     try {


### PR DESCRIPTION
## Summary
- log a startup message that includes the tool count, HTTP gateway port (when available), and the STDIO transport status
- emit an explicit STDIO-only message when the HTTP gateway is unavailable
- document the new startup log entry in the README so operators can identify it quickly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f91e0ef794832aaff59cddffb8dcc7