### PR TITLE
Lock HTTP gateway with config security defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,16 @@ LOG_TRANSPORT_TARGET=tcp://log-collector.local:9000
 LOG_TRANSPORT_OPTIONS={"authToken":"change-me"}
 # Active l'affichage des logs en mode lisible (pretty). Mettre "false" en production pour du JSON compact.
 LOG_PRETTY=true
+
+# Sécurité de la passerelle HTTP/WS
+# Liste de clés API acceptées (séparées par des virgules). Laisser vide pour n'autoriser aucune clé additionnelle.
+MCP_HTTP_API_KEYS=
+# Jetons MCP requis pour authentifier les clients (séparés par des virgules). Remplacez la valeur par défaut.
+MCP_HTTP_MCP_TOKENS=change-me
+# Liste d'adresses IP autorisées. Laisser vide = deny all (aucun accès réseau). Utilisez "*" pour tout autoriser.
+MCP_HTTP_IP_ALLOWLIST=
+# Origines autorisées pour CORS/WebSocket. Laisser vide = deny all (aucune origine). Utilisez "*" pour tout autoriser.
+MCP_HTTP_ALLOWED_ORIGINS=
+# Fenêtre du rate-limit (en millisecondes) et nombre maximal de requêtes par IP.
+MCP_HTTP_RATE_LIMIT_WINDOW=60000
+MCP_HTTP_RATE_LIMIT_MAX=60

--- a/README.md
+++ b/README.md
@@ -265,6 +265,30 @@ wscat \
 
 Si les middlewares intégrés ne conviennent pas, vous pouvez injecter vos propres middlewares Express via `security.express` (par exemple pour utiliser `helmet`, `cors` ou un proxy externe).
 
+#### Exemple `.env`
+
+```env
+MCP_TCP_PORT=3032
+MCP_HTTP_MCP_TOKENS=change-me
+MCP_HTTP_IP_ALLOWLIST=
+MCP_HTTP_ALLOWED_ORIGINS=
+MCP_HTTP_RATE_LIMIT_WINDOW=60000
+MCP_HTTP_RATE_LIMIT_MAX=60
+```
+
+Cette configuration laisse la passerelle HTTP/WS activée mais verrouillée : aucune adresse IP ni origine n'est autorisée tant que les listes restent vides (deny all), et un jeton MCP est exigé pour toute requête.
+
+| Paramètre | Mode strict (défaut) | Mode LAN (exemple) |
+| --- | --- | --- |
+| `MCP_HTTP_IP_ALLOWLIST` | Vide ⇒ deny all | `192.168.1.10,192.168.1.15` |
+| `MCP_HTTP_ALLOWED_ORIGINS` | Vide ⇒ deny all | `http://192.168.1.10,http://192.168.1.15` |
+| `MCP_HTTP_MCP_TOKENS` | `change-me` (à remplacer) | `lan-secret-123` |
+| `MCP_HTTP_API_KEYS` | Vide (désactivé) | `lan-key` |
+| `MCP_HTTP_RATE_LIMIT_WINDOW` | `60000` ms | `60000` ms |
+| `MCP_HTTP_RATE_LIMIT_MAX` | `60` requêtes | `120` requêtes |
+
+Pensez à remplacer les jetons et clés par des valeurs robustes avant d'exposer la passerelle sur votre réseau.
+
 ## Vérification locale avec la CLI MCP
 
 Après démarrage du serveur, utilisez le client officiel pour invoquer un outil :

--- a/docs/connexion-dynamique.md
+++ b/docs/connexion-dynamique.md
@@ -13,6 +13,12 @@ Ce mini tutoriel explique comment piloter dynamiquement le point d'accès du ser
 | `OSC_UDP_OUT_PORT` | Port UDP distant pour l'envoi des messages OSC. | `8001` |
 | `OSC_UDP_IN_PORT` | Port UDP local pour la réception des messages OSC. | `8000` |
 | `OSC_LOCAL_ADDRESS` | Adresse locale écoutée pour les messages OSC. | `0.0.0.0` |
+| `MCP_HTTP_API_KEYS` | Clés API supplémentaires exigées côté HTTP (`X-API-Key`). | Vide (aucune clé) |
+| `MCP_HTTP_MCP_TOKENS` | Jetons MCP (`X-MCP-Token` / `Authorization: Bearer`) requis pour authentifier les clients. | `change-me` |
+| `MCP_HTTP_IP_ALLOWLIST` | Liste d'IP autorisées à consommer la passerelle HTTP/WS (`*` pour tout autoriser). | Vide ⇒ deny all |
+| `MCP_HTTP_ALLOWED_ORIGINS` | Origines HTTP/WS autorisées (`*` pour tout autoriser). | Vide ⇒ deny all |
+| `MCP_HTTP_RATE_LIMIT_WINDOW` | Fenêtre du rate-limit (en millisecondes). | `60000` |
+| `MCP_HTTP_RATE_LIMIT_MAX` | Nombre maximal de requêtes par IP dans la fenêtre. | `60` |
 
 ## Exemples de scénarios
 
@@ -49,6 +55,21 @@ npm run start:dev
 ```
 
 Aucun point d'accès réseau n'est créé ; seuls les clients MCP capables de communiquer via STDIO (par exemple un client CLI intégré) peuvent se connecter.
+
+### 4. Déverrouiller l'accès sur un réseau local
+
+```bash
+export MCP_TCP_PORT=3032
+export MCP_HTTP_IP_ALLOWLIST=192.168.1.10,192.168.1.15
+export MCP_HTTP_ALLOWED_ORIGINS=http://192.168.1.10,http://192.168.1.15
+export MCP_HTTP_MCP_TOKENS=remplacez-moi-par-un-jeton-solide
+export MCP_HTTP_API_KEYS=lan-key
+export MCP_HTTP_RATE_LIMIT_WINDOW=60000
+export MCP_HTTP_RATE_LIMIT_MAX=120
+npm run start:dev
+```
+
+Seules les machines explicitement listées (`192.168.1.10` et `192.168.1.15`) pourront accéder à la passerelle, et elles devront fournir le jeton MCP (et la clé API le cas échéant). Ajustez les origines pour autoriser les navigateurs ou clients WebSocket du LAN.
 
 ## Bonnes pratiques
 

--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -30,6 +30,15 @@ describe('configuration', () => {
             path: resolve(process.cwd(), 'logs/mcp-server.log')
           }
         ]
+      },
+      httpGateway: {
+        security: {
+          apiKeys: [],
+          mcpTokens: ['change-me'],
+          ipAllowlist: [],
+          allowedOrigins: [],
+          rateLimit: { windowMs: 60000, max: 60 }
+        }
       }
     };
 
@@ -46,7 +55,13 @@ describe('configuration', () => {
       OSC_LOCAL_ADDRESS: '192.168.1.2',
       LOG_LEVEL: 'DEBUG',
       MCP_LOG_FILE: 'var/log/eos-mcp.log',
-      LOG_DESTINATIONS: 'stdout,file'
+      LOG_DESTINATIONS: 'stdout,file',
+      MCP_HTTP_API_KEYS: 'admin-key',
+      MCP_HTTP_MCP_TOKENS: 'token-one,token-two',
+      MCP_HTTP_IP_ALLOWLIST: '127.0.0.1,::1',
+      MCP_HTTP_ALLOWED_ORIGINS: 'http://localhost',
+      MCP_HTTP_RATE_LIMIT_WINDOW: '120000',
+      MCP_HTTP_RATE_LIMIT_MAX: '10'
     };
 
     const config = loadConfig(env);
@@ -65,6 +80,13 @@ describe('configuration', () => {
       { type: 'stdout' },
       { type: 'file', path: resolve(process.cwd(), 'var/log/eos-mcp.log') }
     ]);
+    expect(config.httpGateway.security).toEqual({
+      apiKeys: ['admin-key'],
+      mcpTokens: ['token-one', 'token-two'],
+      ipAllowlist: ['127.0.0.1', '::1'],
+      allowedOrigins: ['http://localhost'],
+      rateLimit: { windowMs: 120000, max: 10 }
+    });
   });
 
   it('rejette les ports invalides avec un message explicite', () => {

--- a/src/server/__tests__/httpGateway.test.ts
+++ b/src/server/__tests__/httpGateway.test.ts
@@ -318,6 +318,72 @@ describe('HttpGateway security options', () => {
     expect(response.status).toBe(403);
   });
 
+  test('denies HTTP request when IP allowlist is empty', async () => {
+    await gateway.stop();
+    gateway = createHttpGateway(registry, {
+      port: 0,
+      security: { ...securityOptions, ipWhitelist: [] }
+    });
+    await gateway.start();
+    const address = gateway.getAddress();
+    if (!address) {
+      throw new Error('Adresse de la passerelle introuvable');
+    }
+    const lockedUrl = `http://127.0.0.1:${address.port}`;
+
+    const response = await fetch(`${lockedUrl}/tools/${tool.name}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': securityOptions.apiKeys[0],
+        'x-mcp-token': securityOptions.mcpTokens[0],
+        origin: 'http://localhost'
+      },
+      body: JSON.stringify({ args: { text: 'denied' } })
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  test('denies HTTP request with origin when allowed origins list is empty', async () => {
+    await gateway.stop();
+    gateway = createHttpGateway(registry, {
+      port: 0,
+      security: { ...securityOptions, allowedOrigins: [] }
+    });
+    await gateway.start();
+    const address = gateway.getAddress();
+    if (!address) {
+      throw new Error('Adresse de la passerelle introuvable');
+    }
+    const lockedUrl = `http://127.0.0.1:${address.port}`;
+
+    const response = await fetch(`${lockedUrl}/tools/${tool.name}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': securityOptions.apiKeys[0],
+        'x-mcp-token': securityOptions.mcpTokens[0],
+        origin: 'http://localhost'
+      },
+      body: JSON.stringify({ args: { text: 'cors-denied' } })
+    });
+
+    expect(response.status).toBe(403);
+
+    const responseWithoutOrigin = await fetch(`${lockedUrl}/tools/${tool.name}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': securityOptions.apiKeys[0],
+        'x-mcp-token': securityOptions.mcpTokens[0]
+      },
+      body: JSON.stringify({ args: { text: 'no-origin' } })
+    });
+
+    expect(responseWithoutOrigin.status).toBe(200);
+  });
+
   test('enforces HTTP rate limiting', async () => {
     const headers = {
       'content-type': 'application/json',

--- a/src/server/__tests__/serverVersion.test.ts
+++ b/src/server/__tests__/serverVersion.test.ts
@@ -35,6 +35,15 @@ jest.mock('../../config/index.js', () => ({
       level: 'info',
       format: 'json',
       destinations: [{ type: 'stdout' }]
+    },
+    httpGateway: {
+      security: {
+        apiKeys: [],
+        mcpTokens: ['change-me'],
+        ipAllowlist: [],
+        allowedOrigins: [],
+        rateLimit: { windowMs: 60000, max: 60 }
+      }
     }
   })),
   resetConfigCacheForTesting: jest.fn()

--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -364,7 +364,7 @@ class HttpGateway {
       security &&
         ((security.apiKeys && security.apiKeys.length > 0) ||
           (security.mcpTokens && security.mcpTokens.length > 0) ||
-          (security.ipWhitelist && security.ipWhitelist.length > 0))
+          security.ipWhitelist !== undefined)
     );
 
     if (!requiresAuthentication) {
@@ -412,7 +412,7 @@ class HttpGateway {
 
   private createCorsMiddleware(): RequestHandler | undefined {
     const security = this.options.security;
-    if (!security?.allowedOrigins || security.allowedOrigins.length === 0) {
+    if (security?.allowedOrigins === undefined) {
       return undefined;
     }
 
@@ -432,7 +432,7 @@ class HttpGateway {
           'Content-Type, Authorization, X-API-Key, X-MCP-Token, X-CSRF-Token'
         );
 
-        if (origin && isAllowed) {
+        if ((origin && isAllowed) || (!origin && this.isOriginAllowed(undefined))) {
           res.status(204).end();
           return;
         }
@@ -502,8 +502,12 @@ class HttpGateway {
 
   private isIpAllowed(ip: string): boolean {
     const whitelist = this.options.security?.ipWhitelist;
-    if (!whitelist || whitelist.length === 0) {
+    if (whitelist === undefined) {
       return true;
+    }
+
+    if (whitelist.length === 0) {
+      return false;
     }
 
     if (whitelist.includes('*')) {
@@ -515,8 +519,12 @@ class HttpGateway {
 
   private isOriginAllowed(origin: string | undefined): boolean {
     const origins = this.options.security?.allowedOrigins;
-    if (!origins || origins.length === 0) {
+    if (origins === undefined) {
       return true;
+    }
+
+    if (origins.length === 0) {
+      return origin === undefined;
     }
 
     if (!origin) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -179,7 +179,8 @@ async function bootstrap(): Promise<BootstrapContext> {
   if (tcpPort) {
     gateway = createHttpGateway(registry, {
       port: tcpPort,
-      oscConnectionProvider: oscConnectionState
+      oscConnectionProvider: oscConnectionState,
+      security: config.httpGateway.security
     });
     connections.push(gateway.start());
   }


### PR DESCRIPTION
## Summary
- parse HTTP gateway security environment variables and expose them via the config
- treat empty security allowlists as deny-all, wire config into the HTTP gateway, and extend coverage
- document the secure defaults and LAN override flow in the README, docs, and sample env file

## Testing
- npm test --silent -- src/config/__tests__/config.test.ts src/server/__tests__/httpGateway.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f9711b7458832ab796d2a912efd3cf