### PR TITLE
Adjust OSC handshake client identifier ordering

### DIFF
--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -736,6 +736,7 @@ export class OscClient {
 
   private async performHandshake(options: ConnectOptions, timeout: number): Promise<HandshakeData> {
     const args = [
+      { type: 's', value: 'ETCOSC?' },
       { type: 's', value: options.clientId ?? 'mcp' }
     ];
 


### PR DESCRIPTION
## Summary
- send the OSC handshake message with the ETCOSC? probe followed by the client identifier
- update OSC client tests to assert the new handshake argument order while keeping protocol selection expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd3674cde8832a8fb17aa8906f5328