### PR TITLE
Add CLI utilities for server entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ La description détaillée de chaque outil est disponible dans [`docs/tools.md`]
 
 La procédure de mise à jour de version du serveur est documentée dans [`docs/versioning.md`](docs/versioning.md).
 
+## Options de ligne de commande
+
+Le module principal (`src/server/index.ts`) expose plusieurs utilitaires accessibles sans démarrer le serveur. Les commandes ci-dessous fonctionnent aussi bien avec `ts-node` qu’avec le build compilé (`dist/server/index.js`).
+
+```bash
+# Afficher l'aide intégrée
+npx ts-node src/server/index.ts --help
+
+# Afficher la version du serveur MCP
+npx ts-node src/server/index.ts --version
+
+# Lister les outils MCP embarqués
+npx ts-node src/server/index.ts --list-tools
+
+# Vérifier la configuration (retourne un code de sortie non nul en cas d'erreur)
+npx ts-node src/server/index.ts --check-config
+```
+
+Ces commandes peuvent également être lancées sur la version compilée avec `node dist/server/index.js <option>`. Utilisez `--list-tools` pour inspecter rapidement les outils disponibles et `--check-config` afin de valider votre fichier `.env` ou les variables d'environnement avant un déploiement.
+
 ## Configuration réseau et de la console Eos
 
 | Protocole | Port | Description |

--- a/src/server/__tests__/cli.test.ts
+++ b/src/server/__tests__/cli.test.ts
@@ -1,0 +1,69 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { resolve } from 'node:path';
+import { getPackageVersion } from '../../utils/version';
+
+type CliResult = SpawnSyncReturns<string>;
+
+const projectRoot = resolve(__dirname, '../../..');
+const entryPoint = resolve(projectRoot, 'src/server/index.ts');
+const tsNodeRegister = require.resolve('ts-node/register/transpile-only');
+
+function runCli(args: string[], envOverrides: NodeJS.ProcessEnv = {}): CliResult {
+  const result = spawnSync(
+    process.execPath,
+    ['-r', tsNodeRegister, entryPoint, ...args],
+    {
+      cwd: projectRoot,
+      env: { ...process.env, ...envOverrides },
+      encoding: 'utf-8'
+    }
+  );
+
+  return result;
+}
+
+describe('CLI du serveur MCP', () => {
+  test('affiche l\'aide et quitte avec --help', () => {
+    const result = runCli(['--help']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage : node');
+    expect(result.stdout).toContain('--list-tools');
+    expect(result.stderr).toBe('');
+  });
+
+  test('affiche la version du package avec --version', () => {
+    const version = getPackageVersion();
+    const result = runCli(['--version']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(version);
+    expect(result.stderr).toBe('');
+  });
+
+  test('liste les outils avec --list-tools', () => {
+    const result = runCli(['--list-tools']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Outils MCP disponibles');
+    expect(result.stdout).toMatch(/- ping/);
+    expect(result.stderr).toBe('');
+  });
+
+  test('valide la configuration avec --check-config', () => {
+    const result = runCli(['--check-config']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Configuration valide.');
+    expect(result.stderr).toBe('');
+  });
+
+  test('signale une erreur de configuration avec --check-config', () => {
+    const result = runCli(['--check-config'], { MCP_TCP_PORT: 'abc' });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Configuration invalide :');
+    expect(result.stderr).toContain('MCP_TCP_PORT');
+  });
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -14,6 +14,75 @@ import { getPackageVersion } from '../utils/version';
 
 const logger = createLogger('mcp-server');
 
+interface CliOptions {
+  help: boolean;
+  version: boolean;
+  listTools: boolean;
+  checkConfig: boolean;
+  unknown: string[];
+}
+
+function parseCliArguments(argv: readonly string[]): CliOptions {
+  const options = {
+    help: false,
+    version: false,
+    listTools: false,
+    checkConfig: false,
+    unknown: [] as string[]
+  } satisfies CliOptions;
+
+  for (const token of argv) {
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (token === '--version' || token === '-v') {
+      options.version = true;
+      continue;
+    }
+
+    if (token === '--list-tools') {
+      options.listTools = true;
+      continue;
+    }
+
+    if (token === '--check-config') {
+      options.checkConfig = true;
+      continue;
+    }
+
+    if (token === '--') {
+      break;
+    }
+
+    options.unknown.push(token);
+  }
+
+  return options;
+}
+
+function printHelp(scriptName: string): void {
+  const usage = `Usage : node ${scriptName} [options]\n\n` +
+    'Options :\n' +
+    '  --help, -h          Affiche cette aide et quitte.\n' +
+    '  --version, -v       Affiche la version du serveur et quitte.\n' +
+    '  --list-tools        Liste les outils MCP disponibles et quitte.\n' +
+    '  --check-config      Valide la configuration et quitte.';
+
+  console.log(usage);
+}
+
+async function printToolList(): Promise<void> {
+  const tools = await loadToolDefinitions();
+  console.log(`Outils MCP disponibles (${tools.length}) :`);
+  for (const tool of tools) {
+    const title = tool.config.title ?? tool.name;
+    const description = tool.config.description ? ` — ${tool.config.description}` : '';
+    console.log(`- ${tool.name} (${title})${description}`);
+  }
+}
+
 async function loadToolDefinitions(): Promise<ToolDefinition[]> {
   return toolDefinitions;
 }
@@ -146,8 +215,55 @@ async function bootstrap(): Promise<BootstrapContext> {
   return { server, registry, oscGateway, gateway };
 }
 
+async function runFromCommandLine(argv: NodeJS.Process['argv']): Promise<void> {
+  const [, script = 'src/server/index.js'] = argv;
+  const options = parseCliArguments(argv.slice(2));
+
+  if (options.unknown.length > 0) {
+    console.error(`Option(s) inconnue(s) : ${options.unknown.join(', ')}`);
+    console.error('Utilisez --help pour afficher l\'aide.');
+    process.exit(1);
+    return;
+  }
+
+  if (options.help) {
+    printHelp(script);
+    process.exit(0);
+    return;
+  }
+
+  if (options.version) {
+    const version = getPackageVersion();
+    console.log(`Eos MCP ${version}`);
+    process.exit(0);
+    return;
+  }
+
+  if (options.listTools) {
+    await printToolList();
+    process.exit(0);
+    return;
+  }
+
+  if (options.checkConfig) {
+    try {
+      getConfig();
+      console.log('Configuration valide.');
+      process.exit(0);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      console.error('Configuration invalide :');
+      console.error(reason);
+      process.exit(1);
+    }
+    return;
+  }
+
+  await bootstrap();
+}
+
 if (require.main === module) {
-  void bootstrap().catch((error: unknown) => {
+  void runFromCommandLine(process.argv).catch((error: unknown) => {
     const appError = toAppError(error, {
       code: ErrorCode.MCP_STARTUP_FAILURE,
       message: 'Erreur lors du demarrage du serveur MCP.'


### PR DESCRIPTION
## Summary
- parse command line flags in the MCP server entrypoint and implement the --help, --version, --list-tools and --check-config behaviours before bootstrapping
- document the new CLI commands in the README so operators can discover them easily
- add integration tests that execute the entrypoint through ts-node to assert each flag's output and exit code

## Testing
- npm test -- src/server/__tests__/cli.test.ts
- npx jest --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68f9546406ec832a8dd232bb0b34abb6