### PR TITLE
Export ManifestDocument type for manifest tests

### DIFF
--- a/src/server/__tests__/httpGatewayManifestPrefix.test.ts
+++ b/src/server/__tests__/httpGatewayManifestPrefix.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import type { Request } from 'express';
 import { HttpGateway } from '../httpGateway';
+import type { ManifestDocument } from '../httpGateway';
 import type { ToolRegistry } from '../toolRegistry';
 
 describe('HttpGateway manifest prefix handling', () => {
@@ -15,7 +16,9 @@ describe('HttpGateway manifest prefix handling', () => {
     const manifestTemplate = JSON.parse(readFileSync(manifestPath, 'utf8')) as unknown;
     Object.assign(gateway as unknown as { manifestTemplate: unknown }, { manifestTemplate });
 
-    const manifest = (gateway as unknown as { buildManifestResponse(req: Request): any }).buildManifestResponse(
+    const manifest = (
+      gateway as unknown as { buildManifestResponse(req: Request): ManifestDocument }
+    ).buildManifestResponse(
       {} as Request
     );
 

--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -95,7 +95,7 @@ interface ManifestServerDefinition {
   readonly [key: string]: unknown;
 }
 
-interface ManifestDocument {
+export interface ManifestDocument {
   mcp?: {
     servers?: ManifestServerDefinition[];
     readonly [key: string]: unknown;


### PR DESCRIPTION
## Summary
- export the ManifestDocument interface from the HTTP gateway module for reuse in tests
- update the manifest prefix test to rely on the exported ManifestDocument type when accessing the helper

## Testing
- npm run lint *(fails: existing lint errors in osc and tools modules)*

------
https://chatgpt.com/codex/tasks/task_e_68fd0d94958c832a9d6a79f8f8ecccfa