### PR TITLE
Add CLI logging flags and expand health diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ npx ts-node src/server/index.ts --check-config
 
 Ces commandes peuvent également être lancées sur la version compilée avec `node dist/server/index.js <option>`. Utilisez `--list-tools` pour inspecter rapidement les outils disponibles et `--check-config` afin de valider votre fichier `.env` ou les variables d'environnement avant un déploiement.
 
+Lorsque vous démarrez réellement le serveur (sans combiner d'option utilitaire ci-dessus), plusieurs modificateurs sont disponibles :
+
+- `--verbose` active la journalisation détaillée des messages OSC (entrants/sortants).
+- `--json-logs` force l'envoi des logs au format JSON vers STDOUT, en ignorant la configuration de destinations déclarée dans l'environnement.
+- `--stats-interval <durée>` publie périodiquement les compteurs RX/TX issus d'`OscService.getDiagnostics()` dans les logs (valeurs acceptant `10s`, `5s`, `5000ms`, etc.).
+
+Exemple :
+
+```bash
+npx ts-node src/server/index.ts --verbose --json-logs --stats-interval 30s
+```
+
 ## Configuration réseau et de la console Eos
 
 | Protocole | Port | Description |
@@ -156,9 +168,67 @@ Réponse attendue :
   "status": "ok",
   "uptimeMs": 1234,
   "toolCount": 5,
-  "transportActive": true
+  "transportActive": true,
+  "mcp": {
+    "http": {
+      "status": "listening",
+      "startedAt": 1715080000000,
+      "uptimeMs": 1234,
+      "websocketClients": 0,
+      "address": {
+        "address": "0.0.0.0",
+        "family": "IPv4",
+        "port": 3032
+      }
+    },
+    "stdio": {
+      "status": "listening",
+      "clients": 1,
+      "startedAt": 1715079999000,
+      "uptimeMs": 1200
+    }
+  },
+  "osc": {
+    "status": "online",
+    "updatedAt": 1715080000500,
+    "transports": {
+      "tcp": {
+        "type": "tcp",
+        "state": "connected",
+        "lastHeartbeatSentAt": 1715080000400,
+        "lastHeartbeatAckAt": 1715080000400,
+        "consecutiveFailures": 0
+      },
+      "udp": {
+        "type": "udp",
+        "state": "connected",
+        "lastHeartbeatSentAt": null,
+        "lastHeartbeatAckAt": null,
+        "consecutiveFailures": 0
+      }
+    },
+    "diagnostics": {
+      "config": {
+        "localAddress": "0.0.0.0",
+        "localPort": 8000,
+        "remoteAddress": "127.0.0.1",
+        "remotePort": 8001
+      },
+      "logging": { "incoming": false, "outgoing": false },
+      "stats": {
+        "incoming": { "count": 12, "bytes": 2048, "lastTimestamp": 1715080000300, "lastMessage": null, "addresses": [] },
+        "outgoing": { "count": 18, "bytes": 4096, "lastTimestamp": 1715080000350, "lastMessage": null, "addresses": [] }
+      },
+      "listeners": { "active": 1 },
+      "startedAt": 1715079900000,
+      "uptimeMs": 100000
+    }
+  }
 }
 ```
+
+Le bloc `mcp` regroupe désormais l'état du serveur HTTP (adresse liée, clients WebSocket, durée de fonctionnement) et du transport STDIO (nombre de clients et uptime).
+`osc.transports` expose le détail des liens TCP/UDP (derniers heartbeats, échecs consécutifs) tandis que `osc.diagnostics` réunit les compteurs RX/TX, la configuration réseau appliquée et l'état de la journalisation.
 
 #### Lister les outils disponibles
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -44,3 +44,13 @@ Pour vérifier la configuration effective, vous pouvez exécuter les tests unita
 ```bash
 npm test -- src/config/__tests__/config.test.ts
 ```
+
+## Raccourcis en ligne de commande
+
+En complément des variables d'environnement, certains indicateurs peuvent être activés directement lors du démarrage du serveur :
+
+- `--json-logs` force l'utilisation du format JSON sur STDOUT et ignore les destinations configurées (pratique pour rediriger la sortie vers un collecteur).
+- `--verbose` active la journalisation détaillée des messages OSC (entrants et sortants) via `OscService.setLoggingOptions()`.
+- `--stats-interval <durée>` publie périodiquement les compteurs RX/TX renvoyés par `OscService.getDiagnostics()` dans les logs (valeurs acceptant `10s`, `5s`, `5000ms`, etc.).
+
+Ces options peuvent être combinées avec `npm start` ou `npm run start:dev` en les ajoutant après `--` (ex. `npm run start:dev -- --verbose --stats-interval 30s`).

--- a/src/server/__tests__/cli.test.ts
+++ b/src/server/__tests__/cli.test.ts
@@ -1,6 +1,8 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import { resolve } from 'node:path';
 import { getPackageVersion } from '../../utils/version';
+import type { AppConfig } from '../../config/index';
+import { parseCliArguments, applyBootstrapOverrides } from '../index';
 
 type CliResult = SpawnSyncReturns<string>;
 
@@ -29,6 +31,9 @@ describe('CLI du serveur MCP', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('Usage : node');
     expect(result.stdout).toContain('--list-tools');
+    expect(result.stdout).toContain('--verbose');
+    expect(result.stdout).toContain('--json-logs');
+    expect(result.stdout).toContain('--stats-interval');
     expect(result.stderr).toBe('');
   });
 
@@ -65,5 +70,72 @@ describe('CLI du serveur MCP', () => {
     expect(result.stdout).toBe('');
     expect(result.stderr).toContain('Configuration invalide :');
     expect(result.stderr).toContain('MCP_TCP_PORT');
+  });
+
+  test('refuse une valeur invalide pour --stats-interval', () => {
+    const result = runCli(['--stats-interval', 'abc']);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('--stats-interval');
+  });
+});
+
+describe('analyse des arguments CLI', () => {
+  test('active les options verbose et json-logs', () => {
+    const options = parseCliArguments(['--verbose', '--json-logs']);
+
+    expect(options.verbose).toBe(true);
+    expect(options.jsonLogs).toBe(true);
+    expect(options.errors).toHaveLength(0);
+  });
+
+  test('convertit --stats-interval en millisecondes', () => {
+    const options = parseCliArguments(['--stats-interval', '15s']);
+
+    expect(options.statsIntervalMs).toBe(15000);
+    expect(options.errors).toHaveLength(0);
+  });
+
+  test('signale une valeur invalide pour --stats-interval', () => {
+    const options = parseCliArguments(['--stats-interval=foo']);
+
+    expect(options.errors).toHaveLength(1);
+    expect(options.statsIntervalMs).toBeUndefined();
+  });
+});
+
+describe('override de configuration', () => {
+  test('force une sortie JSON unique sur STDOUT', () => {
+    const baseConfig: AppConfig = {
+      mcp: { tcpPort: 3032 },
+      osc: {
+        remoteAddress: '127.0.0.1',
+        tcpPort: 3032,
+        udpOutPort: 8001,
+        udpInPort: 8000,
+        localAddress: '0.0.0.0'
+      },
+      logging: {
+        level: 'info',
+        format: 'pretty',
+        destinations: [{ type: 'file', path: '/var/log/eos/mcp.log' }]
+      },
+      httpGateway: {
+        security: {
+          apiKeys: [],
+          mcpTokens: [],
+          ipAllowlist: [],
+          allowedOrigins: [],
+          rateLimit: { windowMs: 60000, max: 60 }
+        }
+      }
+    };
+
+    const overridden = applyBootstrapOverrides(baseConfig, { forceJsonLogs: true });
+
+    expect(overridden.logging.format).toBe('json');
+    expect(overridden.logging.destinations).toEqual([{ type: 'stdout' }]);
+    expect(baseConfig.logging.destinations).toEqual([{ type: 'file', path: '/var/log/eos/mcp.log' }]);
   });
 });


### PR DESCRIPTION
## Summary
- extend the CLI to support --verbose, --json-logs and configurable OSC stats reporting while forcing stdout JSON output when requested
- expose richer MCP/OSC information on /health by wiring the OSC gateway and stdio status into the HTTP gateway
- document the new options and update Jest coverage for the CLI parsing, logging overrides and health payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f976ef0ddc832ab21f72f424a0db12