### PR TITLE
Fix palette description label quoting

### DIFF
--- a/src/tools/palettes/index.ts
+++ b/src/tools/palettes/index.ts
@@ -323,7 +323,7 @@ function mapPaletteInfo(raw: unknown, fallback: { type: PaletteType; number: num
 
 function formatPaletteDescription(info: PaletteInfo): string {
   const typeTitle = paletteTypeTitles[info.paletteType];
-  const label = info.label ? `\"${info.label}\"` : 'sans label';
+  const label = info.label ? `"${info.label}"` : 'sans label';
   const mode = info.absolute ? 'absolue' : 'relative';
   const lockState = info.locked ? 'verrouillee' : 'modifiable';
   const channels = info.channels.length > 0 ? info.channels.join(', ') : 'aucun canal';


### PR DESCRIPTION
## Summary
- replace the escaped quote in palette description formatting with a normal double quote

## Testing
- npm run lint *(fails: existing unused variable errors in src/tools/patch/index.ts and src/tools/pixelMaps/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68fd133d4938832a8c8e8100583f53df