### PR TITLE
Switch direct select tools to ETC /eos/ds endpoints

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -789,14 +789,14 @@ oscsend 127.0.0.1 8001 /eos/curve/select s:'{"curve_number":1}'
 _CLI_
 
 ```bash
-npx @modelcontextprotocol/cli call --tool eos_direct_select_bank_create --args '{"bank_index":1,"target_type":"exemple","button_count":1,"flexi_mode":true}'
+npx @modelcontextprotocol/cli call --tool eos_direct_select_bank_create --args '{"bank_index":1,"target_type":"Group","button_count":1,"flexi_mode":true}'
 ```
 
 _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/direct_select/bank/create s:'{"bank_index":1,"target_type":"exemple","button_count":1,"flexi_mode":true}'
+oscsend 127.0.0.1 8001 /eos/ds/1/config/Group/1/1/0
 ```
 
 <a id="eos-direct-select-page"></a>
@@ -827,7 +827,7 @@ _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/direct_select/bank/page s:'{"bank_index":1,"delta":1}'
+oscsend 127.0.0.1 8001 /eos/ds/1/page/1
 ```
 
 <a id="eos-direct-select-press"></a>

--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -79,9 +79,9 @@ export const oscMappings = {
     bankPage: '/eos/fader/{index}/page/{delta}'
   },
   directSelects: {
-    base: '/eos/direct_select/bank',
-    bankCreate: '/eos/direct_select/bank/create',
-    bankPage: '/eos/direct_select/bank/page'
+    base: '/eos/ds/{index}/button/{page}/{button}',
+    bankCreate: '/eos/ds/{index}/config/{target}/{buttons}/{flexi}/{page}',
+    bankPage: '/eos/ds/{index}/page/{delta}'
   },
   pixelMaps: {
     select: '/eos/pixmap/select',


### PR DESCRIPTION
## Summary
- update direct select OSC mappings to the ETC /eos/ds/{…} endpoints
- refactor bank creation and page tools to build the new paths without JSON payloads
- refresh documentation and tests to reflect the new OSC syntax

## Testing
- npm test -- --runTestsByPath src/tools/directSelects/__tests__/directSelects.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fd2f1ad748832ab8b760f5d0648fcd