### PR TITLE
Update cuelist bank OSC commands to parameterized paths

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -606,8 +606,6 @@ _OSC_
 ```bash
 # Exemple d'envoi OSC via oscsend
 oscsend 127.0.0.1 8001 /eos/cmd s:'Cue 1 Stop#'
-# Pour effectuer un back sur la liste 1
-oscsend 127.0.0.1 8001 /eos/cmd s:'Cue 1 Back#'
 ```
 
 <a id="eos-cuelist-bank-create"></a>
@@ -641,7 +639,7 @@ _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/cuelist/bank/create s:'{"bank_index":1,"cuelist_number":1,"num_prev_cues":1,"num_pending_cues":1}'
+oscsend 127.0.0.1 8001 /eos/cuelist/1/config/1/1/1
 ```
 
 <a id="eos-cuelist-bank-page"></a>
@@ -672,7 +670,7 @@ _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/cuelist/bank/page s:'{"bank_index":1,"delta":1}'
+oscsend 127.0.0.1 8001 /eos/cuelist/1/page/1
 ```
 
 <a id="eos-cuelist-get-info"></a>

--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -171,8 +171,8 @@ export const oscMappings = {
     info: '/eos/get/cue',
     list: '/eos/get/cuelist',
     cuelistInfo: '/eos/get/cuelist/info',
-    bankCreate: '/eos/cuelist/bank/create',
-    bankPage: '/eos/cuelist/bank/page',
+    bankCreate: '/eos/cuelist/{bank_index}/config/{cuelist_number}/{num_prev_cues}/{num_pending_cues}',
+    bankPage: '/eos/cuelist/{bank_index}/page/{delta}',
     active: '/eos/get/active/cue',
     pending: '/eos/get/pending/cue'
   },

--- a/src/tools/cues/__tests__/cues.test.ts
+++ b/src/tools/cues/__tests__/cues.test.ts
@@ -4,6 +4,8 @@ import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosCueGoTool,
   eosCueStopBackTool,
+  eosCuelistBankCreateTool,
+  eosCuelistBankPageTool,
   eosGetActiveCueTool
 } from '../index';
 import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
@@ -148,5 +150,32 @@ describe('cue tools', () => {
         remainingSeconds: 30
       }
     });
+  });
+
+  it('configure un bank de cuelist via un chemin parametre', async () => {
+    await runTool(eosCuelistBankCreateTool, {
+      bank_index: 3,
+      cuelist_number: 99,
+      num_prev_cues: 2,
+      num_pending_cues: 4,
+      offset: 7
+    });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const message = service.sentMessages[0];
+    expect(message.address).toBe('/eos/cuelist/3/config/99/2/4/7');
+    expect(message.args ?? []).toEqual([]);
+  });
+
+  it('navigue dans un bank de cuelist via un chemin parametre', async () => {
+    await runTool(eosCuelistBankPageTool, {
+      bank_index: 5,
+      delta: -2
+    });
+
+    expect(service.sentMessages).toHaveLength(1);
+    const message = service.sentMessages[0];
+    expect(message.address).toBe('/eos/cuelist/5/page/-2');
+    expect(message.args ?? []).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- replace the cuelist bank OSC mappings with parameterized path templates
- update the cuelist bank tools to emit the new OSC paths and extend the unit tests
- enhance the documentation generator so the examples show path substitutions and regenerate the tool docs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd2bd84494832aafe28b30025550a9