### PR TITLE
Adjust lint rules for TypeScript globals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,9 @@ module.exports = [
     },
     rules: {
       ...tsPlugin.configs.recommended.rules,
+      'no-undef': 'off',
+      'no-redeclare': 'off',
+      '@typescript-eslint/no-redeclare': 'error',
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/explicit-function-return-type': 'off'
     }


### PR DESCRIPTION
## Summary
- disable the base no-undef and no-redeclare rules in the TypeScript override
- enforce @typescript-eslint/no-redeclare to retain redeclaration coverage in TypeScript files

## Testing
- npm run lint *(fails: pre-existing TypeScript lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68fcf68ed13c832a8f831c4948645163