### PR TITLE
Fix UDP startup check socket close callback signature

### DIFF
--- a/src/server/startupChecks.ts
+++ b/src/server/startupChecks.ts
@@ -56,12 +56,10 @@ export async function assertUdpPortAvailable(port: number, host = '0.0.0.0'): Pr
     });
 
     socket.once('listening', () => {
-      socket.once('close', () => {
+      socket.close(() => {
         cleanup();
         resolve();
       });
-
-      socket.close();
     });
 
     socket.bind({ port, address: host, exclusive: true });


### PR DESCRIPTION
## Summary
- update UDP startup check to resolve using the close callback without arguments
- retain error handling for occupied ports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fd08b44000832abfca8b9b7a5776db