### PR TITLE
Normalize manifest URLs for public prefixes

### DIFF
--- a/src/server/__tests__/httpGateway.test.ts
+++ b/src/server/__tests__/httpGateway.test.ts
@@ -121,8 +121,9 @@ describe('HttpGateway integration', () => {
     if (!transport) {
       throw new Error('HTTP transport missing from manifest');
     }
+    const expectedPublicUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
     expect(transport.type).toBe('http');
-    expect(transport.url).toBe(baseUrl);
+    expect(transport.url).toBe(expectedPublicUrl);
     expect(transport.url).not.toContain('{{SERVER_URL}}');
   });
 
@@ -283,19 +284,20 @@ describe('HttpGateway integration', () => {
     expect(servers).not.toHaveLength(0);
     const [httpServer] = servers;
     expect(httpServer?.server?.transport?.type).toBe('http');
-    expect(httpServer?.server?.transport?.url).toBe(baseUrl);
+    const expectedPublicUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+    expect(httpServer?.server?.transport?.url).toBe(expectedPublicUrl);
     expect(httpServer?.server?.transport?.url).not.toContain('{{SERVER_URL}}');
     const endpoints = httpServer?.server?.endpoints ?? {};
-    expect(endpoints.manifest).toBe('/manifest.json');
-    expect(endpoints.health).toBe('/health');
-    expect(endpoints.tools).toBe('/tools');
-    expect(endpoints.invoke).toBe('/tools/{toolName}');
-    expect(endpoints.websocket).toBe('/ws');
+    expect(endpoints.manifest).toBe('manifest.json');
+    expect(endpoints.health).toBe('health');
+    expect(endpoints.tools).toBe('tools');
+    expect(endpoints.invoke).toBe('tools/{toolName}');
+    expect(endpoints.websocket).toBe('ws');
 
     const catalogRefs = mcp.capabilities?.tools?.schema_catalogs ?? [];
-    expect(catalogRefs).toContain('/schemas/tools/index.json');
+    expect(catalogRefs).toContain('schemas/tools/index.json');
     const basePath = mcp.capabilities?.tools?.schema_base_path;
-    expect(basePath).toBe('/schemas/tools/{toolName}.json');
+    expect(basePath).toBe('schemas/tools/{toolName}.json');
   });
 
   test('execute tool via WebSocket', async () => {

--- a/src/server/__tests__/httpGatewayManifestPrefix.test.ts
+++ b/src/server/__tests__/httpGatewayManifestPrefix.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import type { Request } from 'express';
+import { HttpGateway } from '../httpGateway';
+import type { ToolRegistry } from '../toolRegistry';
+
+describe('HttpGateway manifest prefix handling', () => {
+  test('applies publicUrl pathname prefix to manifest URLs', () => {
+    const gateway = new HttpGateway({} as unknown as ToolRegistry, {
+      port: 0,
+      publicUrl: 'https://example.com/mcp'
+    });
+
+    const manifestPath = path.resolve(__dirname, '../../..', 'manifest.json');
+    const manifestTemplate = JSON.parse(readFileSync(manifestPath, 'utf8')) as unknown;
+    Object.assign(gateway as unknown as { manifestTemplate: unknown }, { manifestTemplate });
+
+    const manifest = (gateway as unknown as { buildManifestResponse(req: Request): any }).buildManifestResponse(
+      {} as Request
+    );
+
+    const baseUrl = 'https://example.com/mcp/';
+    const server = manifest.mcp?.servers?.[0]?.server;
+
+    expect(server?.transport?.url).toBe(baseUrl);
+
+    const collectedValues: string[] = [];
+    const sanitize = (value: string): string => value.replace(/\{[^}]+\}/g, 'placeholder');
+
+    const endpoints = (server?.endpoints ?? {}) as Record<string, unknown>;
+    Object.values(endpoints).forEach((value) => {
+      if (typeof value === 'string') {
+        collectedValues.push(value);
+      }
+    });
+
+    const toolsCapabilities = manifest.mcp?.capabilities?.tools as Record<string, unknown> | undefined;
+    if (toolsCapabilities) {
+      const listEndpoint = toolsCapabilities.list_endpoint;
+      if (typeof listEndpoint === 'string') {
+        collectedValues.push(listEndpoint);
+      }
+
+      const invokeEndpoint = toolsCapabilities.invoke_endpoint;
+      if (typeof invokeEndpoint === 'string') {
+        collectedValues.push(invokeEndpoint);
+      }
+
+      const schemaCatalogs = toolsCapabilities.schema_catalogs;
+      if (Array.isArray(schemaCatalogs)) {
+        schemaCatalogs.forEach((entry) => {
+          if (typeof entry === 'string') {
+            collectedValues.push(entry);
+          }
+        });
+      }
+
+      const schemaBasePath = toolsCapabilities.schema_base_path;
+      if (typeof schemaBasePath === 'string') {
+        collectedValues.push(schemaBasePath);
+      }
+    }
+
+    const schemas = manifest.mcp?.schemas as Record<string, unknown> | undefined;
+    if (schemas) {
+      Object.values(schemas).forEach((value) => {
+        if (typeof value === 'string') {
+          collectedValues.push(value);
+        }
+      });
+    }
+
+    expect(collectedValues).not.toHaveLength(0);
+    collectedValues.forEach((value) => {
+      expect(value.startsWith('/')).toBe(false);
+      const resolvedPath = new URL(sanitize(value), baseUrl).pathname;
+      expect(resolvedPath.startsWith('/mcp/')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- parse the resolved public URL to detect any non-root pathname and reuse it when building the manifest
- normalize manifest endpoints, tool capability URLs, and schema references so consumers resolve them relative to the configured prefix
- add coverage ensuring a configured `/mcp` prefix is preserved and adjust integration tests for the new manifest format

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fcda478b40832ab30473c8ba329470