### PR TITLE
Add OSC connection backoff and health reporting

### DIFF
--- a/src/server/__tests__/serverVersion.test.ts
+++ b/src/server/__tests__/serverVersion.test.ts
@@ -41,9 +41,35 @@ jest.mock('../../config/index.js', () => ({
 }));
 
 const mockOscGateway = { close: jest.fn() };
+const mockOscConnectionStateProvider = jest
+  .fn()
+  .mockImplementation(() => ({
+    setStatus: jest.fn(),
+    getOverview: jest.fn(() => ({
+      health: 'offline',
+      transports: {
+        tcp: {
+          type: 'tcp',
+          state: 'disconnected',
+          lastHeartbeatAckAt: null,
+          lastHeartbeatSentAt: null,
+          consecutiveFailures: 0
+        },
+        udp: {
+          type: 'udp',
+          state: 'disconnected',
+          lastHeartbeatAckAt: null,
+          lastHeartbeatSentAt: null,
+          consecutiveFailures: 0
+        }
+      },
+      updatedAt: Date.now()
+    }))
+  }));
 
 jest.mock('../../services/osc/index.js', () => ({
-  createOscGatewayFromEnv: jest.fn(() => mockOscGateway)
+  createOscGatewayFromEnv: jest.fn(() => mockOscGateway),
+  OscConnectionStateProvider: mockOscConnectionStateProvider
 }));
 
 jest.mock('../../services/osc/client.js', () => ({

--- a/src/services/osc/__tests__/osc.integration.test.ts
+++ b/src/services/osc/__tests__/osc.integration.test.ts
@@ -1,0 +1,146 @@
+import { createServer } from 'node:net';
+import type { AddressInfo } from 'node:net';
+import { UDPPort } from 'osc';
+import { OscService } from '../index';
+import type { OscMessage } from '../index';
+
+describe('OscService integration (UDP sockets)', () => {
+  jest.setTimeout(10_000);
+
+  async function getAvailablePort(): Promise<number> {
+    return new Promise<number>((resolve, reject) => {
+      const server = createServer();
+      server.unref();
+      server.on('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address() as AddressInfo | string | null;
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          if (!address || typeof address === 'string') {
+            reject(new Error('Unable to determine dynamic port'));
+            return;
+          }
+          resolve(address.port);
+        });
+      });
+    });
+  }
+
+  function waitForPortReady(port: UDPPort): Promise<void> {
+    return new Promise((resolve) => {
+      if ((port as unknown as { socket?: { listening: boolean } }).socket?.listening) {
+        resolve();
+        return;
+      }
+      port.on('ready', () => resolve());
+    });
+  }
+
+  let service: OscService | undefined;
+  const resources: Array<{ close: () => void }> = [];
+
+  afterEach(() => {
+    resources.splice(0).forEach((resource) => {
+      try {
+        resource.close();
+      } catch (error) {
+        // Ignore cleanup errors in tests
+      }
+    });
+    service?.close();
+    service = undefined;
+  });
+
+  test('sends OSC messages using real UDP sockets', async () => {
+    const remotePort = await getAvailablePort();
+    const receiver = new UDPPort({
+      localAddress: '127.0.0.1',
+      localPort: remotePort,
+      metadata: true
+    });
+    receiver.open();
+    resources.push({ close: () => receiver.close() });
+    await waitForPortReady(receiver);
+
+    const servicePort = await getAvailablePort();
+    service = new OscService({
+      localAddress: '127.0.0.1',
+      localPort: servicePort,
+      remoteAddress: '127.0.0.1',
+      remotePort
+    });
+
+    const serviceUdp = (service as unknown as { port: UDPPort }).port;
+    await waitForPortReady(serviceUdp);
+
+    const received = new Promise<OscMessage>((resolve) => {
+      receiver.once('message', (message: OscMessage) => {
+        resolve(message);
+      });
+    });
+
+    const message: OscMessage = {
+      address: '/integration/send',
+      args: [
+        { type: 'i', value: 42 },
+        { type: 's', value: 'hello' }
+      ]
+    };
+
+    await service.send(message);
+
+    const payload = await received;
+    expect(payload.address).toBe(message.address);
+    expect(payload.args).toEqual(message.args);
+  });
+
+  test('emits received OSC messages via onMessage listener', async () => {
+    const servicePort = await getAvailablePort();
+    const remotePort = await getAvailablePort();
+
+    service = new OscService({
+      localAddress: '127.0.0.1',
+      localPort: servicePort,
+      remoteAddress: '127.0.0.1',
+      remotePort
+    });
+
+    const serviceUdp = (service as unknown as { port: UDPPort }).port;
+    await waitForPortReady(serviceUdp);
+
+    const sender = new UDPPort({
+      localAddress: '127.0.0.1',
+      localPort: remotePort,
+      remoteAddress: '127.0.0.1',
+      remotePort: servicePort,
+      metadata: true
+    });
+    sender.open();
+    resources.push({ close: () => sender.close() });
+    await waitForPortReady(sender);
+
+    const received = new Promise<OscMessage>((resolve) => {
+      const dispose = service!.onMessage((message) => {
+        dispose();
+        resolve(message);
+      });
+    });
+
+    const message: OscMessage = {
+      address: '/integration/receive',
+      args: [
+        { type: 'f', value: 1.5 },
+        { type: 'T', value: true }
+      ]
+    };
+
+    sender.send(message);
+
+    const payload = await received;
+    expect(payload.address).toBe(message.address);
+    expect(payload.args).toEqual(message.args);
+  });
+});

--- a/src/services/osc/connectionState.ts
+++ b/src/services/osc/connectionState.ts
@@ -1,0 +1,115 @@
+import { EventEmitter } from 'node:events';
+import type { TransportStatus, TransportType } from './connectionManager';
+
+export type OscConnectionHealth = 'online' | 'degraded' | 'offline';
+
+export interface OscConnectionOverview {
+  health: OscConnectionHealth;
+  transports: Record<TransportType, TransportStatus>;
+  updatedAt: number;
+}
+
+type OscConnectionStateEvents = {
+  update: [OscConnectionOverview];
+};
+
+function cloneStatus(status: TransportStatus): TransportStatus {
+  return {
+    type: status.type,
+    state: status.state,
+    lastHeartbeatSentAt: status.lastHeartbeatSentAt,
+    lastHeartbeatAckAt: status.lastHeartbeatAckAt,
+    consecutiveFailures: status.consecutiveFailures
+  };
+}
+
+function createInitialStatus(type: TransportType): TransportStatus {
+  return {
+    type,
+    state: 'disconnected',
+    lastHeartbeatAckAt: null,
+    lastHeartbeatSentAt: null,
+    consecutiveFailures: 0
+  };
+}
+
+export class OscConnectionStateProvider extends EventEmitter {
+  private readonly transports: Record<TransportType, TransportStatus> = {
+    tcp: createInitialStatus('tcp'),
+    udp: createInitialStatus('udp')
+  };
+
+  private updatedAt = Date.now();
+
+  public override on<Event extends keyof OscConnectionStateEvents>(
+    event: Event,
+    listener: (...args: OscConnectionStateEvents[Event]) => void
+  ): this {
+    return super.on(event, listener);
+  }
+
+  public override once<Event extends keyof OscConnectionStateEvents>(
+    event: Event,
+    listener: (...args: OscConnectionStateEvents[Event]) => void
+  ): this {
+    return super.once(event, listener);
+  }
+
+  public override off<Event extends keyof OscConnectionStateEvents>(
+    event: Event,
+    listener: (...args: OscConnectionStateEvents[Event]) => void
+  ): this {
+    return super.off(event, listener);
+  }
+
+  public setStatus(status: TransportStatus): void {
+    const previous = this.transports[status.type];
+    const next = cloneStatus(status);
+    if (
+      previous.state === next.state &&
+      previous.lastHeartbeatAckAt === next.lastHeartbeatAckAt &&
+      previous.lastHeartbeatSentAt === next.lastHeartbeatSentAt &&
+      previous.consecutiveFailures === next.consecutiveFailures
+    ) {
+      return;
+    }
+
+    this.transports[status.type] = next;
+    this.updatedAt = Date.now();
+    this.emit('update', this.getOverview());
+  }
+
+  public getStatus(type: TransportType): TransportStatus {
+    return cloneStatus(this.transports[type]);
+  }
+
+  public getOverview(): OscConnectionOverview {
+    const transports: Record<TransportType, TransportStatus> = {
+      tcp: this.getStatus('tcp'),
+      udp: this.getStatus('udp')
+    };
+
+    return {
+      health: this.computeHealth(transports),
+      transports,
+      updatedAt: this.updatedAt
+    };
+  }
+
+  private computeHealth(
+    transports: Record<TransportType, TransportStatus>
+  ): OscConnectionHealth {
+    const states = Object.values(transports).map((transport) => transport.state);
+    const allConnected = states.every((state) => state === 'connected');
+    if (allConnected) {
+      return 'online';
+    }
+
+    const hasActiveTransport = states.some((state) => state === 'connected' || state === 'connecting');
+    if (hasActiveTransport) {
+      return 'degraded';
+    }
+
+    return 'offline';
+  }
+}

--- a/src/services/osc/index.ts
+++ b/src/services/osc/index.ts
@@ -351,6 +351,7 @@ export function createOscServiceFromEnv(logger?: OscLogger): OscService {
 export {
   OscConnectionManager,
   type OscConnectionManagerOptions,
+  type OscReconnectBackoffOptions,
   type ToolTransportPreference,
   type TransportStatus,
   type TransportType
@@ -362,3 +363,8 @@ export {
   type OscConnectionGatewayOptions,
   createOscGatewayFromEnv
 } from './gateway';
+export {
+  OscConnectionStateProvider,
+  type OscConnectionOverview,
+  type OscConnectionHealth
+} from './connectionState';


### PR DESCRIPTION
## Summary
- add configurable exponential backoff, jitter and timeout handling to the OSC connection manager and update unit coverage
- introduce an OSC connection state provider, integrate it with the gateway and HTTP health endpoint, and validate degraded/offline responses
- add an integration test that exercises OscService send/onMessage behaviour over real UDP sockets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f968c36700832a8a50a0ab8ffe3a59