### PR TITLE
Switch cuelist bank tools to parameterized OSC addresses

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -639,7 +639,11 @@ _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/cuelist/bank/create s:'{"bank_index":1,"cuelist_number":1,"num_prev_cues":1,"num_pending_cues":1}'
+oscsend 127.0.0.1 8001 /eos/cuelist/1/config/list i 1
+oscsend 127.0.0.1 8001 /eos/cuelist/1/config/previous i 1
+oscsend 127.0.0.1 8001 /eos/cuelist/1/config/pending i 1
+# Offset optionnel
+oscsend 127.0.0.1 8001 /eos/cuelist/1/config/offset i 0
 ```
 
 <a id="eos-cuelist-bank-page"></a>
@@ -670,7 +674,7 @@ _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/cuelist/bank/page s:'{"bank_index":1,"delta":1}'
+oscsend 127.0.0.1 8001 /eos/cuelist/1/page/1
 ```
 
 <a id="eos-cuelist-get-info"></a>

--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -171,8 +171,13 @@ export const oscMappings = {
     info: '/eos/get/cue',
     list: '/eos/get/cuelist',
     cuelistInfo: '/eos/get/cuelist/info',
-    bankCreate: '/eos/cuelist/bank/create',
-    bankPage: '/eos/cuelist/bank/page',
+    bankCreate: {
+      list: '/eos/cuelist/{index}/config/list',
+      previous: '/eos/cuelist/{index}/config/previous',
+      pending: '/eos/cuelist/{index}/config/pending',
+      offset: '/eos/cuelist/{index}/config/offset'
+    },
+    bankPage: '/eos/cuelist/{index}/page/{delta}',
     active: '/eos/get/active/cue',
     pending: '/eos/get/pending/cue'
   },

--- a/src/tools/cues/common.ts
+++ b/src/tools/cues/common.ts
@@ -165,3 +165,12 @@ export function createCueCommandResult(
     ]
   } as ToolExecutionResult;
 }
+
+export function resolveOscAddress(template: string, params: Record<string, number | string>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key: string) => {
+    if (!(key in params)) {
+      throw new Error(`Valeur manquante pour le parametre OSC "${key}".`);
+    }
+    return String(params[key]);
+  });
+}


### PR DESCRIPTION
## Summary
- update the OSC mapping for cuelist bank configuration to expose per-parameter address templates
- rewrite the cuelist bank creation and paging tools to emit parameterized OSC messages and expose richer results
- refresh cue tool tests and documentation examples to cover the new OSC syntax

## Testing
- npm test -- src/tools/cues/__tests__/cues.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fd279c0340832a904181378af4a82b