### PR TITLE
Handle legacy Onyx OSC handshake fallback

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -392,6 +392,8 @@ _Pas de mapping OSC documenté._
 
 **Description :** Initie un handshake OSC avec la console EOS, choisit un protocole et retourne la version detectee.
 
+> ℹ️ Lorsque les firmwares Onyx legacy ne repondent pas sur `/eos/handshake/reply`, le client considere les premiers messages `/eos/out/...` comme un handshake implicite. Dans ce mode de secours, aucune version ni liste de protocoles n'est exposee et la selection de protocole est donc ignoree.
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |


### PR DESCRIPTION
## Summary
- treat initial `/eos/out/...` frames as a legacy OSC handshake fallback when no canonical reply arrives
- expose a helper for parsing the fallback so tests can reuse it and document the behaviour for developers

## Testing
- npm test -- --runTestsByPath src/services/osc/__tests__/client.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fd6d6fb69c832a9e1bc259046e22d8