### PR TITLE
Increase OSC handshake timeout during server startup

### DIFF
--- a/src/server/__tests__/bootstrapHandshake.test.ts
+++ b/src/server/__tests__/bootstrapHandshake.test.ts
@@ -176,7 +176,7 @@ describe('bootstrap OSC handshake', () => {
 
     expect(mockConnect).toHaveBeenCalledWith({
       toolId: 'startup_preflight',
-      handshakeTimeoutMs: 2000,
+      handshakeTimeoutMs: 10000,
       protocolTimeoutMs: 2000
     });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -415,7 +415,7 @@ async function bootstrap(options: BootstrapOptions = {}): Promise<BootstrapConte
     try {
       const handshakeResult = await client.connect({
         toolId: 'startup_preflight',
-        handshakeTimeoutMs: 2000,
+        handshakeTimeoutMs: 10000,
         protocolTimeoutMs: 2000
       });
 


### PR DESCRIPTION
## Summary
- extend the OSC startup handshake timeout to 10 seconds
- align the bootstrap handshake test expectation with the new timeout

## Testing
- npm test -- --runTestsByPath src/server/__tests__/bootstrapHandshake.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fd62f96170832a8941726b734d8872