### PR TITLE
Export pixel map fixture schemas

### DIFF
--- a/src/tools/pixelMaps/index.ts
+++ b/src/tools/pixelMaps/index.ts
@@ -74,14 +74,18 @@ const pixelMapFixtureSegmentOutputShape = {
   string_number: z.number().int().min(0).nullable()
 } satisfies ZodRawShape;
 
+export const pixelMapFixtureSegmentOutputSchema = z.object(pixelMapFixtureSegmentOutputShape);
+
 const pixelMapFixtureOutputShape = {
   channel: z.number().int().min(1),
   label: z.string().nullable(),
   start_pixel: z.number().int().min(0).nullable(),
   end_pixel: z.number().int().min(0).nullable(),
   pixel_count: z.number().int().min(0).nullable(),
-  segments: z.array(z.object(pixelMapFixtureSegmentOutputShape))
+  segments: z.array(pixelMapFixtureSegmentOutputSchema)
 } satisfies ZodRawShape;
+
+export const pixelMapFixtureOutputSchema = z.object(pixelMapFixtureOutputShape);
 
 const pixelMapInfoOutputShape = {
   pixmap_number: pixmapNumberSchema,
@@ -92,7 +96,7 @@ const pixelMapInfoOutputShape = {
   height: z.number().int().min(0).nullable(),
   pixel_count: z.number().int().min(0).nullable(),
   fixture_count: z.number().int().min(0).nullable(),
-  fixtures: z.array(z.object(pixelMapFixtureOutputShape))
+  fixtures: z.array(pixelMapFixtureOutputSchema)
 } satisfies ZodRawShape;
 
 const pixelMapInfoOutputSchema = z.object(pixelMapInfoOutputShape);


### PR DESCRIPTION
## Summary
- export the pixel map fixture segment and fixture schemas for reuse
- update the pixel map info schema to reference the exported fixture schemas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd149f5c40832aac10a733e0380295