### PR TITLE
Switch channel tools to documented OSC commands

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -102,7 +102,7 @@ Réaliser un « fade » rapide ou un ajustement ponctuel de niveau depuis un a
 ### Commande OSC commentée
 ```bash
 # Mise à 65 % des canaux 101 et 102
-oscsend 127.0.0.1 8001 /eos/channel/level s:'{"channels":[101,102],"level":65}'
+oscsend 127.0.0.1 8001 /eos/cmd s:"Chan 101 Thru 102 Sneak 65 Enter"
 ```
 
 ### Astuces d'intégration

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -179,7 +179,7 @@ oscsend 127.0.0.1 8001 /eos/get/channels s:'{"channels":1}'
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `channels` | number \| array<number> | Oui | Un numero de canal ou une liste de canaux |
-| `exclusive` | boolean | Non | — |
+| `exclusive` | boolean | Non | Ajoute un `+` final pour conserver la selection existante |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 
@@ -197,7 +197,7 @@ _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/chan/select s:'{"channels":1}'
+oscsend 127.0.0.1 8001 /eos/cmd s:"Chan 1 Enter"
 ```
 
 <a id="eos-channel-set-level"></a>
@@ -211,7 +211,7 @@ oscsend 127.0.0.1 8001 /eos/chan/select s:'{"channels":1}'
 | --- | --- | --- | --- |
 | `channels` | number \| array<number> | Oui | Un numero de canal ou une liste de canaux |
 | `level` | number \| string | Oui | — |
-| `snap` | boolean | Non | — |
+| `snap` | boolean | Non | Utilise `At` (snap immediat) si vrai, `Sneak` sinon |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 
@@ -229,7 +229,7 @@ _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/chan/level s:'{"channels":1,"level":1}'
+oscsend 127.0.0.1 8001 /eos/cmd s:"Chan 1 Sneak 1 Enter"
 ```
 
 <a id="eos-channel-set-parameter"></a>
@@ -2420,7 +2420,7 @@ oscsend 127.0.0.1 8001 /eos/set/cue/send_string s:'{"format_string":"exemple"}'
 
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `addresses` | number \| array<number> | Oui | — |
+| `addresses` | number \| array<number> | Oui | Liste d'adresses absolues ou sequences DMX |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `value` | number \| string | Oui | — |
@@ -2439,7 +2439,7 @@ _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/dmx/level s:'{"addresses":1,"value":1}'
+oscsend 127.0.0.1 8001 /eos/cmd s:"Address 1 At 1 Enter"
 ```
 
 <a id="eos-set-pantilt-xy"></a>

--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -1,12 +1,12 @@
 export const oscMappings = {
   channels: {
-    select: '/eos/chan/select',
-    level: '/eos/chan/level',
-    dmx: '/eos/dmx/level',
+    command: '/eos/cmd',
+    base: '/eos/chan',
     parameter: '/eos/chan/param',
     info: '/eos/get/channels'
   },
   dmx: {
+    command: '/eos/cmd',
     addressSelect: '/eos/dmx/address/select',
     addressLevel: '/eos/dmx/address/level',
     addressDmx: '/eos/dmx/address/dmx'

--- a/src/tools/channels/__tests__/channels.test.ts
+++ b/src/tools/channels/__tests__/channels.test.ts
@@ -46,20 +46,20 @@ describe('channel tools', () => {
     await runTool(eosChannelSetLevelTool, { channels: [1, 2], level: 'out' });
 
     expect(service.sentMessages).toHaveLength(1);
-    expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.channels.level });
+    expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.channels.command });
 
-    const payload = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
-    expect(payload).toMatchObject({ level: 0, channels: [1, 2] });
+    const message = service.sentMessages[0];
+    expect(message?.args?.[0]?.value).toBe('Chan 1 Thru 2 Sneak 0 Enter');
   });
 
   it('transforme full en 255 pour le DMX', async () => {
     await runTool(eosSetDmxTool, { addresses: [101], value: 'full' });
 
     expect(service.sentMessages).toHaveLength(1);
-    expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.channels.dmx });
+    expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.dmx.command });
 
-    const payload = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
-    expect(payload).toMatchObject({ value: 255, addresses: [101] });
+    const message = service.sentMessages[0];
+    expect(message?.args?.[0]?.value).toBe('Address 101 At 255 Enter');
   });
 
   it('parse la reponse JSON pour la commande get_info', async () => {


### PR DESCRIPTION
## Summary
- replace legacy channel and DMX OSC mappings with the documented /eos/cmd entry points
- emit textual Eos commands for channel selection, level, and DMX tools while keeping info/param JSON flows intact
- refresh documentation and unit tests to reflect the new OSC syntax

## Testing
- npm test -- --runTestsByPath src/tools/channels/__tests__/channels.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fd31ab66cc832a92baf152cba77a08