### PR TITLE
Fix OSC cue stop/back command mapping

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -606,6 +606,8 @@ _OSC_
 ```bash
 # Exemple d'envoi OSC via oscsend
 oscsend 127.0.0.1 8001 /eos/cmd s:'Cue 1 Stop#'
+# Pour effectuer un back sur la liste 1
+oscsend 127.0.0.1 8001 /eos/cmd s:'Cue 1 Back#'
 ```
 
 <a id="eos-cuelist-bank-create"></a>

--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -166,7 +166,7 @@ export const oscMappings = {
   cues: {
     fire: '/eos/cue/fire',
     go: '/eos/cue/go',
-    stopBack: '/eos/cmd',
+    stopBackCommand: '/eos/cmd',
     select: '/eos/cue/select',
     info: '/eos/get/cue',
     list: '/eos/get/cuelist',

--- a/src/tools/cues/__tests__/cues.test.ts
+++ b/src/tools/cues/__tests__/cues.test.ts
@@ -54,9 +54,13 @@ describe('cue tools', () => {
     expect(goPayload).toMatchObject({ cuelist: 5 });
 
     const stopMessage = service.sentMessages[1];
-    expect(stopMessage.address).toBe(oscMappings.cues.stopBack);
-    const stopPayload = JSON.parse(String(stopMessage?.args?.[0]?.value ?? '{}'));
-    expect(stopPayload).toMatchObject({ cuelist: 5, back: true });
+    expect(stopMessage.address).toBe(oscMappings.cues.stopBackCommand);
+    expect(stopMessage.args).toEqual([
+      {
+        type: 's',
+        value: 'Cue 5 Back#'
+      }
+    ]);
   });
 
   it('normalise les donnees renvoyees par get_active_cue', async () => {

--- a/src/tools/cues/stop_back.ts
+++ b/src/tools/cues/stop_back.ts
@@ -34,7 +34,7 @@ export const eosCueStopBackTool: ToolDefinition<typeof stopBackInputSchema> = {
     inputSchema: stopBackInputSchema,
     annotations: {
       mapping: {
-        osc: oscMappings.cues.stopBack,
+        osc: oscMappings.cues.stopBackCommand,
         commandExample: 'Cue {cuelist_number} Stop#'
       },
       highlighted: true
@@ -52,15 +52,14 @@ export const eosCueStopBackTool: ToolDefinition<typeof stopBackInputSchema> = {
 
     const action = options.back ? 'cue_back' : 'cue_stop';
     const command = `Cue ${listNumber} ${options.back ? 'Back#' : 'Stop#'}`;
-    const commandPayload = { command };
 
     await client.sendCommand(command, extractTargetOptions(options));
 
     return createCueCommandResult(
       action,
       identifier,
-      commandPayload,
-      oscMappings.cues.stopBack,
+      { command },
+      oscMappings.cues.stopBackCommand,
       {
         summary: `${options.back ? 'Back' : 'Stop'} sur ${formatCueDescription(identifier)}`
       },


### PR DESCRIPTION
## Summary
- rename the cue stop/back OSC mapping to use the command endpoint
- update the stop/back tool to emit the text command and adjust its test
- refresh the documentation example to cover stop and back commands

## Testing
- npm test -- cues

------
https://chatgpt.com/codex/tasks/task_e_68fd278cac28832aacf5a67176334a5a