### PR TITLE
Support binding UDP OSC sockets to local endpoints

### DIFF
--- a/src/services/osc/__tests__/gateway.test.ts
+++ b/src/services/osc/__tests__/gateway.test.ts
@@ -91,6 +91,8 @@ describe('OscConnectionGateway', () => {
       throw new Error('Gestionnaire de connexion non initialise');
     }
 
+    expect(manager.options).toEqual(expect.objectContaining({ localPort: 8000 }));
+
     manager.transportSequence = ['tcp', 'udp'];
 
     const statuses: TransportStatus[] = [];
@@ -170,5 +172,24 @@ describe('OscConnectionGateway', () => {
     ]);
 
     gateway.close();
+  });
+
+  it('transmet les options de liaison locales au gestionnaire de connexion', () => {
+    createOscConnectionGateway({
+      host: '127.0.0.1',
+      tcpPort: 3032,
+      udpPort: 8001,
+      localPort: 8100,
+      localAddress: '192.168.1.10'
+    });
+
+    const manager = instances.at(-1);
+    if (!manager) {
+      throw new Error('Gestionnaire de connexion non initialise');
+    }
+
+    expect(manager.options).toEqual(
+      expect.objectContaining({ localPort: 8100, localAddress: '192.168.1.10' })
+    );
   });
 });

--- a/src/services/osc/gateway.ts
+++ b/src/services/osc/gateway.ts
@@ -206,7 +206,7 @@ export class OscConnectionGateway implements OscGateway {
   }
 
   private createManager(options: OscConnectionGatewayOptions): OscConnectionManager {
-    const { metadata: _metadata, localAddress: _localAddress, localPort: _localPort, ...rest } = options;
+    const { metadata: _metadata, ...rest } = options;
     return new OscConnectionManager(rest);
   }
 


### PR DESCRIPTION
## Summary
- allow OSC connection manager to accept optional local binding configuration and bind sockets before connecting
- forward local binding options from the OSC gateway to the connection manager
- cover the new behaviour with unit tests for the gateway and connection manager

## Testing
- npm test -- --runTestsByPath src/services/osc/__tests__/connectionManager.test.ts src/services/osc/__tests__/gateway.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f95b4c12f8832aafa049e81c57c5db