### PR TITLE
Remove redundant UDP socket error wrappers

### DIFF
--- a/src/services/osc/connectionManager.ts
+++ b/src/services/osc/connectionManager.ts
@@ -374,12 +374,7 @@ export class OscConnectionManager extends EventEmitter {
     };
 
     const connectSocket = (): void => {
-      try {
-        socket.connect(this.options.udpPort, this.options.host, markConnected);
-      } catch (error) {
-        throw error;
-      }
-
+      socket.connect(this.options.udpPort, this.options.host, markConnected);
       queueMicrotask(markConnected);
     };
 
@@ -395,11 +390,7 @@ export class OscConnectionManager extends EventEmitter {
         bindOptions.port = this.options.localPort;
       }
 
-      try {
-        socket.bind(bindOptions, connectSocket);
-      } catch (error) {
-        throw error;
-      }
+      socket.bind(bindOptions, connectSocket);
     } else {
       connectSocket();
     }


### PR DESCRIPTION
## Summary
- remove redundant try/catch wrappers around UDP socket connect/bind so errors propagate naturally

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68fcf8563120832aa1b0db90764ee133