### PR TITLE
Normalize manifest transport URL placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Réponse attendue :
 
 #### Publier la passerelle via un tunnel ou un reverse proxy
 
-L'endpoint `/manifest.json` annonce une URL absolue à destination des clients MCP. Par défaut, cette URL est déduite dynamiquement de la requête entrante (en tenant compte des en-têtes `Host`, `X-Forwarded-Host` et `X-Forwarded-Proto`). Lorsque vous exposez le serveur derrière un tunnel (`ngrok`, `Cloudflare Tunnel`, etc.) ou un reverse proxy (Nginx, Traefik, Caddy), vous pouvez forcer l'URL publiée via la variable d’environnement `MCP_HTTP_PUBLIC_URL` :
+L'endpoint `/manifest.json` annonce une URL absolue à destination des clients MCP. Le manifest embarqué fournit désormais le placeholder explicite `http://{HOST}:{PORT}` : il est remplacé au moment de la réponse HTTP par l'adresse détectée (`Host`, `X-Forwarded-Host`, `X-Forwarded-Proto`) ou par la valeur de `MCP_HTTP_PUBLIC_URL`. Lorsque vous exposez le serveur derrière un tunnel (`ngrok`, `Cloudflare Tunnel`, etc.) ou un reverse proxy (Nginx, Traefik, Caddy), vous pouvez forcer l'URL publiée via la variable d’environnement `MCP_HTTP_PUBLIC_URL` :
 
 ```bash
 MCP_TCP_PORT=3032 \
@@ -254,7 +254,7 @@ npm run start:dev
 
 - Si votre proxy réécrit le chemin (ex. `https://example.com/mcp`), incluez-le dans `MCP_HTTP_PUBLIC_URL` afin que les clients MCP résolvent correctement les endpoints (`/manifest.json`, `/health`, `/tools`, `/ws`).
 - Conservez les en-têtes `X-Forwarded-*` lorsque vous terminez TLS en amont : le serveur peut ainsi détecter automatiquement le schéma `https` et générer un manifest cohérent, même sans variable dédiée.
-- Pour les tunnels dynamiques (adresse changeante), automatisez la mise à jour de `MCP_HTTP_PUBLIC_URL` ou vérifiez que l’outil propage bien les en-têtes originaux.
+- Pour les tunnels dynamiques (adresse changeante), automatisez la mise à jour de `MCP_HTTP_PUBLIC_URL` ou vérifiez que l’outil propage bien les en-têtes originaux. Si la variable n'est pas définie, le placeholder `http://{HOST}:{PORT}` est résolu à chaque requête.
 
 Une URL publique correctement configurée garantit que les assistants IA et orchestrateurs MCP peuvent établir des connexions WebSocket et HTTP sans dépendre d’un placeholder statique.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,6 +10,7 @@ Ce guide explique comment executer Eos MCP en tant que service durable sous Linu
    npm run package
    ```
 2. Le binaire autonome est produit dans `dist/bin/eos-mcp`. Copiez-le sur la machine cible avec votre fichier `.env` et le dossier `logs/` si vous souhaitez reutiliser la meme arborescence.
+3. Ajustez l'URL publique exposee par la passerelle HTTP si necessaire : le manifest contient le placeholder `http://{HOST}:{PORT}` et le serveur le remplace automatiquement. Pour une adresse statique (reverse proxy, tunnel), declarez `MCP_HTTP_PUBLIC_URL=https://mcp.example.com` dans votre fichier `.env` afin que le manifest distribue l'URL correcte.
 
 ## Linux (systemd)
 

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
         "server": {
           "transport": {
             "type": "http",
-            "url": ""
+            "url": "http://{HOST}:{PORT}"
           },
           "endpoints": {
             "manifest": "/manifest.json",


### PR DESCRIPTION
## Summary
- replace the HTTP transport URL in manifest.json with an explicit placeholder and document how it is resolved
- adjust the HTTP gateway to substitute placeholders with absolute URLs and normalize custom values
- extend manifest validation to accept the placeholder and ensure HTTP URLs are not empty

## Testing
- npm run lint:manifest
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd42f174ac832a9b9d510761637e17