### PR TITLE
Rename HTTP gateway IP whitelist option to allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ La fonction `createHttpGateway` accepte un objet `security` pour appliquer une p
 |--------|-------------|
 | `apiKeys` | Tableau de clés API autorisées. À transmettre dans l’en-tête `X-API-Key`. |
 | `mcpTokens` | Liste de jetons MCP pour l’authentification (en-tête `X-MCP-Token` ou `Authorization: Bearer <token>`). Ces jetons sont également requis pour les requêtes mutantes afin de limiter les attaques CSRF. |
-| `ipWhitelist` | Liste d’adresses IP autorisées (`"*"` pour tout accepter). |
+| `ipAllowlist` | Liste d’adresses IP autorisées (`"*"` pour tout accepter). |
 | `allowedOrigins` | Origines HTTP/WS autorisées pour CORS/CORS WS (`"*"` pour tout accepter). |
 | `rateLimit` | Limiteur de débit en mémoire `{ windowMs, max }` appliqué par adresse IP. |
 | `express` | Permet de surcharger les middlewares Express (`authentication`, `csrf`, `cors`, `throttling`). |
@@ -331,7 +331,7 @@ createHttpGateway(registry, {
   security: {
     apiKeys: ['test-key'],
     mcpTokens: ['token-123'],
-    ipWhitelist: ['127.0.0.1'],
+    ipAllowlist: ['127.0.0.1'],
     allowedOrigins: ['http://localhost'],
     rateLimit: { windowMs: 60000, max: 30 }
   }

--- a/src/server/__tests__/httpGateway.test.ts
+++ b/src/server/__tests__/httpGateway.test.ts
@@ -257,7 +257,7 @@ describe('HttpGateway security options', () => {
   const securityOptions = {
     apiKeys: ['test-key'],
     mcpTokens: ['token-123'],
-    ipWhitelist: ['127.0.0.1', '::1', '::ffff:127.0.0.1'],
+    ipAllowlist: ['127.0.0.1', '::1', '::ffff:127.0.0.1'],
     allowedOrigins: ['http://localhost'],
     rateLimit: { windowMs: 10_000, max: 2 }
   } as const;
@@ -345,7 +345,7 @@ describe('HttpGateway security options', () => {
     await gateway.stop();
     gateway = createHttpGateway(registry, {
       port: 0,
-      security: { ...securityOptions, ipWhitelist: [] }
+      security: { ...securityOptions, ipAllowlist: [] }
     });
     await gateway.start();
     const address = gateway.getAddress();

--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -33,10 +33,10 @@ interface HttpGatewayOptions {
 }
 
 interface HttpGatewaySecurityOptions {
-  apiKeys?: string[];
-  mcpTokens?: string[];
-  ipWhitelist?: string[];
-  allowedOrigins?: string[];
+  apiKeys?: readonly string[];
+  mcpTokens?: readonly string[];
+  ipAllowlist?: readonly string[];
+  allowedOrigins?: readonly string[];
   rateLimit?: RateLimitOptions;
   express?: ExpressSecurityMiddlewares;
 }
@@ -477,7 +477,7 @@ class HttpGateway {
       security &&
         ((security.apiKeys && security.apiKeys.length > 0) ||
           (security.mcpTokens && security.mcpTokens.length > 0) ||
-          security.ipWhitelist !== undefined)
+          security.ipAllowlist !== undefined)
     );
 
     if (!requiresAuthentication) {
@@ -614,20 +614,20 @@ class HttpGateway {
   }
 
   private isIpAllowed(ip: string): boolean {
-    const whitelist = this.options.security?.ipWhitelist;
-    if (whitelist === undefined) {
+    const allowlist = this.options.security?.ipAllowlist;
+    if (allowlist === undefined) {
       return true;
     }
 
-    if (whitelist.length === 0) {
+    if (allowlist.length === 0) {
       return false;
     }
 
-    if (whitelist.includes('*')) {
+    if (allowlist.includes('*')) {
       return true;
     }
 
-    return whitelist.includes(ip) || whitelist.includes(`::ffff:${ip}`);
+    return allowlist.includes(ip) || allowlist.includes(`::ffff:${ip}`);
   }
 
   private isOriginAllowed(origin: string | undefined): boolean {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -264,10 +264,10 @@ async function bootstrap(options: BootstrapOptions = {}): Promise<BootstrapConte
   const securityOptions: NonNullable<
     Parameters<typeof createHttpGateway>[1]['security']
   > = {
-    apiKeys: [...effectiveConfig.httpGateway.security.apiKeys],
-    mcpTokens: [...effectiveConfig.httpGateway.security.mcpTokens],
-    ipWhitelist: [...effectiveConfig.httpGateway.security.ipAllowlist],
-    allowedOrigins: [...effectiveConfig.httpGateway.security.allowedOrigins],
+    apiKeys: Array.from(effectiveConfig.httpGateway.security.apiKeys),
+    mcpTokens: Array.from(effectiveConfig.httpGateway.security.mcpTokens),
+    ipAllowlist: Array.from(effectiveConfig.httpGateway.security.ipAllowlist),
+    allowedOrigins: Array.from(effectiveConfig.httpGateway.security.allowedOrigins),
     rateLimit: {
       windowMs: effectiveConfig.httpGateway.security.rateLimit.windowMs,
       max: effectiveConfig.httpGateway.security.rateLimit.max


### PR DESCRIPTION
## Summary
- rename the HTTP gateway security option from `ipWhitelist` to `ipAllowlist` and accept readonly arrays
- update configuration bootstrap logic and documentation to work with the new allowlist name
- refresh the HTTP gateway security tests to exercise the renamed allowlist behaviour

## Testing
- npm run build
- npm test -- httpGateway

------
https://chatgpt.com/codex/tasks/task_e_68f9f4780354832abbd66945f53adc6a