### PR TITLE
Add automation cookbook and highlight core tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@
 - Intégrer Eos dans un workflow n8n afin de synchroniser régie, timecode et automation.
 - Superviser et auditer les commandes envoyées à distance via la passerelle HTTP/WS optionnelle.
 
+## Documentation complémentaire
+
+- [Cookbook d’automatisation](docs/cookbook.md) : scénarios prêts à l’emploi pour déclencher des cues, manipuler les presets et ajuster des niveaux d’intensité.
+- [`docs/tools.md`](docs/tools.md) : référence exhaustive générée automatiquement pour chaque outil MCP.
+
+### Outils MCP essentiels
+
+| Outil | Description | Fiche détaillée |
+| --- | --- | --- |
+| `eos_cue_go` | GO sur la liste de cues active. | [docs/tools.md#eos-cue-go](docs/tools.md#eos-cue-go) |
+| `eos_cue_stop_back` | Stop ou retour en arrière sur une liste. | [docs/tools.md#eos-cue-stop-back](docs/tools.md#eos-cue-stop-back) |
+| `eos_preset_fire` | Rappel immédiat d’un preset. | [docs/tools.md#eos-preset-fire](docs/tools.md#eos-preset-fire) |
+| `eos_channel_set_level` | Réglage d’intensité (0–100 %) d’un canal. | [docs/tools.md#eos-channel-set-level](docs/tools.md#eos-channel-set-level) |
+
 ## Prérequis
 
 - Node.js 20+ (tests effectués avec la LTS actuelle).

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,0 +1,115 @@
+# Cookbook d'automatisation Eos MCP
+
+Ce guide rassemble des scénarios prêts à l'emploi pour piloter la console ETC Eos via la passerelle MCP. Chaque section combine un rappel métier, un exemple JSON directement exploitable dans un client MCP et la commande OSC correspondante (commentée) pour vos tests manuels. Les fiches d'outils détaillées sont disponibles dans [docs/tools.md](tools.md) ; les ancres sont rappelées ci-dessous pour passer rapidement de la recette à la référence complète.
+
+## Déclencher et rattraper une cue
+
+### Objectif
+Assurer un top lumière depuis un LLM ou un workflow d'automatisation, tout en gardant la main pour annuler/rattraper immédiatement si nécessaire.
+
+### Outils MCP mobilisés
+- [`eos_cue_go`](tools.md#eos-cue-go) : lance la prochaine cue d'une liste.
+- [`eos_cue_stop_back`](tools.md#eos-cue-stop-back) : stoppe la lecture en cours ou revient à la cue précédente.
+
+### Requête MCP (JSON)
+```json
+{
+  "type": "call_tool",
+  "tool": "eos_cue_go",
+  "arguments": {
+    "cuelist_number": 1
+  }
+}
+```
+
+> 💡 Ajustez `cuelist_number` si vous utilisez plusieurs listes dans le show. Combinez cette requête avec un ID de conversation côté LLM pour tracer vos déclenchements.
+
+### Commandes OSC commentées
+```bash
+# GO sur la liste 1 (port UDP sortant par défaut : 8001)
+oscsend 127.0.0.1 8001 /eos/cue/1/go s:'{"cuelist_number":1}'
+
+# STOP/BACK sur la même liste pour annuler le top
+oscsend 127.0.0.1 8001 /eos/cue/1/stop_back s:'{"cuelist_number":1}'
+```
+
+### Astuces d'intégration
+- Encapsulez `eos_cue_go` dans une commande « safe » côté LLM : demandez une confirmation écrite avant l'appel final.
+- Connectez un webhook de monitoring sur le log `ToolExecutionResult` pour tracer qui a déclenché le GO et à quelle heure.
+
+## Orchestrer vos presets
+
+### Objectif
+Rappeler, présélectionner ou auditer un preset lumière pour préparer un tableau sans casser la balance actuelle.
+
+### Outils MCP mobilisés
+- [`eos_preset_get_info`](tools.md#eos-preset-get-info) : récupère label, niveaux et métadonnées du preset.
+- [`eos_preset_select`](tools.md#eos-preset-select) : prépare le preset sur le clavier virtuel Eos.
+- [`eos_preset_fire`](tools.md#eos-preset-fire) : applique immédiatement le preset aux canaux concernés.
+
+### Requête MCP (JSON)
+```json
+{
+  "type": "call_tool",
+  "tool": "eos_preset_get_info",
+  "arguments": {
+    "preset_number": 12,
+    "fields": ["label", "channels", "effects"]
+  }
+}
+```
+
+> 💡 Débutez toujours par `eos_preset_get_info` pour vérifier l'état avant rappel. Les champs optionnels permettent de limiter la taille de la réponse si vous intégrez le résultat dans une interface.
+
+### Commandes OSC commentées
+```bash
+# Inspection du preset 12 (réponse JSON renvoyée sur le port UDP entrant du serveur MCP)
+oscsend 127.0.0.1 8001 /eos/preset/info s:'{"preset_number":12}'
+
+# Mise en sélection du preset 12 pour prévisualiser au clavier
+oscsend 127.0.0.1 8001 /eos/preset/12/select s:'{"preset_number":12}'
+
+# Rappel immédiat du preset 12 sur scène
+oscsend 127.0.0.1 8001 /eos/preset/12/fire s:'{"preset_number":12}'
+```
+
+### Astuces d'intégration
+- Enchaînez la sélection (`select`) puis le rappel (`fire`) dans un même script MCP si vous souhaitez valider la balance avec un opérateur avant application.
+- Enregistrez la réponse de `eos_preset_get_info` pour alimenter vos fiches régie ou générer un rapport de focale.
+
+## Ajuster l'intensité en live
+
+### Objectif
+Réaliser un « fade » rapide ou un ajustement ponctuel de niveau depuis un assistant conversationnel sans ouvrir le clavier physique.
+
+### Outil MCP mobilisé
+- [`eos_channel_set_level`](tools.md#eos-channel-set-level) : fixe la valeur (0–100 %) d'un canal.
+
+### Requête MCP (JSON)
+```json
+{
+  "type": "call_tool",
+  "tool": "eos_channel_set_level",
+  "arguments": {
+    "channels": [101, 102],
+    "level": 65
+  }
+}
+```
+
+> 💡 Vous pouvez fournir un seul canal (`"channels": 101`) ou une plage (`"channels": "101-110"`) selon vos besoins. Le champ `level` accepte une valeur numérique ou des mots-clés (`"FULL"`, `"OUT"`).
+
+### Commande OSC commentée
+```bash
+# Mise à 65 % des canaux 101 et 102
+oscsend 127.0.0.1 8001 /eos/channel/level s:'{"channels":[101,102],"level":65}'
+```
+
+### Astuces d'intégration
+- Combinez cette recette avec `eos_group_set_level` si vous pilotez des groupes plutôt que des canaux individuels.
+- Pour animer un fade, déclenchez plusieurs appels `eos_channel_set_level` espacés dans le temps (par exemple via un workflow n8n) en ajustant la valeur progressivement.
+
+## Aller plus loin
+- Les commandes CLI générées automatiquement sont disponibles dans [`docs/tools.md`](tools.md) pour chaque outil.
+- Ajoutez des validations côté LLM (ex. : confirmation vocale) avant d'exécuter une commande critique.
+- Utilisez les champs `targetAddress` / `targetPort` lorsque le serveur MCP doit router des messages vers une console distante spécifique.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -5,6 +5,16 @@
 
 Chaque outil expose son nom MCP, une description, la liste des arguments attendus ainsi qu'un exemple d'appel en CLI et par OSC.
 
+## Outils mis en avant
+
+| Outil | Résumé | Lien |
+| --- | --- | --- |
+| `eos_channel_set_level` | Reglage de niveau | [#eos-channel-set-level](#eos-channel-set-level) |
+| `eos_cue_go` | GO sur liste de cues | [#eos-cue-go](#eos-cue-go) |
+| `eos_cue_stop_back` | Stop ou Back sur liste de cues | [#eos-cue-stop-back](#eos-cue-stop-back) |
+| `eos_preset_fire` | Declenchement de preset | [#eos-preset-fire](#eos-preset-fire) |
+| `eos_preset_get_info` | Informations de preset | [#eos-preset-get-info](#eos-preset-get-info) |
+
 <a id="eos-address-select"></a>
 ## Selection d'adresse DMX (`eos_address_select`)
 
@@ -361,6 +371,7 @@ oscsend 127.0.0.1 8001 /eos/cmd s:'{"template":"exemple"}'
 | `localPort` | number | Oui | — |
 | `remoteAddress` | string | Oui | — |
 | `remotePort` | number | Oui | — |
+| `tcpPort` | number | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -391,6 +402,7 @@ _Pas de mapping OSC documenté._
 | `protocolTimeoutMs` | number | Non | — |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
+| `transportPreference` | enum(reliability, speed, auto) | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -2076,6 +2088,7 @@ oscsend 127.0.0.1 8001 /eos/get/patch/chan_info s:'{"channel_number":1}'
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `timeoutMs` | number | Non | — |
+| `transportPreference` | enum(reliability, speed, auto) | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -2257,6 +2270,7 @@ oscsend 127.0.0.1 8001 /eos/preset/select s:'{"preset_number":1}'
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `timeoutMs` | number | Non | — |
+| `transportPreference` | enum(reliability, speed, auto) | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -2690,6 +2704,7 @@ oscsend 127.0.0.1 8001 /eos/sub/{id} s:'{"submaster_number":1,"level":1}'
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `timeoutMs` | number | Non | — |
+| `transportPreference` | enum(reliability, speed, auto) | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 

--- a/src/tools/channels/index.ts
+++ b/src/tools/channels/index.ts
@@ -231,7 +231,10 @@ export const eosChannelSetLevelTool: ToolDefinition<typeof setLevelSchema> = {
     title: 'Reglage de niveau',
     description: 'Ajuste le niveau intensite de canaux specifiques (0-100).',
     inputSchema: setLevelSchema,
-    annotations: annotate(oscMappings.channels.level)
+    annotations: {
+      ...annotate(oscMappings.channels.level),
+      highlighted: true
+    }
   },
   handler: async (args, _extra) => {
     const schema = z.object(setLevelSchema).strict();

--- a/src/tools/cues/go.ts
+++ b/src/tools/cues/go.ts
@@ -40,7 +40,8 @@ export const eosCueGoTool: ToolDefinition<typeof goInputSchema> = {
     annotations: {
       mapping: {
         osc: oscMappings.cues.go
-      }
+      },
+      highlighted: true
     }
   },
   handler: async (args) => {

--- a/src/tools/cues/stop_back.ts
+++ b/src/tools/cues/stop_back.ts
@@ -37,7 +37,8 @@ export const eosCueStopBackTool: ToolDefinition<typeof stopBackInputSchema> = {
     annotations: {
       mapping: {
         osc: oscMappings.cues.stopBack
-      }
+      },
+      highlighted: true
     }
   },
   handler: async (args) => {

--- a/src/tools/presets/index.ts
+++ b/src/tools/presets/index.ts
@@ -477,7 +477,10 @@ export const eosPresetFireTool: ToolDefinition<typeof presetFireInputSchema> = {
     title: 'Declenchement de preset',
     description: 'Declenche un preset sur la console Eos.',
     inputSchema: presetFireInputSchema,
-    annotations: annotate(oscMappings.presets.fire)
+    annotations: {
+      ...annotate(oscMappings.presets.fire),
+      highlighted: true
+    }
   },
   handler: async (args) => {
     const schema = z.object(presetFireInputSchema).strict();
@@ -553,7 +556,10 @@ export const eosPresetGetInfoTool: ToolDefinition<typeof presetGetInfoInputSchem
     title: 'Informations de preset',
     description: 'Recupere les informations detaillees pour un preset donne.',
     inputSchema: presetGetInfoInputSchema,
-    annotations: annotate(oscMappings.presets.info)
+    annotations: {
+      ...annotate(oscMappings.presets.info),
+      highlighted: true
+    }
   },
   handler: async (args) => {
     const schema = z.object(presetGetInfoInputSchema).strict();


### PR DESCRIPTION
## Summary
- add a ready-to-use automation cookbook with JSON MCP and OSC examples
- link the cookbook from the README and surface a table of must-know tools
- surface highlighted tools in the generated docs by extending the tooling script

## Testing
- npm run docs:generate
- npm run lint *(fails: existing lint configuration errors about parserOptions.project and NodeJS globals)*

------
https://chatgpt.com/codex/tasks/task_e_68f97b05e044832a91d68e8a57158cd8