### PR TITLE
Mark request queue execution promise as intentionally unmanaged

### DIFF
--- a/src/services/osc/requestQueue.ts
+++ b/src/services/osc/requestQueue.ts
@@ -62,7 +62,7 @@ export class RequestQueue {
       }
 
       this.activeCount += 1;
-      this.execute(next).finally(() => {
+      void this.execute(next).finally(() => {
         this.activeCount -= 1;
         this.process();
       });


### PR DESCRIPTION
## Summary
- prefix the unmanaged request queue execution promise with `void` to satisfy the floating promise rule

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fcf8bd23a0832ab78e49499ed84567