### PR TITLE
Use /eos/cmd for cue stop/back tool

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -605,7 +605,7 @@ _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/cue/stop/back s:'{"cuelist_number":1}'
+oscsend 127.0.0.1 8001 /eos/cmd s:'Cue 1 Stop#'
 ```
 
 <a id="eos-cuelist-bank-create"></a>

--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -166,7 +166,7 @@ export const oscMappings = {
   cues: {
     fire: '/eos/cue/fire',
     go: '/eos/cue/go',
-    stopBack: '/eos/cue/stop/back',
+    stopBack: '/eos/cmd',
     select: '/eos/cue/select',
     info: '/eos/get/cue',
     list: '/eos/get/cuelist',

--- a/src/tools/cues/common.ts
+++ b/src/tools/cues/common.ts
@@ -124,14 +124,27 @@ export function formatCueDescription(identifier: CueIdentifier): string {
   return parts.join(' ');
 }
 
+export interface CueCommandResultOverrides {
+  request?: unknown;
+  oscAddress?: string;
+  oscArgs?: unknown;
+  cli?: { text: string };
+}
+
 export function createCueCommandResult(
   action: string,
   identifier: CueIdentifier,
   payload: Record<string, unknown>,
   oscAddress: string,
-  extra: Record<string, unknown> = {}
+  extra: Record<string, unknown> = {},
+  overrides: CueCommandResultOverrides = {}
 ): ToolExecutionResult {
   const text = `Commande ${action} envoyee pour ${formatCueDescription(identifier)}.`;
+  const request = overrides.request ?? payload;
+  const address = overrides.oscAddress ?? oscAddress;
+  const oscArgs = overrides.oscArgs ?? payload;
+  const cli = overrides.cli;
+
   return {
     content: [
       { type: 'text', text },
@@ -140,11 +153,12 @@ export function createCueCommandResult(
         data: {
           action,
           identifier,
-          request: payload,
+          request,
           osc: {
-            address: oscAddress,
-            args: payload
+            address,
+            args: oscArgs
           },
+          ...(cli ? { cli } : {}),
           ...extra
         }
       }


### PR DESCRIPTION
## Summary
- switch the cue stop/back tool to issue text commands over /eos/cmd
- extend cue command result helpers and documentation generator to reflect command payloads
- regenerate the tool documentation with the updated OSC example

## Testing
- npm run docs:generate
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd250d24e4832a93ca633ac3b622e6