### PR TITLE
Remove redundant ESLint suppression in HTTP gateway

### DIFF
--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -682,7 +682,6 @@ class HttpGateway {
   }
 
   private createErrorHandler() {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return (error: unknown, _req: Request, res: Response, _next: NextFunction): void => {
       const err = error instanceof Error ? error : new Error('Erreur inconnue');
       logger.error({ error: err }, "Erreur HTTP lors de l'appel d'un outil");


### PR DESCRIPTION
## Summary
- remove the unused ESLint disable comment above the HTTP gateway error handler

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fd1288dac0832a9426b4331f949e18