### PR TITLE
Ensure OSC service test awaits send

### DIFF
--- a/src/services/osc/__tests__/service.test.ts
+++ b/src/services/osc/__tests__/service.test.ts
@@ -16,7 +16,6 @@ declare module 'osc' {
     reset(): void;
   }
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const __mock: __MockModule;
 }
 
@@ -96,12 +95,12 @@ describe('OscService diagnostics', () => {
     }
   });
 
-  it('agrège les statistiques des messages entrants et sortants', () => {
+  it('agrège les statistiques des messages entrants et sortants', async () => {
     const { service, port } = createService();
 
     try {
       service.setLoggingOptions({ incoming: true, outgoing: true });
-      service.send({ address: '/test/out', args: [{ type: 'i', value: 1 }] });
+      await service.send({ address: '/test/out', args: [{ type: 'i', value: 1 }] });
 
       expect(logger.debug).toHaveBeenCalledWith(
         { args: [{ type: 'i', value: 1 }] },


### PR DESCRIPTION
## Summary
- remove the naming-convention disable comment from the OSC service test mock declaration
- update the aggregate statistics test to await OscService.send

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fd0f876414832a8b363b36266d8e91