### PR TITLE
Fix MCP token validation narrowing logic

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -312,14 +312,16 @@ async function bootstrap(options: BootstrapOptions = {}): Promise<BootstrapConte
   const effectiveConfig = applyBootstrapOverrides(config, options);
 
   const tokenValidation = validateMcpTokenConfiguration(effectiveConfig);
-  if (tokenValidation.status === 'error') {
-    logger.error(tokenValidation.message);
-    process.exit(1);
-    throw new Error(tokenValidation.message);
-  }
+  if (tokenValidation.status !== 'ok') {
+    const { message } = tokenValidation;
 
-  if (tokenValidation.status === 'warn') {
-    logger.warn(tokenValidation.message);
+    if (tokenValidation.status === 'error') {
+      logger.error(message);
+      process.exit(1);
+      throw new Error(message);
+    }
+
+    logger.warn(message);
   }
 
   try {

--- a/src/server/startupChecks.ts
+++ b/src/server/startupChecks.ts
@@ -46,6 +46,7 @@ export async function assertUdpPortAvailable(port: number, host = '0.0.0.0'): Pr
     const cleanup = () => {
       socket.removeAllListeners('error');
       socket.removeAllListeners('listening');
+      socket.removeAllListeners('close');
     };
 
     socket.once('error', (error) => {
@@ -55,14 +56,12 @@ export async function assertUdpPortAvailable(port: number, host = '0.0.0.0'): Pr
     });
 
     socket.once('listening', () => {
-      cleanup();
-      socket.close((error) => {
-        if (error) {
-          reject(createPortInUseError(port, 'UDP', error));
-        } else {
-          resolve();
-        }
+      socket.once('close', () => {
+        cleanup();
+        resolve();
       });
+
+      socket.close();
     });
 
     socket.bind({ port, address: host, exclusive: true });


### PR DESCRIPTION
## Summary
- ensure the MCP token validation flow branches on non-ok status before logging or throwing so the message field is safe to use
- update the UDP port availability check to resolve on socket close without using an invalid callback signature

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fd06fd95ec832a987a5d0d6947e5fa