### PR TITLE
Handle OSC gateway replacement and preserve diagnostics

### DIFF
--- a/src/server/__tests__/bootstrapHandshake.test.ts
+++ b/src/server/__tests__/bootstrapHandshake.test.ts
@@ -98,7 +98,12 @@ jest.mock('../../services/osc/client.js', () => ({
   initializeOscClient: jest.fn(),
   getOscClient: jest.fn(() => ({
     connect: mockConnect
-  }))
+  })),
+  getOscGateway: jest.fn(() => mockOscGateway),
+  onOscGatewayChange: jest.fn((listener: (gateway: typeof mockOscGateway) => void) => {
+    listener(mockOscGateway);
+    return jest.fn();
+  })
 }));
 
 const mockGatewayInstance = {

--- a/src/server/__tests__/healthAfterConfigure.test.ts
+++ b/src/server/__tests__/healthAfterConfigure.test.ts
@@ -1,0 +1,227 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createHttpGateway, type HttpGateway } from '../httpGateway';
+import { ToolRegistry } from '../toolRegistry';
+import type { ToolDefinition } from '../../tools/types';
+import {
+  OscConnectionStateProvider,
+  type OscDiagnostics,
+  type OscMessage
+} from '../../services/osc/index';
+import {
+  initializeOscClient,
+  getOscGateway,
+  setOscClient
+} from '../../services/osc/client';
+import * as oscModule from '../../services/osc/index';
+import { eosConfigureTool } from '../../tools/connection/eos_configure';
+
+class TestGateway {
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  constructor(
+    private readonly provider: OscConnectionStateProvider,
+    private diagnostics: OscDiagnostics
+  ) {}
+
+  public async send(_message: OscMessage, _options?: unknown): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public emit(message: OscMessage): void {
+    this.listeners.forEach((listener) => listener(message));
+  }
+
+  public setDiagnostics(diagnostics: OscDiagnostics): void {
+    this.diagnostics = diagnostics;
+  }
+
+  public getDiagnostics(): OscDiagnostics {
+    return this.diagnostics;
+  }
+
+  public getConnectionStateProvider(): OscConnectionStateProvider {
+    return this.provider;
+  }
+
+  public close(): void {
+    this.listeners.clear();
+  }
+}
+
+function createDiagnostics(
+  overrides: Partial<OscDiagnostics> & {
+    config: OscDiagnostics['config'];
+  }
+): OscDiagnostics {
+  return {
+    config: overrides.config,
+    logging: overrides.logging ?? { incoming: false, outgoing: false },
+    stats:
+      overrides.stats ??
+      {
+        incoming: { count: 0, bytes: 0, lastTimestamp: null, lastMessage: null, addresses: [] },
+        outgoing: { count: 0, bytes: 0, lastTimestamp: null, lastMessage: null, addresses: [] }
+      },
+    listeners: overrides.listeners ?? { active: 0 },
+    startedAt: overrides.startedAt ?? Date.now(),
+    uptimeMs: overrides.uptimeMs ?? 0
+  };
+}
+
+const tool: ToolDefinition = {
+  name: 'noop',
+  config: {
+    description: 'noop'
+  },
+  handler: async () => ({
+    content: [
+      {
+        type: 'text',
+        text: 'noop'
+      }
+    ]
+  })
+};
+
+describe('HTTP /health after eos_configure', () => {
+  let server: McpServer;
+  let registry: ToolRegistry;
+  let gateway: HttpGateway;
+  let baseUrl: string;
+  let connectionState: OscConnectionStateProvider;
+  let initialGateway: TestGateway;
+
+  const markConnected = (type: 'tcp' | 'udp'): void => {
+    const timestamp = Date.now();
+    connectionState.setStatus({
+      type,
+      state: 'connected',
+      lastHeartbeatAckAt: timestamp,
+      lastHeartbeatSentAt: timestamp,
+      consecutiveFailures: 0
+    });
+  };
+
+  beforeAll(async () => {
+    setOscClient(null);
+
+    server = new McpServer({ name: 'health-test', version: '0.0.0-test' });
+    registry = new ToolRegistry(server);
+    registry.register(tool);
+
+    connectionState = new OscConnectionStateProvider();
+    markConnected('tcp');
+    markConnected('udp');
+
+    initialGateway = new TestGateway(
+      connectionState,
+      createDiagnostics({
+        config: {
+          localAddress: '0.0.0.0',
+          localPort: 7001,
+          remoteAddress: '192.168.0.10',
+          remotePort: 9002
+        }
+      })
+    );
+
+    initializeOscClient(initialGateway);
+
+    gateway = createHttpGateway(registry, {
+      port: 0,
+      oscConnectionProvider: connectionState,
+      oscGateway: {
+        getDiagnostics: () => {
+          const diagnostics = getOscGateway().getDiagnostics?.();
+          if (!diagnostics) {
+            throw new Error('Diagnostics indisponibles');
+          }
+          return diagnostics;
+        }
+      }
+    });
+
+    await gateway.start();
+    const address = gateway.getAddress();
+    if (!address) {
+      throw new Error('Adresse HTTP indisponible');
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await gateway.stop();
+    await server.close();
+    setOscClient(null);
+  });
+
+  test('exposes diagnostics after reconfiguration', async () => {
+    const initialResponse = await fetch(`${baseUrl}/health`);
+    expect(initialResponse.status).toBe(200);
+    const initialPayload = (await initialResponse.json()) as {
+      osc?: { diagnostics?: OscDiagnostics };
+    };
+
+    const initialDiagnostics = initialPayload.osc?.diagnostics;
+    expect(initialDiagnostics?.config.remoteAddress).toBe('192.168.0.10');
+    expect(initialDiagnostics?.config.remotePort).toBe(9002);
+
+    const newGateway = new TestGateway(
+      connectionState,
+      createDiagnostics({
+        config: {
+          localAddress: '0.0.0.0',
+          localPort: 7001,
+          remoteAddress: '203.0.113.5',
+          remotePort: 10001
+        }
+      })
+    );
+
+    const gatewaySpy = jest
+      .spyOn(oscModule, 'createOscConnectionGateway')
+      .mockReturnValue(newGateway as unknown as oscModule.OscConnectionGateway);
+
+    await eosConfigureTool.handler({
+      remoteAddress: '203.0.113.5',
+      remotePort: 10001,
+      localPort: 7001,
+      tcpPort: 3032
+    });
+
+    expect(gatewaySpy).toHaveBeenCalledTimes(1);
+    const createArgs = gatewaySpy.mock.calls[0]?.[0];
+    expect(createArgs?.connectionStateProvider).toBe(connectionState);
+    gatewaySpy.mockRestore();
+
+    const response = await fetch(`${baseUrl}/health`);
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      status: string;
+      osc?: {
+        status?: string;
+        diagnostics?: OscDiagnostics;
+      };
+    };
+
+    expect(payload.status).toBe('ok');
+    const osc = payload.osc;
+    expect(osc).toBeDefined();
+    const diagnostics = osc?.diagnostics;
+    expect(diagnostics).toBeDefined();
+    if (!diagnostics) {
+      throw new Error('Diagnostics absents du payload');
+    }
+
+    expect(diagnostics.config.remoteAddress).toBe('203.0.113.5');
+    expect(diagnostics.config.remotePort).toBe(10001);
+  });
+});
+

--- a/src/server/__tests__/serverVersion.test.ts
+++ b/src/server/__tests__/serverVersion.test.ts
@@ -89,7 +89,12 @@ jest.mock('../../services/osc/client.js', () => ({
   initializeOscClient: jest.fn(),
   getOscClient: jest.fn(() => ({
     connect: mockConnect
-  }))
+  })),
+  getOscGateway: jest.fn(() => mockOscGateway),
+  onOscGatewayChange: jest.fn((listener: (gateway: typeof mockOscGateway) => void) => {
+    listener(mockOscGateway);
+    return jest.fn();
+  })
 }));
 
 jest.mock('../startupChecks.js', () => ({

--- a/src/services/osc/gateway.ts
+++ b/src/services/osc/gateway.ts
@@ -178,6 +178,10 @@ export class OscConnectionGateway implements OscGateway {
     };
   }
 
+  public getConnectionStateProvider(): OscConnectionStateProvider | undefined {
+    return this.connectionStateProvider;
+  }
+
   public setLoggingOptions(options: OscLoggingOptions): OscLoggingState {
     if (typeof options.incoming === 'boolean') {
       this.loggingState.incoming = options.incoming;

--- a/src/tools/connection/__tests__/eos_configure.test.ts
+++ b/src/tools/connection/__tests__/eos_configure.test.ts
@@ -11,7 +11,8 @@ jest.mock('../../../services/osc/client.js', () => ({
   })),
   resetOscClient: jest.fn(() => ({
     getDiagnostics: mockGetDiagnostics
-  }))
+  })),
+  getOscConnectionStateProvider: jest.fn(() => undefined)
 }));
 
 jest.mock('../../../services/osc/index.js', () => ({
@@ -22,6 +23,7 @@ describe('eos_configure tool', () => {
   const clientModule = jest.requireMock('../../../services/osc/client.js') as {
     getOscGateway: jest.Mock;
     resetOscClient: jest.Mock;
+    getOscConnectionStateProvider: jest.Mock;
   };
   const oscModule = jest.requireMock('../../../services/osc/index.js') as {
     createOscConnectionGateway: jest.Mock;
@@ -39,6 +41,7 @@ describe('eos_configure tool', () => {
     clientModule.resetOscClient.mockReturnValue({
       getDiagnostics: mockGetDiagnostics
     });
+    clientModule.getOscConnectionStateProvider.mockReturnValue(null);
     oscModule.createOscConnectionGateway.mockImplementation(mockCreateGateway);
   });
 
@@ -75,7 +78,8 @@ describe('eos_configure tool', () => {
       udpPort: 9002,
       tcpPort: 3032,
       localPort: 7001,
-      logger: expect.any(Object)
+      logger: expect.any(Object),
+      connectionStateProvider: undefined
     });
     const createdGateway = mockCreateGateway.mock.results[0]?.value;
     expect(clientModule.resetOscClient).toHaveBeenCalledWith(createdGateway);

--- a/src/tools/connection/eos_configure.ts
+++ b/src/tools/connection/eos_configure.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { getOscGateway, resetOscClient } from '../../services/osc/client';
+import {
+  getOscConnectionStateProvider,
+  getOscGateway,
+  resetOscClient
+} from '../../services/osc/client';
 import { createOscConnectionGateway } from '../../services/osc/index';
 import { createLogger } from '../../server/logger';
 import type { ToolDefinition } from '../types';
@@ -35,13 +39,16 @@ export const eosConfigureTool: ToolDefinition<typeof inputSchema> = {
     currentGateway.close?.();
 
     const tcpPort = options.tcpPort ?? Number.parseInt(process.env.OSC_TCP_PORT ?? '3032', 10);
-    const gateway = createOscConnectionGateway({
+    const gatewayOptions = {
       host: options.remoteAddress,
       udpPort: options.remotePort,
       tcpPort: Number.isFinite(tcpPort) ? tcpPort : 3032,
       localPort: options.localPort,
-      logger: createLogger('osc-gateway')
-    });
+      logger: createLogger('osc-gateway'),
+      connectionStateProvider: getOscConnectionStateProvider() ?? undefined
+    };
+
+    const gateway = createOscConnectionGateway(gatewayOptions);
 
     const client = resetOscClient(gateway);
     const diagnostics = client.getDiagnostics();


### PR DESCRIPTION
## Summary
- add an observer mechanism in the OSC client so gateway replacements retain the shared connection state provider
- propagate refreshed gateway instances to HTTP diagnostics and reuse the server-managed provider in eos_configure
- add coverage ensuring /health continues to report diagnostics after running eos_configure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd4e0c6044832a98270c43cb24df34