### PR TITLE
Align manifest servers structure with MCP schema

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,14 +7,18 @@
     "documentation_url": "https://github.com/Nairolf138/Eos_MCP",
     "servers": [
       {
-        "type": "http",
-        "url": "{{SERVER_URL}}",
-        "endpoints": {
-          "manifest": "/manifest.json",
-          "health": "/health",
-          "tools": "/tools",
-          "invoke": "/tools/{toolName}",
-          "websocket": "/ws"
+        "server": {
+          "transport": {
+            "type": "http",
+            "url": "{{SERVER_URL}}"
+          },
+          "endpoints": {
+            "manifest": "/manifest.json",
+            "health": "/health",
+            "tools": "/tools",
+            "invoke": "/tools/{toolName}",
+            "websocket": "/ws"
+          }
         }
       }
     ],

--- a/scripts/validateManifest.ts
+++ b/scripts/validateManifest.ts
@@ -11,9 +11,13 @@ interface Manifest {
     schema_version: string;
     documentation_url?: string;
     servers: Array<{
-      type: string;
-      url?: string;
-      endpoints?: Record<string, string>;
+      server: {
+        transport: {
+          type: string;
+          url?: string;
+        };
+        endpoints?: Record<string, string>;
+      };
     }>;
     capabilities: {
       tools?: {
@@ -50,15 +54,29 @@ const manifestSchema: JSONSchemaType<Manifest> = {
           items: {
             type: 'object',
             additionalProperties: true,
-            required: ['type'],
+            required: ['server'],
             properties: {
-              type: { type: 'string', minLength: 1 },
-              url: { type: 'string', nullable: true },
-              endpoints: {
+              server: {
                 type: 'object',
-                nullable: true,
-                required: [],
-                additionalProperties: { type: 'string' }
+                additionalProperties: true,
+                required: ['transport'],
+                properties: {
+                  transport: {
+                    type: 'object',
+                    additionalProperties: true,
+                    required: ['type'],
+                    properties: {
+                      type: { type: 'string', minLength: 1 },
+                      url: { type: 'string', nullable: true }
+                    }
+                  },
+                  endpoints: {
+                    type: 'object',
+                    nullable: true,
+                    required: [],
+                    additionalProperties: { type: 'string' }
+                  }
+                }
               }
             }
           }

--- a/src/server/__tests__/httpGateway.test.ts
+++ b/src/server/__tests__/httpGateway.test.ts
@@ -215,6 +215,12 @@ describe('HttpGateway integration', () => {
       description?: unknown;
       version?: string;
       mcp?: {
+        servers?: Array<{
+          server?: {
+            transport?: { type?: string; url?: string };
+            endpoints?: Record<string, string>;
+          };
+        }>;
         capabilities?: {
           tools?: {
             schema_catalogs?: string[];
@@ -229,6 +235,12 @@ describe('HttpGateway integration', () => {
     expect(typedManifest.version).toBe('1.0.0');
     const mcp = typedManifest.mcp as
       | {
+          servers?: Array<{
+            server?: {
+              transport?: { type?: string; url?: string };
+              endpoints?: Record<string, string>;
+            };
+          }>;
           capabilities?: {
             tools?: {
               schema_catalogs?: string[];
@@ -241,6 +253,18 @@ describe('HttpGateway integration', () => {
     if (!mcp) {
       throw new Error('Manifest MCP block missing');
     }
+
+    const servers = mcp.servers ?? [];
+    expect(servers).not.toHaveLength(0);
+    const [httpServer] = servers;
+    expect(httpServer?.server?.transport?.type).toBe('http');
+    expect(httpServer?.server?.transport?.url).toBe('{{SERVER_URL}}');
+    const endpoints = httpServer?.server?.endpoints ?? {};
+    expect(endpoints.manifest).toBe('/manifest.json');
+    expect(endpoints.health).toBe('/health');
+    expect(endpoints.tools).toBe('/tools');
+    expect(endpoints.invoke).toBe('/tools/{toolName}');
+    expect(endpoints.websocket).toBe('/ws');
 
     const catalogRefs = mcp.capabilities?.tools?.schema_catalogs ?? [];
     expect(catalogRefs).toContain('/schemas/tools/index.json');


### PR DESCRIPTION
## Summary
- adopt the `servers[].server` manifest structure with nested transport and endpoint fields for the HTTP gateway
- update the manifest validation schema and interfaces to accept and enforce the new layout
- extend the HTTP gateway test to assert the manifest response matches the updated format

## Testing
- npm run lint:manifest
- npm test -- httpGateway

------
https://chatgpt.com/codex/tasks/task_e_68fccfe7db00832ab9ced02549ba5852