### PR TITLE
refactor: centralize tool test runner helper

### DIFF
--- a/src/tools/__tests__/helpers/runTool.ts
+++ b/src/tools/__tests__/helpers/runTool.ts
@@ -1,0 +1,39 @@
+import type { ToolDefinition, ToolExecutionResult } from '../../types';
+
+type ToolContentEntry = ToolExecutionResult['content'][number];
+
+export interface ObjectContent extends ToolContentEntry {
+  type: 'object';
+  data: Record<string, unknown>;
+}
+
+export interface TextContent extends ToolContentEntry {
+  type: 'text';
+  text: string;
+}
+
+export async function runTool(
+  tool: ToolDefinition,
+  args: unknown,
+  extra: unknown = {}
+): Promise<ToolExecutionResult> {
+  return tool.handler(args, extra);
+}
+
+export function isObjectContent(entry: ToolContentEntry): entry is ObjectContent {
+  if (entry.type !== 'object') {
+    return false;
+  }
+
+  const candidate = entry as { data?: unknown };
+  return typeof candidate.data === 'object' && candidate.data !== null;
+}
+
+export function isTextContent(entry: ToolContentEntry): entry is TextContent {
+  if (entry.type !== 'text') {
+    return false;
+  }
+
+  const candidate = entry as { text?: unknown };
+  return typeof candidate.text === 'string';
+}

--- a/src/tools/channels/__tests__/channels.test.ts
+++ b/src/tools/channels/__tests__/channels.test.ts
@@ -6,6 +6,7 @@ import {
   eosSetDmxTool,
   eosChannelGetInfoTool
 } from '../index';
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -30,11 +31,6 @@ class FakeOscService implements OscGateway {
 
 describe('channel tools', () => {
   let service: FakeOscService;
-
-  const runTool = async (tool: any, args: unknown): Promise<any> => {
-    const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
-    return handler(args, {});
-  };
 
   beforeEach(() => {
     service = new FakeOscService();
@@ -87,8 +83,11 @@ describe('channel tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
     expect(objectContent.data).toMatchObject({
       status: 'ok',

--- a/src/tools/commands/__tests__/command_tools.test.ts
+++ b/src/tools/commands/__tests__/command_tools.test.ts
@@ -7,6 +7,7 @@ import {
   eosGetCommandLineTool
 } from '../command_tools';
 import { clearCurrentUserId, setCurrentUserId } from '../../session';
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 describe('command tools', () => {
   class FakeOscService implements OscGateway {
@@ -32,11 +33,6 @@ describe('command tools', () => {
 
   let service: FakeOscService;
 
-  const runTool = async (tool: any, args: unknown): Promise<any> => {
-    const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
-    return handler(args, {});
-  };
-
   beforeEach(() => {
     service = new FakeOscService();
     const client = new OscClient(service, { defaultTimeoutMs: 50 });
@@ -61,8 +57,11 @@ describe('command tools', () => {
       ]
     });
 
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
   });
 
   it('applique la substitution et efface la ligne pour eos_new_command', async () => {
@@ -125,10 +124,13 @@ describe('command tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
 
     expect(objectContent).toBeDefined();
-    expect((objectContent as { type: string; data: unknown }).data).toMatchObject({
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
+    expect(objectContent.data).toMatchObject({
       status: 'ok',
       text: 'Chan 1 At 50',
       user: 4

--- a/src/tools/curves/__tests__/curves.test.ts
+++ b/src/tools/curves/__tests__/curves.test.ts
@@ -2,8 +2,7 @@ import type { OscMessage } from '../../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosCurveGetInfoTool, eosCurveSelectTool } from '../index';
-
-type ToolHandler = (args: unknown, extra?: unknown) => Promise<any>;
+import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -28,11 +27,6 @@ class FakeOscService implements OscGateway {
 
 describe('curve tools', () => {
   let service: FakeOscService;
-
-  const runTool = async (tool: any, args: unknown): Promise<any> => {
-    const handler = tool.handler as ToolHandler;
-    return handler(args, {});
-  };
 
   beforeEach(() => {
     service = new FakeOscService();
@@ -87,10 +81,18 @@ describe('curve tools', () => {
     });
 
     const result = await promise;
-    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    const textContent = result.content.find(isTextContent);
+    expect(textContent).toBeDefined();
+    if (!textContent) {
+      throw new Error('Expected text content');
+    }
     expect(textContent.text).toBe('Courbe 8 "Custom Fade" (Time) - 3 points.');
 
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
     expect(objectContent.data).toMatchObject({
       status: 'ok',
       error: null,
@@ -131,10 +133,18 @@ describe('curve tools', () => {
     });
 
     const result = await promise;
-    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    const textContent = result.content.find(isTextContent);
+    expect(textContent).toBeDefined();
+    if (!textContent) {
+      throw new Error('Expected text content');
+    }
     expect(textContent.text).toBe('Courbe 42 introuvable.');
 
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
     expect(objectContent.data).toMatchObject({
       status: 'error',
       error: 'Curve not found',

--- a/src/tools/directSelects/__tests__/directSelects.test.ts
+++ b/src/tools/directSelects/__tests__/directSelects.test.ts
@@ -7,6 +7,7 @@ import {
   eosDirectSelectPageTool,
   eosDirectSelectPressTool
 } from '../index';
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -24,11 +25,6 @@ class FakeOscService implements OscGateway {
     };
   }
 }
-
-const runTool = async (tool: any, args: unknown): Promise<any> => {
-  const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
-  return handler(args, {});
-};
 
 describe('direct select tools', () => {
   let service: FakeOscService;
@@ -88,7 +84,11 @@ describe('direct select tools', () => {
     const forwardPayload = JSON.parse(String(forwardMessage.args?.[0]?.value));
     expect(forwardPayload).toEqual({ bank: 4, delta: 2 });
 
-    const forwardData = (nextPageResult.content as any[]).find((item) => item.type === 'object');
+    const forwardData = nextPageResult.content.find(isObjectContent);
+    expect(forwardData).toBeDefined();
+    if (!forwardData) {
+      throw new Error('Expected object content');
+    }
     expect(forwardData.data).toMatchObject({ previousPage: 1, page: 3 });
 
     service.sentMessages.length = 0;
@@ -100,7 +100,11 @@ describe('direct select tools', () => {
     const backPayload = JSON.parse(String(backMessage.args?.[0]?.value));
     expect(backPayload).toEqual({ bank: 4, delta: -5 });
 
-    const backData = (backResult.content as any[]).find((item) => item.type === 'object');
+    const backData = backResult.content.find(isObjectContent);
+    expect(backData).toBeDefined();
+    if (!backData) {
+      throw new Error('Expected object content');
+    }
     expect(backData.data).toMatchObject({ previousPage: 3, page: 0 });
 
     service.sentMessages.length = 0;

--- a/src/tools/dmx/__tests__/dmx.test.ts
+++ b/src/tools/dmx/__tests__/dmx.test.ts
@@ -6,8 +6,7 @@ import {
   eosAddressSetLevelTool,
   eosAddressSetDmxTool
 } from '../index';
-
-type ToolHandler = (args: unknown, extra?: unknown) => Promise<any>;
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -32,11 +31,6 @@ class FakeOscService implements OscGateway {
 
 describe('dmx address tools', () => {
   let service: FakeOscService;
-
-  const runTool = async (tool: any, args: unknown): Promise<any> => {
-    const handler = tool.handler as ToolHandler;
-    return handler(args, {});
-  };
 
   beforeEach(() => {
     service = new FakeOscService();
@@ -71,10 +65,12 @@ describe('dmx address tools', () => {
     const payload = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
     expect(payload).toEqual({ address: '2/041' });
 
-    const objectContent = (result.content as Array<{ type: string; data?: any }>).find(
-      (item) => item.type === 'object'
-    );
-    expect(objectContent?.data.status).toBe('ok');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
+    expect(objectContent.data.status).toBe('ok');
   });
 
   it('convertit full en 100% pour le niveau', async () => {

--- a/src/tools/faders/__tests__/faders.test.ts
+++ b/src/tools/faders/__tests__/faders.test.ts
@@ -9,6 +9,7 @@ import {
   eosFaderUnloadTool,
   eosFaderPageTool
 } from '../index';
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -26,11 +27,6 @@ class FakeOscService implements OscGateway {
     };
   }
 }
-
-const runTool = async (tool: any, args: unknown): Promise<any> => {
-  const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
-  return handler(args, {});
-};
 
 describe('fader tools', () => {
   let service: FakeOscService;
@@ -78,7 +74,11 @@ describe('fader tools', () => {
     await runTool(eosFaderPageTool, { bank_index: 3, delta: 1 });
 
     const pageResult = await runTool(eosFaderPageTool, { bank_index: 3, delta: -2 });
-    const pageData = (pageResult.content as any[]).find((item) => item.type === 'object');
+    const pageData = pageResult.content.find(isObjectContent);
+    expect(pageData).toBeDefined();
+    if (!pageData) {
+      throw new Error('Expected object content');
+    }
     expect(pageData.data).toMatchObject({ page: 1 });
 
     service.sentMessages.length = 0;
@@ -104,7 +104,11 @@ describe('fader tools', () => {
     const payload = JSON.parse(String(message.args?.[0]?.value));
     expect(payload).toEqual({ bank: 7, delta: 1 });
 
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
     expect(objectContent.data).toMatchObject({ previousPage: 0, page: 1 });
   });
 });

--- a/src/tools/fpe/__tests__/fpe.test.ts
+++ b/src/tools/fpe/__tests__/fpe.test.ts
@@ -6,10 +6,7 @@ import {
   eosFpeGetSetInfoTool,
   eosFpeGetPointInfoTool
 } from '../index';
-
-interface ToolHandler {
-  (args: unknown, extra?: unknown): Promise<any>;
-}
+import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -32,23 +29,8 @@ class FakeOscService implements OscGateway {
   }
 }
 
-function extractObjectContent(result: any): any {
-  const content = (result?.content ?? []) as any[];
-  return content.find((item) => item.type === 'object')?.data ?? null;
-}
-
-function extractTextContent(result: any): string | null {
-  const content = (result?.content ?? []) as any[];
-  return content.find((item) => item.type === 'text')?.text ?? null;
-}
-
 describe('fpe tools', () => {
   let service: FakeOscService;
-
-  const runTool = async (tool: any, args: unknown, extra: unknown = {}): Promise<any> => {
-    const handler = tool.handler as ToolHandler;
-    return handler(args, extra);
-  };
 
   beforeEach(() => {
     service = new FakeOscService();
@@ -87,11 +69,11 @@ describe('fpe tools', () => {
     });
 
     const result = await promise;
-    const textContent = extractTextContent(result);
-    const objectContent = extractObjectContent(result);
+    const textContent = result.content.find(isTextContent);
+    const objectContent = result.content.find(isObjectContent);
 
-    expect(textContent).toBe('Nombre de sets FPE: 5.');
-    expect(objectContent).toMatchObject({
+    expect(textContent?.text).toBe('Nombre de sets FPE: 5.');
+    expect(objectContent?.data).toMatchObject({
       action: 'get_set_count',
       set_count: 5,
       status: 'ok'
@@ -136,11 +118,11 @@ describe('fpe tools', () => {
     });
 
     const result = await promise;
-    const textContent = extractTextContent(result);
-    const objectContent = extractObjectContent(result);
+    const textContent = result.content.find(isTextContent);
+    const objectContent = result.content.find(isObjectContent);
 
-    expect(textContent).toBe('Set FPE 3 "Main Stage" - 2 points.');
-    expect(objectContent).toMatchObject({
+    expect(textContent?.text).toBe('Set FPE 3 "Main Stage" - 2 points.');
+    expect(objectContent?.data).toMatchObject({
       action: 'get_set_info',
       status: 'ok',
       set_number: 3,
@@ -212,13 +194,13 @@ describe('fpe tools', () => {
     });
 
     const result = await promise;
-    const textContent = extractTextContent(result);
-    const objectContent = extractObjectContent(result);
+    const textContent = result.content.find(isTextContent);
+    const objectContent = result.content.find(isObjectContent);
 
-    expect(textContent).toBe(
+    expect(textContent?.text).toBe(
       'Point FPE 4.2 "Right Balcony" - Palette focus 202 - Position (4.5, 6.1, 0).'
     );
-    expect(objectContent).toMatchObject({
+    expect(objectContent?.data).toMatchObject({
       action: 'get_point_info',
       status: 'ok',
       set_number: 4,
@@ -254,11 +236,11 @@ describe('fpe tools', () => {
     });
 
     const result = await promise;
-    const textContent = extractTextContent(result);
-    const objectContent = extractObjectContent(result);
+    const textContent = result.content.find(isTextContent);
+    const objectContent = result.content.find(isObjectContent);
 
-    expect(textContent).toBe('Set FPE 12 introuvable.');
-    expect(objectContent).toMatchObject({
+    expect(textContent?.text).toBe('Set FPE 12 introuvable.');
+    expect(objectContent?.data).toMatchObject({
       status: 'error',
       set_number: 12,
       error: 'Set not found'

--- a/src/tools/groups/__tests__/groups.test.ts
+++ b/src/tools/groups/__tests__/groups.test.ts
@@ -8,6 +8,7 @@ import {
   eosGroupGetInfoTool,
   eosGroupListAllTool
 } from '../index';
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -29,11 +30,6 @@ class FakeOscService implements OscGateway {
     this.listeners.forEach((listener) => listener(message));
   }
 }
-
-const runTool = async (tool: any, args: unknown): Promise<any> => {
-  const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
-  return handler(args, {});
-};
 
 describe('group tools', () => {
   let service: FakeOscService;
@@ -97,8 +93,11 @@ describe('group tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
     expect(objectContent.data).toMatchObject({
       action: 'get_info',
@@ -145,8 +144,11 @@ describe('group tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
     expect(objectContent.data).toMatchObject({
       action: 'list_all',

--- a/src/tools/keys/__tests__/keys.test.ts
+++ b/src/tools/keys/__tests__/keys.test.ts
@@ -5,6 +5,7 @@ import {
   eosKeyPressTool,
   eosSoftkeyPressTool
 } from '../index';
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 describe('key tools', () => {
   class FakeOscService implements OscGateway {
@@ -29,11 +30,6 @@ describe('key tools', () => {
   }
 
   let service: FakeOscService;
-
-  const runTool = async (tool: any, args: unknown): Promise<any> => {
-    const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
-    return handler(args, {});
-  };
 
   beforeEach(() => {
     service = new FakeOscService();
@@ -102,9 +98,12 @@ describe('key tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
 
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
     expect(objectContent.data).toMatchObject({
       action: 'get_softkey_labels',
       status: 'ok',

--- a/src/tools/macros/__tests__/macros.test.ts
+++ b/src/tools/macros/__tests__/macros.test.ts
@@ -6,8 +6,7 @@ import {
   eosMacroGetInfoTool,
   eosMacroSelectTool
 } from '../index';
-
-type ToolHandler = (args: unknown, extra?: unknown) => Promise<any>;
+import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -32,11 +31,6 @@ class FakeOscService implements OscGateway {
 
 describe('macro tools', () => {
   let service: FakeOscService;
-
-  const runTool = async (tool: any, args: unknown): Promise<any> => {
-    const handler = tool.handler as ToolHandler;
-    return handler(args, {});
-  };
 
   beforeEach(() => {
     service = new FakeOscService();
@@ -98,11 +92,18 @@ describe('macro tools', () => {
     });
 
     const result = await promise;
-    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    const textContent = result.content.find(isTextContent);
+    expect(textContent).toBeDefined();
+    if (!textContent) {
+      throw new Error('Expected text content');
+    }
     expect(textContent.text).toBe('Macro 12 "Blackout" (3 commandes).');
 
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
     expect(objectContent.data).toMatchObject({
       status: 'ok',
@@ -142,10 +143,18 @@ describe('macro tools', () => {
     });
 
     const result = await promise;
-    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    const textContent = result.content.find(isTextContent);
+    expect(textContent).toBeDefined();
+    if (!textContent) {
+      throw new Error('Expected text content');
+    }
     expect(textContent.text).toBe('Macro 99 introuvable.');
 
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
     expect(objectContent.data).toMatchObject({
       status: 'error',
       error: 'Macro not found',

--- a/src/tools/magicSheets/__tests__/magicSheets.test.ts
+++ b/src/tools/magicSheets/__tests__/magicSheets.test.ts
@@ -6,8 +6,7 @@ import {
   eosMagicSheetOpenTool,
   eosMagicSheetSendStringTool
 } from '../index';
-
-type ToolHandler = (args: unknown, extra?: unknown) => Promise<any>;
+import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -32,11 +31,6 @@ class FakeOscService implements OscGateway {
 
 describe('magic sheet tools', () => {
   let service: FakeOscService;
-
-  const runTool = async (tool: any, args: unknown, extra: unknown = {}): Promise<any> => {
-    const handler = tool.handler as ToolHandler;
-    return handler(args, extra);
-  };
 
   beforeEach(() => {
     service = new FakeOscService();
@@ -85,10 +79,18 @@ describe('magic sheet tools', () => {
     );
 
     expect(service.sentMessages).toHaveLength(0);
-    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    const textContent = result.content.find(isTextContent);
+    expect(textContent).toBeDefined();
+    if (!textContent) {
+      throw new Error('Expected text content');
+    }
     expect(textContent.text).toContain('connexion Primary');
 
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
     expect(objectContent.data).toMatchObject({
       action: 'magic_sheet_send_string',
       required_role: 'Primary',
@@ -121,7 +123,11 @@ describe('magic sheet tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
     expect(objectContent.data).toMatchObject({
       status: 'ok',
@@ -154,10 +160,18 @@ describe('magic sheet tools', () => {
     });
 
     const result = await promise;
-    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    const textContent = result.content.find(isTextContent);
+    expect(textContent).toBeDefined();
+    if (!textContent) {
+      throw new Error('Expected text content');
+    }
     expect(textContent.text).toContain('introuvable');
 
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
     expect(objectContent.data).toMatchObject({
       status: 'error',
       magic_sheet: {

--- a/src/tools/patch/__tests__/patch.test.ts
+++ b/src/tools/patch/__tests__/patch.test.ts
@@ -6,10 +6,8 @@ import {
   eosPatchGetAugment3dPositionTool,
   eosPatchGetChannelInfoTool
 } from '../index';
-
-interface ToolHandler {
-  (args: unknown, extra?: unknown): Promise<any>;
-}
+import type { ToolExecutionResult } from '../../types';
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -32,18 +30,13 @@ class FakeOscService implements OscGateway {
   }
 }
 
-function extractObjectContent(result: any): any {
-  const content = (result?.content ?? []) as any[];
-  return content.find((item) => item.type === 'object')?.data ?? null;
+function extractObjectContent(result: ToolExecutionResult): Record<string, unknown> | null {
+  const objectContent = result.content.find(isObjectContent);
+  return objectContent?.data ?? null;
 }
 
 describe('patch tools', () => {
   let service: FakeOscService;
-
-  const runTool = async (tool: any, args: unknown, extra: unknown = {}): Promise<any> => {
-    const handler = tool.handler as ToolHandler;
-    return handler(args, extra);
-  };
 
   beforeEach(() => {
     service = new FakeOscService();

--- a/src/tools/pixelMaps/__tests__/pixelMaps.test.ts
+++ b/src/tools/pixelMaps/__tests__/pixelMaps.test.ts
@@ -3,10 +3,7 @@ import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } 
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosPixmapGetInfoTool, eosPixmapSelectTool } from '../index';
 import largePixmapFixture from './fixtures/pixmap-large.json';
-
-interface ToolHandler {
-  (args: unknown, extra?: unknown): Promise<any>;
-}
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -31,11 +28,6 @@ class FakeOscService implements OscGateway {
 
 describe('pixel map tools', () => {
   let service: FakeOscService;
-
-  const runTool = async (tool: any, args: unknown, extra: unknown = {}): Promise<any> => {
-    const handler = tool.handler as ToolHandler;
-    return handler(args, extra);
-  };
 
   beforeEach(() => {
     service = new FakeOscService();
@@ -98,7 +90,11 @@ describe('pixel map tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
     expect(objectContent.data).toMatchObject({
       status: 'ok',
@@ -142,7 +138,11 @@ describe('pixel map tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
     expect(objectContent.data).toMatchObject({
       status: 'ok',

--- a/src/tools/queries/__tests__/queries.test.ts
+++ b/src/tools/queries/__tests__/queries.test.ts
@@ -2,6 +2,7 @@ import type { OscMessage } from '../../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosGetCountTool, eosGetListAllTool } from '../index';
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -23,11 +24,6 @@ class FakeOscService implements OscGateway {
     this.listeners.forEach((listener) => listener(message));
   }
 }
-
-const runTool = async (tool: any, args: unknown): Promise<any> => {
-  const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
-  return handler(args, {});
-};
 
 describe('query tools', () => {
   let service: FakeOscService;
@@ -61,8 +57,11 @@ describe('query tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
     expect(objectContent.data).toMatchObject({
       action: 'get_count',
       status: 'ok',
@@ -95,8 +94,11 @@ describe('query tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
     expect(objectContent.data).toMatchObject({
       action: 'list_all',
@@ -131,8 +133,11 @@ describe('query tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
     expect(objectContent.data).toMatchObject({
       action: 'list_all',
@@ -167,8 +172,11 @@ describe('query tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
     expect(objectContent.data).toMatchObject({
       target_type: 'ms',

--- a/src/tools/session/__tests__/session.test.ts
+++ b/src/tools/session/__tests__/session.test.ts
@@ -4,13 +4,9 @@ import {
   sessionGetCurrentUserTool,
   sessionSetCurrentUserTool
 } from '../index';
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 describe('session tools', () => {
-  const runTool = async (tool: any, args: unknown): Promise<any> => {
-    const handler = tool.handler as (input: unknown, extra?: unknown) => Promise<any>;
-    return handler(args, {});
-  };
-
   beforeEach(() => {
     clearCurrentUserId();
   });
@@ -19,16 +15,23 @@ describe('session tools', () => {
     const result = await runTool(sessionSetCurrentUserTool, { user: 7 });
 
     expect(getCurrentUserId()).toBe(7);
-    expect(Array.isArray(result.content)).toBe(true);
-    const objectContent = result.content.find((item: any) => item.type === 'object');
-    expect(objectContent?.data).toEqual({ user: 7 });
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
+    expect(objectContent.data).toEqual({ user: 7 });
   });
 
   it('renvoie null lorsqu aucun utilisateur nest defini', async () => {
     const result = await runTool(sessionGetCurrentUserTool, undefined);
 
-    const objectContent = result.content.find((item: any) => item.type === 'object');
-    expect(objectContent?.data).toEqual({ user: null });
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
+    expect(objectContent.data).toEqual({ user: null });
   });
 
   it('renvoie l utilisateur courant memorise', async () => {
@@ -36,7 +39,11 @@ describe('session tools', () => {
     await runTool(sessionSetCurrentUserTool, { user: 3 });
 
     const result = await runTool(sessionGetCurrentUserTool, undefined);
-    const objectContent = result.content.find((item: any) => item.type === 'object');
-    expect(objectContent?.data).toEqual({ user: 3 });
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
+    expect(objectContent.data).toEqual({ user: 3 });
   });
 });

--- a/src/tools/showControl/__tests__/showControl.test.ts
+++ b/src/tools/showControl/__tests__/showControl.test.ts
@@ -8,8 +8,7 @@ import {
   eosSetCueSendStringTool,
   eosSetCueReceiveStringTool
 } from '../index';
-
-type ToolHandler = (args: unknown, extra?: unknown) => Promise<any>;
+import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -34,11 +33,6 @@ class FakeOscService implements OscGateway {
 
 describe('show control tools', () => {
   let service: FakeOscService;
-
-  const runTool = async (tool: any, args: unknown): Promise<any> => {
-    const handler = tool.handler as ToolHandler;
-    return handler(args, {});
-  };
 
   beforeEach(() => {
     service = new FakeOscService();
@@ -70,15 +64,19 @@ describe('show control tools', () => {
     expect(service.sentMessages).toHaveLength(1);
     expect(service.sentMessages[0]?.address).toBe(oscMappings.showControl.showName);
 
-    const textContent = (result.content as Array<{ type: string; text?: string }>).find(
-      (item) => item.type === 'text'
-    );
-    expect(textContent?.text).toContain('Festival 2024');
+    const textContent = result.content.find(isTextContent);
+    expect(textContent).toBeDefined();
+    if (!textContent) {
+      throw new Error('Expected text content');
+    }
+    expect(textContent.text).toContain('Festival 2024');
 
-    const objectContent = (result.content as Array<{ type: string; data?: any }>).find(
-      (item) => item.type === 'object'
-    );
-    expect(objectContent?.data.show_name).toBe('Festival 2024');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
+    expect(objectContent.data.show_name).toBe('Festival 2024');
   });
 
   it('normalise et valide le mode Live/Blind', async () => {
@@ -97,15 +95,19 @@ describe('show control tools', () => {
     });
 
     const result = await promise;
-    const textContent = (result.content as Array<{ type: string; text?: string }>).find(
-      (item) => item.type === 'text'
-    );
-    expect(textContent?.text).toContain('Blind');
+    const textContent = result.content.find(isTextContent);
+    expect(textContent).toBeDefined();
+    if (!textContent) {
+      throw new Error('Expected text content');
+    }
+    expect(textContent.text).toContain('Blind');
 
-    const objectContent = (result.content as Array<{ type: string; data?: any }>).find(
-      (item) => item.type === 'object'
-    );
-    expect(objectContent?.data.state).toEqual({ numeric: 0, label: 'Blind' });
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
+    expect(objectContent.data.state).toEqual({ numeric: 0, label: 'Blind' });
   });
 
   it('renvoie une erreur lisible quand le mode Live/Blind est invalide', async () => {
@@ -124,10 +126,12 @@ describe('show control tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as Array<{ type: string; data?: any }>).find(
-      (item) => item.type === 'object'
-    );
-    expect(objectContent?.data.error).toContain('Etat Live/Blind invalide');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
+    expect(objectContent.data.error).toContain('Etat Live/Blind invalide');
   });
 
   it('bascule le mode staging et retourne un accusé', async () => {
@@ -147,10 +151,12 @@ describe('show control tools', () => {
 
     const result = await promise;
     expect(service.sentMessages[0]?.address).toBe(oscMappings.showControl.toggleStagingMode);
-    const textContent = (result.content as Array<{ type: string; text?: string }>).find(
-      (item) => item.type === 'text'
-    );
-    expect(textContent?.text).toContain('Mode staging bascule');
+    const textContent = result.content.find(isTextContent);
+    expect(textContent).toBeDefined();
+    if (!textContent) {
+      throw new Error('Expected text content');
+    }
+    expect(textContent.text).toContain('Mode staging bascule');
   });
 
   it('valide et configure le format d\'envoi des cues', async () => {
@@ -173,10 +179,12 @@ describe('show control tools', () => {
     const payload = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
     expect(payload).toEqual({ format: 'Cue %1 -> %2 (%3)' });
 
-    const objectContent = (result.content as Array<{ type: string; data?: any }>).find(
-      (item) => item.type === 'object'
-    );
-    expect(objectContent?.data.format).toBe('Cue %1 -> %2 (%3)');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
+    expect(objectContent.data.format).toBe('Cue %1 -> %2 (%3)');
   });
 
   it('refuse les placeholders invalides pour le format d\'envoi', async () => {

--- a/src/tools/snapshots/__tests__/snapshots.test.ts
+++ b/src/tools/snapshots/__tests__/snapshots.test.ts
@@ -2,8 +2,7 @@ import type { OscMessage } from '../../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosSnapshotGetInfoTool, eosSnapshotRecallTool } from '../index';
-
-type ToolHandler = (args: unknown, extra?: unknown) => Promise<any>;
+import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -28,11 +27,6 @@ class FakeOscService implements OscGateway {
 
 describe('snapshot tools', () => {
   let service: FakeOscService;
-
-  const runTool = async (tool: any, args: unknown, extra: unknown = {}): Promise<any> => {
-    const handler = tool.handler as ToolHandler;
-    return handler(args, extra);
-  };
 
   beforeEach(() => {
     service = new FakeOscService();
@@ -96,11 +90,18 @@ describe('snapshot tools', () => {
     });
 
     const result = await promise;
-    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    const textContent = result.content.find(isTextContent);
+    expect(textContent).toBeDefined();
+    if (!textContent) {
+      throw new Error('Expected text content');
+    }
     expect(textContent.text).toBe('Snapshot 12 "Ballet Acte II" (UID 1.2.3.4.5).');
 
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
     expect(objectContent.data).toMatchObject({
       status: 'ok',
       snapshot: {
@@ -132,10 +133,18 @@ describe('snapshot tools', () => {
     });
 
     const result = await promise;
-    const textContent = (result.content as any[]).find((item) => item.type === 'text');
+    const textContent = result.content.find(isTextContent);
+    expect(textContent).toBeDefined();
+    if (!textContent) {
+      throw new Error('Expected text content');
+    }
     expect(textContent.text).toBe('Snapshot 99 introuvable.');
 
-    const objectContent = (result.content as any[]).find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
+    expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
     expect(objectContent.data).toMatchObject({
       status: 'error',
       error: 'Snapshot missing',

--- a/src/tools/submasters/__tests__/submasters.test.ts
+++ b/src/tools/submasters/__tests__/submasters.test.ts
@@ -6,6 +6,7 @@ import {
   eosSubmasterBumpTool,
   eosSubmasterGetInfoTool
 } from '../index';
+import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -27,11 +28,6 @@ class FakeOscService implements OscGateway {
     this.listeners.forEach((listener) => listener(message));
   }
 }
-
-const runTool = async (tool: any, args: unknown): Promise<any> => {
-  const handler = tool.handler as unknown as (input: unknown, extra?: unknown) => Promise<any>;
-  return handler(args, {});
-};
 
 describe('submaster tools', () => {
   let service: FakeOscService;
@@ -104,8 +100,11 @@ describe('submaster tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
     expect(objectContent.data).toMatchObject({
       action: 'submaster_get_info',
@@ -158,14 +157,19 @@ describe('submaster tools', () => {
     });
 
     const result = await promise;
-    const objectContent = (result.content as any[])?.find((item) => item.type === 'object');
+    const objectContent = result.content.find(isObjectContent);
     expect(objectContent).toBeDefined();
+    if (!objectContent) {
+      throw new Error('Expected object content');
+    }
 
-    expect(objectContent.data.submaster).toMatchObject({
-      submasterNumber: 4,
-      label: 'Side Light',
-      htp: false,
-      exclusive: true
+    expect(objectContent.data).toMatchObject({
+      submaster: {
+        submasterNumber: 4,
+        label: 'Side Light',
+        htp: false,
+        exclusive: true
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a shared `runTool` helper for tool test suites, including type guards for object and text content
- update every tool-focused test to rely on the shared helper instead of inlined implementations
- adjust assertions to work with typed `ToolExecutionResult` content without casting to `any`

## Testing
- npm run lint *(fails: existing unrelated lint errors in server and tool source files)*

------
https://chatgpt.com/codex/tasks/task_e_68fd0b58207c832aac01e140b8394fdd