### PR TITLE
Fix cleanup error parameter naming in OSC integration test

### DIFF
--- a/src/services/osc/__tests__/osc.integration.test.ts
+++ b/src/services/osc/__tests__/osc.integration.test.ts
@@ -46,7 +46,7 @@ describe('OscService integration (UDP sockets)', () => {
     resources.splice(0).forEach((resource) => {
       try {
         resource.close();
-      } catch (error) {
+      } catch (_error) {
         // Ignore cleanup errors in tests
       }
     });


### PR DESCRIPTION
## Summary
- rename the caught error variable in the OSC integration test cleanup to `_error`

## Testing
- npm run lint *(fails: pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68fd0f1742e0832abff266dfe3a5bd43