### PR TITLE
Add CI workflow and document release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Prepare log directory
+        run: mkdir -p artifacts
+
+      - name: Install dependencies
+        run: npm ci 2>&1 | tee artifacts/npm-ci.log
+        shell: bash
+
+      - name: Run lint
+        run: npm run lint 2>&1 | tee artifacts/lint.log
+        shell: bash
+
+      - name: Run tests
+        run: npm test 2>&1 | tee artifacts/test.log
+        shell: bash
+
+      - name: Build project
+        run: npm run build 2>&1 | tee artifacts/build.log
+        shell: bash
+
+      - name: Upload logs on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-logs
+          path: artifacts
+
+  docs:
+    runs-on: ubuntu-latest
+    needs: build
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify generated documentation
+        run: npm run docs:check 2>&1 | tee docs-check.log
+        shell: bash
+
+      - name: Upload docs check logs on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-check-logs
+          path: docs-check.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Toutes les modifications notables de ce projet sont consignées dans ce fichier.
+
+Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/),
+et ce projet respecte la [version sémantique](https://semver.org/lang/fr/spec/v2.0.0.html).
+
+## [Unreleased]
+### Ajouté
+- Pipeline d'intégration continue GitHub Actions pour les lint/tests/build et la vérification optionnelle de la documentation.
+- Procédure de release documentée incluant la mise à jour du changelog et la publication des tags Git.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ node --version
 
 La description détaillée de chaque outil est disponible dans [`docs/tools.md`](docs/tools.md). Le fichier est généré automatiquement à partir des schémas Zod déclarés dans `src/tools/**`.
 
-La procédure de mise à jour de version du serveur est documentée dans [`docs/versioning.md`](docs/versioning.md).
+Toutes les modifications publiées sont consignées dans [`CHANGELOG.md`](CHANGELOG.md). La procédure de mise à jour de version du serveur est documentée dans [`docs/versioning.md`](docs/versioning.md).
 
 ## Options de ligne de commande
 
@@ -118,6 +118,19 @@ Le serveur écoute sur STDIO pour les clients MCP et initialise un service OSC a
 ```
 
 Si la passerelle HTTP/WS n’est pas configurée ou ne peut pas démarrer, le message précise que seule la communication STDIO est active, ce qui permet aux opérateurs d’identifier rapidement la configuration effective au lancement du service.
+
+## Checklist de publication
+
+Avant de publier une nouvelle version :
+
+1. Mettre à jour [`CHANGELOG.md`](CHANGELOG.md) avec les évolutions et corrections apportées.
+2. Appliquer `npm version <patch|minor|major>` pour générer le commit et le tag correspondant.
+3. Lancer la suite de tests (`npm test`) et les vérifications (`npm run lint`, `npm run build`) si ce n’est pas déjà fait.
+4. Pousser la branche et le tag associé :
+   ```bash
+   git push --follow-tags
+   ```
+5. Vérifier que la documentation générée reste à jour (`npm run docs:check`).
 
 ### Passerelle HTTP/WS optionnelle
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,15 +1,20 @@
 # Gestion des versions du serveur MCP
 
-Le serveur MCP expose désormais sa version directement depuis le `package.json` grâce à l'utilitaire `getPackageVersion`. Cela garantit que les clients reçoivent la même valeur que celle publiée sur npm.
+Le serveur MCP expose sa version directement depuis le `package.json` grâce à l'utilitaire `getPackageVersion`. Cela garantit que les clients reçoivent la même valeur que celle publiée sur npm.
 
 ## Mettre à jour la version
 
-1. Utiliser `npm version <patch|minor|major>` (ou mettre à jour la clé `version` du `package.json` manuellement si besoin).
-2. Vérifier que la modification est cohérente avec le changelog ou les notes de version associées.
-3. Lancer la suite de tests pour s'assurer que l'initialisation du serveur continue de fonctionner :
+1. Mettre à jour le changelog dans [`CHANGELOG.md`](../CHANGELOG.md) avec les éléments de la prochaine version.
+2. Utiliser `npm version <patch|minor|major>` (ou mettre à jour la clé `version` du `package.json` manuellement si besoin). Cette commande crée automatiquement un commit et un tag Git correspondant.
+3. Vérifier que la modification est cohérente avec les notes de version consignées.
+4. Lancer la suite de tests pour s'assurer que l'initialisation du serveur continue de fonctionner :
    ```bash
    npm test
    ```
-4. Commiter les changements (`package.json`, `package-lock.json`, documentation, etc.) et publier la nouvelle version si nécessaire.
+5. Pousser la branche et le tag généré :
+   ```bash
+   git push --follow-tags
+   ```
+6. Commiter les autres changements nécessaires (`package.json`, `package-lock.json`, documentation, etc.) et publier la nouvelle version si nécessaire.
 
 Aucune autre mise à jour de code n'est requise : le serveur lira automatiquement la nouvelle version lors du démarrage.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run npm install, linting, tests, build, and optional docs checks
- publish logs as artifacts on failure to help debugging
- introduce a changelog and document the release checklist including tagging instructions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f967e41158832ab28b51a809d6e21b