### PR TITLE
Serve dynamic manifest URL with configurable public endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,22 @@ Réponse attendue :
 }
 ```
 
+#### Publier la passerelle via un tunnel ou un reverse proxy
+
+L'endpoint `/manifest.json` annonce une URL absolue à destination des clients MCP. Par défaut, cette URL est déduite dynamiquement de la requête entrante (en tenant compte des en-têtes `Host`, `X-Forwarded-Host` et `X-Forwarded-Proto`). Lorsque vous exposez le serveur derrière un tunnel (`ngrok`, `Cloudflare Tunnel`, etc.) ou un reverse proxy (Nginx, Traefik, Caddy), vous pouvez forcer l'URL publiée via la variable d’environnement `MCP_HTTP_PUBLIC_URL` :
+
+```bash
+MCP_TCP_PORT=3032 \
+MCP_HTTP_PUBLIC_URL="https://eos-mcp.example.com" \
+npm run start:dev
+```
+
+- Si votre proxy réécrit le chemin (ex. `https://example.com/mcp`), incluez-le dans `MCP_HTTP_PUBLIC_URL` afin que les clients MCP résolvent correctement les endpoints (`/manifest.json`, `/health`, `/tools`, `/ws`).
+- Conservez les en-têtes `X-Forwarded-*` lorsque vous terminez TLS en amont : le serveur peut ainsi détecter automatiquement le schéma `https` et générer un manifest cohérent, même sans variable dédiée.
+- Pour les tunnels dynamiques (adresse changeante), automatisez la mise à jour de `MCP_HTTP_PUBLIC_URL` ou vérifiez que l’outil propage bien les en-têtes originaux.
+
+Une URL publique correctement configurée garantit que les assistants IA et orchestrateurs MCP peuvent établir des connexions WebSocket et HTTP sans dépendre d’un placeholder statique.
+
 Le bloc `mcp` regroupe désormais l'état du serveur HTTP (adresse liée, clients WebSocket, durée de fonctionnement) et du transport STDIO (nombre de clients et uptime).
 `osc.transports` expose le détail des liens TCP/UDP (derniers heartbeats, échecs consécutifs) tandis que `osc.diagnostics` réunit les compteurs RX/TX, la configuration réseau appliquée et l'état de la journalisation.
 

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
         "server": {
           "transport": {
             "type": "http",
-            "url": "{{SERVER_URL}}"
+            "url": ""
           },
           "endpoints": {
             "manifest": "/manifest.json",

--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -38,6 +38,7 @@ describe('configuration', () => {
         ]
       },
       httpGateway: {
+        publicUrl: undefined,
         security: {
           apiKeys: [],
           mcpTokens: ['change-me'],
@@ -66,6 +67,7 @@ describe('configuration', () => {
       MCP_HTTP_MCP_TOKENS: 'token-one,token-two',
       MCP_HTTP_IP_ALLOWLIST: '127.0.0.1,::1',
       MCP_HTTP_ALLOWED_ORIGINS: 'http://localhost',
+      MCP_HTTP_PUBLIC_URL: 'https://public.example/mcp/',
       MCP_HTTP_RATE_LIMIT_WINDOW: '120000',
       MCP_HTTP_RATE_LIMIT_MAX: '10'
     };
@@ -93,6 +95,7 @@ describe('configuration', () => {
       allowedOrigins: ['http://localhost'],
       rateLimit: { windowMs: 120000, max: 10 }
     });
+    expect(config.httpGateway.publicUrl).toBe('https://public.example/mcp');
   });
 
   it('rejette les ports invalides avec un message explicite', () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -329,6 +329,7 @@ async function bootstrap(options: BootstrapOptions = {}): Promise<BootstrapConte
   if (tcpPort) {
     gateway = createHttpGateway(registry, {
       port: tcpPort,
+      publicUrl: effectiveConfig.httpGateway.publicUrl,
       oscConnectionProvider: oscConnectionState,
       security: securityOptions,
       oscGateway,


### PR DESCRIPTION
## Summary
- generate the manifest response dynamically so the HTTP transport URL is resolved from the incoming request or an optional override
- introduce the `MCP_HTTP_PUBLIC_URL` configuration option with validation and updated test coverage
- document how to expose the gateway behind tunnels or reverse proxies and adjust manifest fixtures/tests

## Testing
- npm test
- npm test -- src/server/__tests__/httpGateway.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fcd14a338c832aa32b7fb69378b579