### PR TITLE
Preserve OSC gateway listeners during reconfigure

### DIFF
--- a/src/services/osc/gateway.ts
+++ b/src/services/osc/gateway.ts
@@ -203,19 +203,21 @@ export class OscConnectionGateway implements OscGateway {
     this.manager.removeTool(toolId);
   }
 
-  public close(): void {
+  public close(options: { preserveListeners?: boolean } = {}): void {
     this.detachManagerEvents(this.manager);
     this.manager.stop();
     if (this.connectionStateProvider) {
       this.connectionStateProvider.setStatus(this.manager.getStatus('tcp'));
       this.connectionStateProvider.setStatus(this.manager.getStatus('udp'));
     }
-    this.listeners.clear();
-    this.statusListeners.clear();
+    if (!options.preserveListeners) {
+      this.listeners.clear();
+      this.statusListeners.clear();
+    }
   }
 
   public reconfigure(options: OscConnectionGatewayOptions): void {
-    this.close();
+    this.close({ preserveListeners: true });
     this.config.host = options.host;
     this.config.tcpPort = options.tcpPort;
     this.config.udpPort = options.udpPort;


### PR DESCRIPTION
## Summary
- keep existing OSC message and status listeners when reconfiguring the gateway by preserving them during close
- add regression coverage ensuring registered listeners still receive events after reconfiguration

## Testing
- npx jest src/services/osc/__tests__/gateway.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fcbe395c38832a83f2e25248f31a0d