### PR TITLE
Improve HTTP access logging and docs

### DIFF
--- a/docs/connexion-dynamique.md
+++ b/docs/connexion-dynamique.md
@@ -1,0 +1,57 @@
+# Connexion dynamique au serveur MCP
+
+Ce mini tutoriel explique comment piloter dynamiquement le point d'accès du serveur MCP en fonction des variables d'environnement. Il permet d'intégrer rapidement le serveur aussi bien dans une console locale que dans un LLM compatible MCP.
+
+## Variables d'environnement clés
+
+| Variable | Description | Valeur par défaut |
+| --- | --- | --- |
+| `MCP_TCP_PORT` | Active la passerelle HTTP/WebSocket et définit le port d'écoute. | Non défini (mode STDIO uniquement) |
+| `MCP_TLS_ENABLED` | Force l'utilisation du protocole HTTPS. Les valeurs acceptées sont `1`, `true`, `yes`, `on`, `enable`, `enabled`. | `false` |
+| `OSC_REMOTE_ADDRESS` | Adresse du serveur OSC distant à contacter. | `127.0.0.1` |
+| `OSC_TCP_PORT` | Port TCP distant utilisé pour la négociation OSC. | `3032` |
+| `OSC_UDP_OUT_PORT` | Port UDP distant pour l'envoi des messages OSC. | `8001` |
+| `OSC_UDP_IN_PORT` | Port UDP local pour la réception des messages OSC. | `8000` |
+| `OSC_LOCAL_ADDRESS` | Adresse locale écoutée pour les messages OSC. | `0.0.0.0` |
+
+## Exemples de scénarios
+
+### 1. Démarrage local pour développement console
+
+```bash
+export MCP_TCP_PORT=5173
+export MCP_TLS_ENABLED=0
+export OSC_REMOTE_ADDRESS=127.0.0.1
+npm run start:dev
+```
+
+Le journal de démarrage affichera une URL du type `http://localhost:5173`, directement copiable dans votre console MCP locale.
+
+### 2. Exposition sécurisée pour un LLM hébergé
+
+```bash
+export MCP_TCP_PORT=7443
+export MCP_TLS_ENABLED=true
+export OSC_REMOTE_ADDRESS=mcp-backend.internal
+export OSC_TCP_PORT=4000
+export OSC_UDP_OUT_PORT=4600
+export OSC_UDP_IN_PORT=4601
+npm run start:dev
+```
+
+Le serveur annoncera `https://mcp-backend.internal:7443`. Vous pouvez transmettre cette URL au LLM pour créer une connexion HTTP ou WebSocket sécurisée.
+
+### 3. Mode STDIO uniquement
+
+```bash
+unset MCP_TCP_PORT
+npm run start:dev
+```
+
+Aucun point d'accès réseau n'est créé ; seuls les clients MCP capables de communiquer via STDIO (par exemple un client CLI intégré) peuvent se connecter.
+
+## Bonnes pratiques
+
+1. **Centralisez les variables** dans un fichier `.env` dédié pour chaque environnement (dev, staging, production).
+2. **Synchronisez l'URL affichée par les logs** avec la configuration de vos clients : l'adresse affichée par le serveur est déjà normalisée (`localhost` pour `0.0.0.0` ou `::`, crochets automatiques pour l'IPv6).
+3. **Automatisez la découverte** en lisant la clé `accessUrl` des logs structurés si vous consommez les journaux depuis une plateforme d'observabilité.

--- a/src/server/__tests__/index.test.ts
+++ b/src/server/__tests__/index.test.ts
@@ -1,0 +1,37 @@
+import type { AddressInfo } from 'node:net';
+import { buildHttpAccessDetails } from '../index';
+
+describe('buildHttpAccessDetails', () => {
+  it('normalise une adresse IPv4 generique vers localhost en HTTP', () => {
+    const address = { address: '0.0.0.0', family: 'IPv4', port: 8080 } as AddressInfo;
+    const result = buildHttpAccessDetails(address, { MCP_TLS_ENABLED: 'false' });
+
+    expect(result).toEqual({
+      host: 'localhost',
+      protocol: 'http',
+      accessUrl: 'http://localhost:8080'
+    });
+  });
+
+  it('normalise une adresse IPv6 et active le protocole HTTPS', () => {
+    const address = { address: '2001:db8::1', family: 'IPv6', port: 7443 } as AddressInfo;
+    const result = buildHttpAccessDetails(address, { MCP_TLS_ENABLED: 'true' });
+
+    expect(result).toEqual({
+      host: '[2001:db8::1]',
+      protocol: 'https',
+      accessUrl: 'https://[2001:db8::1]:7443'
+    });
+  });
+
+  it('reconnaît les alias TLS supplementaires et preserve localhost en IPv6', () => {
+    const address = { address: 'localhost', family: 'IPv6', port: 9000 } as AddressInfo;
+    const result = buildHttpAccessDetails(address, { MCP_TLS: 'ENABLED' });
+
+    expect(result).toEqual({
+      host: 'localhost',
+      protocol: 'https',
+      accessUrl: 'https://localhost:9000'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize gateway addresses, compute access URLs, and surface them in startup logs
- keep a clear STDIO-only startup message and prepare for future TLS mode selection
- document environment-driven connection setups for consoles and LLM clients

## Testing
- npm test -- --runTestsByPath src/server/__tests__/index.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f9571b6fe4832aba84a04b1bdc0215