### PR TITLE
Expose Claude manifest endpoints for Claude integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ node --version
 
 - `npm run build` : compile TypeScript vers `dist/`.
 - `npm run lint` : vérifie le style de code avec ESLint.
+- `npm run lint:manifest` : valide la structure du manifest MCP via Ajv.
 - `npm test` : exécute la suite de tests (Jest).
 - `npm start` : lance le serveur MCP compilé en mode stdio.
 - `npm run start:dev` : lance le serveur MCP directement avec `ts-node`.
@@ -243,6 +244,32 @@ Réponse attendue :
 
 Le bloc `mcp` regroupe désormais l'état du serveur HTTP (adresse liée, clients WebSocket, durée de fonctionnement) et du transport STDIO (nombre de clients et uptime).
 `osc.transports` expose le détail des liens TCP/UDP (derniers heartbeats, échecs consécutifs) tandis que `osc.diagnostics` réunit les compteurs RX/TX, la configuration réseau appliquée et l'état de la journalisation.
+
+### Enregistrer le manifest MCP dans Claude
+
+Le serveur expose automatiquement le manifest Claude-compatible sur `GET /manifest.json`. Ce fichier référence la liste des outils (`/tools`), le schéma JSON de chaque outil (`/schemas/tools/{toolName}.json`) ainsi qu’un catalogue (`/schemas/tools/index.json`).
+
+1. Vérifiez la validité du manifest localement :
+
+   ```bash
+   npm run lint:manifest
+   ```
+
+2. Assurez-vous que votre passerelle HTTP/WS est accessible publiquement (reverse proxy, tunnel, etc.) et notez l’URL complète du manifest (par exemple `https://mcp.example.com/manifest.json`).
+
+3. Enregistrez le service dans Claude via l’outil officiel :
+
+   ```bash
+   npx @anthropic-ai/anthropic-cli mcp register --manifest-url https://mcp.example.com/manifest.json
+   ```
+
+4. Vous pouvez tester l’intégration MCP en mode local via :
+
+   ```bash
+   npx @anthropic-ai/anthropic-cli mcp test --manifest-url http://localhost:3032/manifest.json
+   ```
+
+Le manifest est également copié automatiquement dans `dist/manifest.json` lors du `npm run build`, garantissant sa présence dans vos artefacts de déploiement (binaire `pkg`, archives, etc.).
 
 #### Lister les outils disponibles
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,35 @@
+{
+  "name": "Eos MCP",
+  "description": "Serveur MCP pour piloter les consoles ETC Eos via des outils compatibles Claude et Model Context Protocol.",
+  "version": "1.0.0",
+  "mcp": {
+    "schema_version": "1.0",
+    "documentation_url": "https://github.com/Nairolf138/Eos_MCP",
+    "servers": [
+      {
+        "type": "http",
+        "url": "{{SERVER_URL}}",
+        "endpoints": {
+          "manifest": "/manifest.json",
+          "health": "/health",
+          "tools": "/tools",
+          "invoke": "/tools/{toolName}",
+          "websocket": "/ws"
+        }
+      }
+    ],
+    "capabilities": {
+      "tools": {
+        "list_endpoint": "/tools",
+        "invoke_endpoint": "/tools/{toolName}",
+        "schema_catalogs": [
+          "/schemas/tools/index.json"
+        ],
+        "schema_base_path": "/schemas/tools/{toolName}.json"
+      }
+    },
+    "schemas": {
+      "tool_catalog": "/schemas/tools/index.json"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3697,9 +3697,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "description": "Bootstrap project for an MCP-compatible OSC service",
   "main": "dist/server/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node -e \"const fs=require('node:fs');fs.mkdirSync('dist',{recursive:true});fs.copyFileSync('manifest.json','dist/manifest.json');\"",
     "lint": "eslint \"src/**/*.ts\"",
     "test": "jest --passWithNoTests",
     "start": "node dist/server/index.js",
     "start:dev": "ts-node src/server/index.ts",
     "docs:generate": "ts-node --transpile-only --compiler-options '{\"allowImportingTsExtensions\":true}' scripts/toolDocs.ts",
     "docs:check": "ts-node --transpile-only --compiler-options '{\"allowImportingTsExtensions\":true}' scripts/toolDocs.ts --check --skip-jsdoc",
-    "package": "npm run build && node -e \"require('node:fs').mkdirSync('dist/bin',{recursive:true});\" && npx pkg dist/server/index.js --targets node20-linux-x64 --output dist/bin/eos-mcp"
+    "package": "npm run build && node -e \"require('node:fs').mkdirSync('dist/bin',{recursive:true});\" && npx pkg dist/server/index.js --targets node20-linux-x64 --output dist/bin/eos-mcp",
+    "lint:manifest": "ts-node --transpile-only scripts/validateManifest.ts"
   },
   "keywords": [
     "mcp",
@@ -23,11 +24,11 @@
   "type": "commonjs",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.20.1",
+    "dotenv": "^16.4.5",
     "express": "^5.1.0",
     "osc": "^2.4.5",
     "pino": "^10.1.0",
     "pino-pretty": "^11.2.2",
-    "dotenv": "^16.4.5",
     "ws": "^8.18.3",
     "zod": "^3.25.6",
     "zod-to-json-schema": "^3.24.6"
@@ -43,10 +44,10 @@
     "eslint": "^9.38.0",
     "globals": "^16.4.0",
     "jest": "^30.2.0",
+    "pkg": "^5.8.1",
     "ts-jest": "^29.4.5",
     "ts-morph": "^27.0.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3",
-    "pkg": "^5.8.1"
+    "typescript": "^5.9.3"
   }
 }

--- a/scripts/validateManifest.ts
+++ b/scripts/validateManifest.ts
@@ -1,0 +1,159 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import Ajv, { type JSONSchemaType } from 'ajv';
+
+interface Manifest {
+  name: string;
+  description: string;
+  version: string;
+  mcp: {
+    schema_version: string;
+    documentation_url?: string;
+    servers: Array<{
+      type: string;
+      url?: string;
+      endpoints?: Record<string, string>;
+    }>;
+    capabilities: {
+      tools?: {
+        list_endpoint?: string;
+        invoke_endpoint?: string;
+        schema_catalogs?: string[];
+        schema_base_path?: string;
+      };
+    };
+    schemas?: {
+      tool_catalog?: string;
+    };
+  };
+}
+
+const manifestSchema: JSONSchemaType<Manifest> = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['name', 'description', 'version', 'mcp'],
+  properties: {
+    name: { type: 'string', minLength: 1 },
+    description: { type: 'string', minLength: 1 },
+    version: { type: 'string', minLength: 1 },
+    mcp: {
+      type: 'object',
+      additionalProperties: true,
+      required: ['schema_version', 'servers', 'capabilities'],
+      properties: {
+        schema_version: { type: 'string', minLength: 1 },
+        documentation_url: { type: 'string', nullable: true },
+        servers: {
+          type: 'array',
+          minItems: 1,
+          items: {
+            type: 'object',
+            additionalProperties: true,
+            required: ['type'],
+            properties: {
+              type: { type: 'string', minLength: 1 },
+              url: { type: 'string', nullable: true },
+              endpoints: {
+                type: 'object',
+                nullable: true,
+                required: [],
+                additionalProperties: { type: 'string' }
+              }
+            }
+          }
+        },
+        capabilities: {
+          type: 'object',
+          additionalProperties: true,
+          required: [],
+          properties: {
+            tools: {
+              type: 'object',
+              nullable: true,
+              additionalProperties: true,
+              required: [],
+              properties: {
+                list_endpoint: { type: 'string', nullable: true },
+                invoke_endpoint: { type: 'string', nullable: true },
+                schema_catalogs: {
+                  type: 'array',
+                  nullable: true,
+                  items: { type: 'string', minLength: 1 }
+                },
+                schema_base_path: { type: 'string', nullable: true }
+              }
+            }
+          }
+        },
+        schemas: {
+          type: 'object',
+          nullable: true,
+          additionalProperties: true,
+          required: [],
+          properties: {
+            tool_catalog: { type: 'string', nullable: true }
+          }
+        }
+      }
+    }
+  }
+};
+
+function ensureToolSchemaLinks(manifest: Manifest): void {
+  const schemaCatalogs = manifest.mcp.capabilities.tools?.schema_catalogs ?? [];
+  if (!schemaCatalogs.includes('/schemas/tools/index.json')) {
+    throw new Error(
+      "Le manifest doit référencer '/schemas/tools/index.json' dans mcp.capabilities.tools.schema_catalogs."
+    );
+  }
+
+  const basePath = manifest.mcp.capabilities.tools?.schema_base_path;
+  if (typeof basePath !== 'string' || basePath.length === 0) {
+    throw new Error(
+      "Le manifest doit définir mcp.capabilities.tools.schema_base_path vers les schémas JSON des outils."
+    );
+  }
+
+  if (!basePath.includes('{toolName}')) {
+    throw new Error(
+      "Le champ mcp.capabilities.tools.schema_base_path doit contenir le placeholder '{toolName}'."
+    );
+  }
+
+  const catalogRef = manifest.mcp.schemas?.tool_catalog;
+  if (catalogRef !== '/schemas/tools/index.json') {
+    throw new Error(
+      "Le manifest doit aligner mcp.schemas.tool_catalog sur '/schemas/tools/index.json'."
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const manifestPath = path.resolve(process.cwd(), 'manifest.json');
+  const raw = await fs.readFile(manifestPath, 'utf-8');
+  let manifest: Manifest;
+
+  try {
+    manifest = JSON.parse(raw) as Manifest;
+  } catch (error) {
+    throw new Error(`Impossible de parser ${manifestPath} : ${(error as Error).message}`);
+  }
+
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  const validate = ajv.compile(manifestSchema);
+  const valid = validate(manifest);
+
+  if (!valid) {
+    const messages = (validate.errors ?? []).map((err) => `${err.instancePath} ${err.message ?? ''}`.trim());
+    throw new Error(`Le manifest est invalide :\n - ${messages.join('\n - ')}`);
+  }
+
+  ensureToolSchemaLinks(manifest);
+  console.log('Manifest valide ✅');
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a Claude-compatible manifest at the repository root and ensure it is packaged during builds
- introduce an AJV-based validation script wired to `npm run lint:manifest`
- serve the manifest and generated tool schemas from the HTTP gateway with documentation and Jest coverage

## Testing
- npm run lint:manifest
- npm test -- src/server/__tests__/httpGateway.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa2a602bf8832a8f1a468181b896e9