### PR TITLE
Adjust unused variable lint handling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,7 +29,15 @@ module.exports = [
       'no-redeclare': 'off',
       '@typescript-eslint/no-redeclare': 'error',
       '@typescript-eslint/no-floating-promises': 'error',
-      '@typescript-eslint/explicit-function-return-type': 'off'
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_'
+        }
+      ]
     }
   }
 ];

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -322,7 +322,7 @@ function createTransportOptionsSchema(
       }
 
       return parsed as Record<string, unknown>;
-    } catch (error) {
+    } catch (_error) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: `La variable d'environnement ${variableName} doit contenir un objet JSON valide.`
@@ -364,7 +364,7 @@ function createStringArraySchema(
 ): z.ZodEffects<z.ZodUnknown, string[], unknown> {
   const defaultValue = options.defaultValue ? [...options.defaultValue] : [];
 
-  return z.unknown().transform((value, ctx) => {
+  return z.unknown().transform((value, _ctx) => {
     if (value === undefined || value === null) {
       return [...defaultValue];
     }
@@ -408,7 +408,7 @@ function createOptionalHttpUrlSchema(
 
       const normalised = parsed.toString();
       return normalised.endsWith('/') ? normalised.slice(0, -1) : normalised;
-    } catch (error) {
+    } catch (_error) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: `La variable d'environnement ${variableName} doit être une URL absolue valide.`

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -906,7 +906,7 @@ export class OscClient {
     if (typeof firstArg === 'string') {
       try {
         return JSON.parse(firstArg);
-      } catch (error) {
+      } catch (_error) {
         return firstArg;
       }
     }
@@ -945,7 +945,7 @@ export class OscClient {
       try {
         const parsed = JSON.parse(payload) as Record<string, unknown>;
         return this.normaliseCommandLinePayload(parsed);
-      } catch (error) {
+      } catch (_error) {
         return { text: payload, user: null };
       }
     }


### PR DESCRIPTION
## Summary
- configure `@typescript-eslint/no-unused-vars` to allow leading underscores for intentionally ignored identifiers
- rename the unused `ctx` parameter in the config schema helper and mark ignored catch errors
- update OSC client parsing helpers to mark intentionally ignored caught errors

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68fcf715af60832aafca5b5e1063269b