### PR TITLE
Handle configuration loading lazily and improve bootstrap error handling

### DIFF
--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -1,5 +1,10 @@
 import { resolve } from 'node:path';
-import { loadConfig, type AppConfig } from '../../config/index';
+import {
+  getConfig,
+  loadConfig,
+  resetConfigCacheForTesting,
+  type AppConfig
+} from '../../config/index';
 
 describe('configuration', () => {
   it('fournit des valeurs par défaut cohérentes lorsque aucune variable est définie', () => {
@@ -92,5 +97,31 @@ describe('configuration', () => {
       },
       { type: 'stdout' }
     ]);
+  });
+
+  describe('getConfig', () => {
+    let originalOscTcpPort: string | undefined;
+
+    beforeEach(() => {
+      originalOscTcpPort = process.env.OSC_TCP_PORT;
+      resetConfigCacheForTesting();
+    });
+
+    afterEach(() => {
+      resetConfigCacheForTesting();
+      if (originalOscTcpPort === undefined) {
+        delete process.env.OSC_TCP_PORT;
+      } else {
+        process.env.OSC_TCP_PORT = originalOscTcpPort;
+      }
+    });
+
+    it('renvoie le message agrege en cas de configuration invalide', () => {
+      process.env.OSC_TCP_PORT = 'not-a-number';
+
+      expect(() => getConfig()).toThrow(
+        "Configuration invalide:\n- La variable d'environnement OSC_TCP_PORT doit être un entier entre 1 et 65535 (reçu: not-a-number)."
+      );
+    });
   });
 });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -455,8 +455,23 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
   return result.data;
 }
 
+let cachedConfig: AppConfig | undefined;
+
 /**
- * Configuration applicative validée et prête à l'emploi.
- * Les valeurs sont évaluées une seule fois au chargement du module.
+ * Retourne la configuration applicative en la chargeant à la première
+ * invocation uniquement.
  */
-export const config: AppConfig = loadConfig();
+export function getConfig(): AppConfig {
+  if (cachedConfig === undefined) {
+    cachedConfig = loadConfig();
+  }
+
+  return cachedConfig;
+}
+
+/**
+ * Réinitialise le cache de configuration (utilisé uniquement pour les tests).
+ */
+export function resetConfigCacheForTesting(): void {
+  cachedConfig = undefined;
+}

--- a/src/server/__tests__/serverVersion.test.ts
+++ b/src/server/__tests__/serverVersion.test.ts
@@ -22,7 +22,7 @@ jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
 }));
 
 jest.mock('../../config/index.js', () => ({
-  config: {
+  getConfig: jest.fn(() => ({
     mcp: {},
     osc: {
       remoteAddress: '127.0.0.1',
@@ -34,9 +34,10 @@ jest.mock('../../config/index.js', () => ({
     logging: {
       level: 'info',
       format: 'json',
-      destinations: []
+      destinations: [{ type: 'stdout' }]
     }
-  }
+  })),
+  resetConfigCacheForTesting: jest.fn()
 }));
 
 const mockOscGateway = { close: jest.fn() };

--- a/src/services/osc/__tests__/service.test.ts
+++ b/src/services/osc/__tests__/service.test.ts
@@ -103,11 +103,17 @@ describe('OscService diagnostics', () => {
       service.setLoggingOptions({ incoming: true, outgoing: true });
       service.send({ address: '/test/out', args: [{ type: 'i', value: 1 }] });
 
-      expect(logger.debug).toHaveBeenCalledWith('[OSC] -> /test/out', [{ type: 'i', value: 1 }]);
+      expect(logger.debug).toHaveBeenCalledWith(
+        { args: [{ type: 'i', value: 1 }] },
+        '[OSC] -> /test/out'
+      );
 
       port.emit('message', { address: '/test/in', args: [{ type: 's', value: 'hello' }] });
 
-      expect(logger.debug).toHaveBeenCalledWith('[OSC] <- /test/in', [{ type: 's', value: 'hello' }]);
+      expect(logger.debug).toHaveBeenCalledWith(
+        { args: [{ type: 's', value: 'hello' }] },
+        '[OSC] <- /test/in'
+      );
 
       const diagnostics = service.getDiagnostics();
 

--- a/src/services/osc/gateway.ts
+++ b/src/services/osc/gateway.ts
@@ -1,5 +1,5 @@
 import osc from 'osc';
-import { config, type OscConfig as ResolvedOscConfig } from '../../config/index';
+import { getConfig, type OscConfig as ResolvedOscConfig } from '../../config/index';
 import { createLogger } from '../../server/logger';
 import type {
   OscDiagnostics,
@@ -384,5 +384,5 @@ export function createOscGatewayFromEnv(
     >
   > = {}
 ): OscConnectionGateway {
-  return createOscGatewayFromConfig(config.osc, options);
+  return createOscGatewayFromConfig(getConfig().osc, options);
 }

--- a/src/services/osc/index.ts
+++ b/src/services/osc/index.ts
@@ -1,6 +1,6 @@
 import { UDPPort } from 'osc';
 import type { Logger } from 'pino';
-import { config, type OscConfig as ResolvedOscConfig } from '../../config/index';
+import { getConfig, type OscConfig as ResolvedOscConfig } from '../../config/index';
 import { createLogger } from '../../server/logger';
 
 export interface OscMessageArgument {
@@ -345,7 +345,7 @@ export function createOscServiceFromConfig(oscConfig: ResolvedOscConfig, logger?
 }
 
 export function createOscServiceFromEnv(logger?: OscLogger): OscService {
-  return createOscServiceFromConfig(config.osc, logger);
+  return createOscServiceFromConfig(getConfig().osc, logger);
 }
 
 export {


### PR DESCRIPTION
## Summary
- add a cached `getConfig` accessor along with a test helper for resetting the configuration cache
- initialize logging after configuration retrieval, handle bootstrap failures gracefully, and update OSC helpers to use the lazy accessor
- extend configuration tests to cover aggregated error messages and align existing mocks/expectations with the new API

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68f95224d0b0832abbd958ba34c2e929