### PR TITLE
Refactor tool structured outputs

### DIFF
--- a/src/server/__tests__/bootstrapHandshake.test.ts
+++ b/src/server/__tests__/bootstrapHandshake.test.ts
@@ -168,7 +168,7 @@ describe('bootstrap OSC handshake', () => {
     const context = await bootstrap();
 
     expect(mockAssertTcpPortAvailable).toHaveBeenCalledTimes(1);
-    expect(mockAssertTcpPortAvailable).toHaveBeenCalledWith(3100);
+    expect(mockAssertTcpPortAvailable).toHaveBeenCalledWith(3033);
     expect(mockAssertUdpPortAvailable).toHaveBeenCalledTimes(1);
     expect(mockAssertUdpPortAvailable).toHaveBeenCalledWith(8000);
     expect(mockAssertUdpPortAvailable).not.toHaveBeenCalledWith(8001);

--- a/src/tools/__tests__/helpers/runTool.ts
+++ b/src/tools/__tests__/helpers/runTool.ts
@@ -2,11 +2,6 @@ import type { ToolDefinition, ToolExecutionResult } from '../../types';
 
 type ToolContentEntry = ToolExecutionResult['content'][number];
 
-export interface ObjectContent extends ToolContentEntry {
-  type: 'object';
-  data: Record<string, unknown>;
-}
-
 export interface TextContent extends ToolContentEntry {
   type: 'text';
   text: string;
@@ -20,13 +15,14 @@ export async function runTool(
   return tool.handler(args, extra);
 }
 
-export function isObjectContent(entry: ToolContentEntry): entry is ObjectContent {
-  if (entry.type !== 'object') {
-    return false;
+export function getStructuredContent(
+  result: ToolExecutionResult
+): Record<string, unknown> | undefined {
+  const { structuredContent } = result;
+  if (structuredContent && typeof structuredContent === 'object' && !Array.isArray(structuredContent)) {
+    return structuredContent as Record<string, unknown>;
   }
-
-  const candidate = entry as { data?: unknown };
-  return typeof candidate.data === 'object' && candidate.data !== null;
+  return undefined;
 }
 
 export function isTextContent(entry: ToolContentEntry): entry is TextContent {

--- a/src/tools/channels/__tests__/channels.test.ts
+++ b/src/tools/channels/__tests__/channels.test.ts
@@ -6,7 +6,7 @@ import {
   eosSetDmxTool,
   eosChannelGetInfoTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -83,13 +83,13 @@ describe('channel tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'ok',
       request: { channels: [1], fields: ['label'] },
       data: {

--- a/src/tools/channels/index.ts
+++ b/src/tools/channels/index.ts
@@ -175,12 +175,10 @@ function buildChannelExpression(values: number[]): string {
     .join(' + ');
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/commands/__tests__/command_tools.test.ts
+++ b/src/tools/commands/__tests__/command_tools.test.ts
@@ -7,7 +7,7 @@ import {
   eosGetCommandLineTool
 } from '../command_tools';
 import { clearCurrentUserId, setCurrentUserId } from '../../session';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 describe('command tools', () => {
   class FakeOscService implements OscGateway {
@@ -57,11 +57,7 @@ describe('command tools', () => {
       ]
     });
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
-    }
+    expect(getStructuredContent(result)).toBeDefined();
   });
 
   it('applique la substitution et efface la ligne pour eos_new_command', async () => {
@@ -124,13 +120,13 @@ describe('command tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
+    const structuredContent = getStructuredContent(result);
 
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'ok',
       text: 'Chan 1 At 50',
       user: 4

--- a/src/tools/commands/command_tools.ts
+++ b/src/tools/commands/command_tools.ts
@@ -58,22 +58,19 @@ function formatSendResult(command: string, user: number | null, oscAddress: stri
       {
         type: 'text',
         text: `Commande envoyee sur ${oscAddress}: ${command}`
-      },
-      {
-        type: 'object',
-        data: {
-          command,
-          user,
-          osc: {
-            address: oscAddress,
-            ...buildOscDescriptor(command, user)
-          },
-          cli: {
-            text: command
-          }
-        }
       }
-    ]
+    ],
+    structuredContent: {
+      command,
+      user,
+      osc: {
+        address: oscAddress,
+        ...buildOscDescriptor(command, user)
+      },
+      cli: {
+        text: command
+      }
+    }
   } as ToolExecutionResult;
 }
 
@@ -85,12 +82,9 @@ function formatCommandLineState(result: CommandLineState): ToolExecutionResult {
         text: result.status === 'ok'
           ? `Ligne de commande utilisateur ${result.user ?? 'global'}: ${result.text}`
           : `Lecture de la ligne de commande indisponible (${result.status})`
-      },
-      {
-        type: 'object',
-        data: result
       }
-    ]
+    ],
+    structuredContent: result
   } as ToolExecutionResult;
 }
 

--- a/src/tools/connection/__tests__/eos_configure.test.ts
+++ b/src/tools/connection/__tests__/eos_configure.test.ts
@@ -86,18 +86,15 @@ describe('eos_configure tool', () => {
     expect(clientModule.resetOscClient).toHaveBeenCalledTimes(1);
     expect(mockGetDiagnostics).toHaveBeenCalledTimes(1);
 
-    expect(result.content).toHaveLength(2);
-    const [textContent, objectContent] = result.content;
+    expect(result.content).toHaveLength(1);
+    const [textContent] = result.content;
     if (textContent.type !== 'text') {
       throw new Error('Le premier contenu doit etre du texte');
     }
     expect(textContent.text).toContain('10.1.0.5:9002');
     expect(textContent.text).toContain('Local : 0.0.0.0:7001');
 
-    if (objectContent.type !== 'object') {
-      throw new Error('Le second contenu doit etre un objet');
-    }
-    expect(objectContent.data).toEqual({ diagnostics });
+    expect(result.structuredContent).toEqual({ diagnostics });
   });
 
   it('rejette les configurations invalides', async () => {

--- a/src/tools/connection/eos_configure.ts
+++ b/src/tools/connection/eos_configure.ts
@@ -71,12 +71,9 @@ export const eosConfigureTool: ToolDefinition<typeof inputSchema> = {
         {
           type: 'text',
           text: summary
-        },
-        {
-          type: 'object',
-          data: { diagnostics }
         }
-      ]
+      ],
+      structuredContent: { diagnostics }
     };
   }
 };

--- a/src/tools/connection/eos_connect.ts
+++ b/src/tools/connection/eos_connect.ts
@@ -51,12 +51,9 @@ export const eosConnectTool: ToolDefinition<typeof inputSchema> = {
         {
           type: 'text',
           text: summaryParts.join('\n')
-        },
-        {
-          type: 'object',
-          data: result
         }
-      ]
+      ],
+      structuredContent: result
     };
   }
 };

--- a/src/tools/connection/eos_ping.ts
+++ b/src/tools/connection/eos_ping.ts
@@ -53,12 +53,9 @@ export const eosPingTool: ToolDefinition<typeof inputSchema> = {
         {
           type: 'text',
           text: lines.join('\n')
-        },
-        {
-          type: 'object',
-          data: result
         }
-      ]
+      ],
+      structuredContent: result
     };
   }
 };

--- a/src/tools/connection/eos_reset.ts
+++ b/src/tools/connection/eos_reset.ts
@@ -53,12 +53,9 @@ export const eosResetTool: ToolDefinition<typeof inputSchema> = {
         {
           type: 'text',
           text: lines.join('\n')
-        },
-        {
-          type: 'object',
-          data: result
         }
-      ]
+      ],
+      structuredContent: result
     };
   }
 };

--- a/src/tools/connection/eos_subscribe.ts
+++ b/src/tools/connection/eos_subscribe.ts
@@ -63,12 +63,9 @@ export const eosSubscribeTool: ToolDefinition<typeof inputSchema> = {
         {
           type: 'text',
           text: lines.join('\n')
-        },
-        {
-          type: 'object',
-          data: result
         }
-      ]
+      ],
+      structuredContent: result
     };
   }
 };

--- a/src/tools/cues/__tests__/cues.test.ts
+++ b/src/tools/cues/__tests__/cues.test.ts
@@ -8,7 +8,7 @@ import {
   eosCuelistBankPageTool,
   eosGetActiveCueTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -111,13 +111,13 @@ describe('cue tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       cue: {
         details: {
           identifier: {

--- a/src/tools/cues/common.ts
+++ b/src/tools/cues/common.ts
@@ -146,22 +146,17 @@ export function createCueCommandResult(
   const cli = overrides.cli;
 
   return {
-    content: [
-      { type: 'text', text },
-      {
-        type: 'object',
-        data: {
-          action,
-          identifier,
-          request,
-          osc: {
-            address,
-            args: oscArgs
-          },
-          ...(cli ? { cli } : {}),
-          ...extra
-        }
-      }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent: {
+      action,
+      identifier,
+      request,
+      osc: {
+        address,
+        args: oscArgs
+      },
+      ...(cli ? { cli } : {}),
+      ...extra
+    }
   } as ToolExecutionResult;
 }

--- a/src/tools/cues/cuelist_bank_create.ts
+++ b/src/tools/cues/cuelist_bank_create.ts
@@ -89,20 +89,15 @@ export const eosCuelistBankCreateTool: ToolDefinition<typeof bankCreateInputSche
     }
 
     const result: ToolExecutionResult = {
-      content: [
-        { type: 'text', text },
-        {
-          type: 'object',
-          data: {
-            action: 'cuelist_bank_create',
-            request,
-            osc: {
-              address,
-              args: [] as const
-            }
-          }
+      content: [{ type: 'text', text }],
+      structuredContent: {
+        action: 'cuelist_bank_create',
+        request,
+        osc: {
+          address,
+          args: [] as const
         }
-      ]
+      }
     } as ToolExecutionResult;
 
     return result;

--- a/src/tools/cues/cuelist_bank_page.ts
+++ b/src/tools/cues/cuelist_bank_page.ts
@@ -48,20 +48,15 @@ export const eosCuelistBankPageTool: ToolDefinition<typeof bankPageInputSchema> 
     };
 
     const result: ToolExecutionResult = {
-      content: [
-        { type: 'text', text },
-        {
-          type: 'object',
-          data: {
-            action: 'cuelist_bank_page',
-            request,
-            osc: {
-              address,
-              args: [] as const
-            }
-          }
+      content: [{ type: 'text', text }],
+      structuredContent: {
+        action: 'cuelist_bank_page',
+        request,
+        osc: {
+          address,
+          args: [] as const
         }
-      ]
+      }
     } as ToolExecutionResult;
 
     return result;

--- a/src/tools/cues/cuelist_get_info.ts
+++ b/src/tools/cues/cuelist_get_info.ts
@@ -83,22 +83,17 @@ export const eosCuelistGetInfoTool: ToolDefinition<typeof cuelistInfoInputSchema
         const text = `${listLabel}: ${info.label ?? 'sans label'}`;
 
         const result: ToolExecutionResult = {
-          content: [
-            { type: 'text', text },
-            {
-              type: 'object',
-              data: {
-                action: 'cuelist_get_info',
-                status: response.status,
-                request: payload,
-                cuelist: info,
-                osc: {
-                  address: oscMappings.cues.cuelistInfo,
-                  response: response.payload
-                }
-              }
+          content: [{ type: 'text', text }],
+          structuredContent: {
+            action: 'cuelist_get_info',
+            status: response.status,
+            request: payload,
+            cuelist: info,
+            osc: {
+              address: oscMappings.cues.cuelistInfo,
+              response: response.payload
             }
-          ]
+          }
         } as ToolExecutionResult;
 
         return result;

--- a/src/tools/cues/get_active_cue.ts
+++ b/src/tools/cues/get_active_cue.ts
@@ -64,22 +64,17 @@ export const eosGetActiveCueTool: ToolDefinition<typeof getActiveCueInputSchema>
     const text = formatActiveText(state.details.identifier, state.progressPercent);
 
     const result: ToolExecutionResult = {
-      content: [
-        { type: 'text', text },
-        {
-          type: 'object',
-          data: {
-            action: 'get_active_cue',
-            status: response.status,
-            request: payload,
-            cue: state,
-            osc: {
-              address: oscMappings.cues.active,
-              response: response.payload
-            }
-          }
+      content: [{ type: 'text', text }],
+      structuredContent: {
+        action: 'get_active_cue',
+        status: response.status,
+        request: payload,
+        cue: state,
+        osc: {
+          address: oscMappings.cues.active,
+          response: response.payload
         }
-      ]
+      }
     } as ToolExecutionResult;
 
     return result;

--- a/src/tools/cues/get_info.ts
+++ b/src/tools/cues/get_info.ts
@@ -100,22 +100,17 @@ export const eosCueGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
         const text = formatCueInfoText(details);
 
         const result: ToolExecutionResult = {
-          content: [
-            { type: 'text', text },
-            {
-              type: 'object',
-              data: {
-                action: 'cue_get_info',
-                status: response.status,
-                request: payload,
-                cue: details,
-                osc: {
-                  address: oscMappings.cues.info,
-                  response: response.payload
-                }
-              }
+          content: [{ type: 'text', text }],
+          structuredContent: {
+            action: 'cue_get_info',
+            status: response.status,
+            request: payload,
+            cue: details,
+            osc: {
+              address: oscMappings.cues.info,
+              response: response.payload
             }
-          ]
+          }
         } as ToolExecutionResult;
 
         return result;

--- a/src/tools/cues/get_pending_cue.ts
+++ b/src/tools/cues/get_pending_cue.ts
@@ -58,22 +58,17 @@ export const eosGetPendingCueTool: ToolDefinition<typeof getPendingCueInputSchem
     const text = `Cue en attente ${formatCueDescription(state.details.identifier)} (${state.details.label ?? 'sans label'})`;
 
     const result: ToolExecutionResult = {
-      content: [
-        { type: 'text', text },
-        {
-          type: 'object',
-          data: {
-            action: 'get_pending_cue',
-            status: response.status,
-            request: payload,
-            cue: state,
-            osc: {
-              address: oscMappings.cues.pending,
-              response: response.payload
-            }
-          }
+      content: [{ type: 'text', text }],
+      structuredContent: {
+        action: 'get_pending_cue',
+        status: response.status,
+        request: payload,
+        cue: state,
+        osc: {
+          address: oscMappings.cues.pending,
+          response: response.payload
         }
-      ]
+      }
     } as ToolExecutionResult;
 
     return result;

--- a/src/tools/cues/list_all.ts
+++ b/src/tools/cues/list_all.ts
@@ -83,22 +83,17 @@ export const eosCueListAllTool: ToolDefinition<typeof listAllInputSchema> = {
         const text = `${listLabel}: ${cues.length} cue(s).`;
 
         const result: ToolExecutionResult = {
-          content: [
-            { type: 'text', text },
-            {
-              type: 'object',
-              data: {
-                action: 'cue_list_all',
-                status: response.status,
-                request: payload,
-                cues,
-                osc: {
-                  address: oscMappings.cues.list,
-                  response: response.payload
-                }
-              }
+          content: [{ type: 'text', text }],
+          structuredContent: {
+            action: 'cue_list_all',
+            status: response.status,
+            request: payload,
+            cues,
+            osc: {
+              address: oscMappings.cues.list,
+              response: response.payload
             }
-          ]
+          }
         } as ToolExecutionResult;
 
         return result;

--- a/src/tools/curves/__tests__/curves.test.ts
+++ b/src/tools/curves/__tests__/curves.test.ts
@@ -2,7 +2,7 @@ import type { OscMessage } from '../../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosCurveGetInfoTool, eosCurveSelectTool } from '../index';
-import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -88,12 +88,12 @@ describe('curve tools', () => {
     }
     expect(textContent.text).toBe('Courbe 8 "Custom Fade" (Time) - 3 points.');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'ok',
       error: null,
       curve: {
@@ -140,12 +140,12 @@ describe('curve tools', () => {
     }
     expect(textContent.text).toBe('Courbe 42 introuvable.');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'error',
       error: 'Curve not found',
       curve: {

--- a/src/tools/curves/index.ts
+++ b/src/tools/curves/index.ts
@@ -71,21 +71,16 @@ function createSelectResult(
   oscAddress: string
 ): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text: `Courbe ${curveNumber} selectionnee.` },
-      {
-        type: 'object',
-        data: {
-          action: 'curve_select',
-          curve_number: curveNumber,
-          request: payload,
-          osc: {
-            address: oscAddress,
-            args: payload
-          }
-        }
+    content: [{ type: 'text', text: `Courbe ${curveNumber} selectionnee.` }],
+    structuredContent: {
+      action: 'curve_select',
+      curve_number: curveNumber,
+      request: payload,
+      osc: {
+        address: oscAddress,
+        args: payload
       }
-    ]
+    }
   } as ToolExecutionResult;
 }
 
@@ -330,23 +325,18 @@ function buildCurveInfoResult(
   }
 
   return {
-    content: [
-      { type: 'text', text },
-      {
-        type: 'object',
-        data: {
-          action: 'curve_get_info',
-          status: response.status,
-          request: payload,
-          curve: details,
-          error: meaningfulMessage,
-          osc: {
-            address: oscMappings.curves.info,
-            response: response.payload
-          }
-        }
+    content: [{ type: 'text', text }],
+    structuredContent: {
+      action: 'curve_get_info',
+      status: response.status,
+      request: payload,
+      curve: details,
+      error: meaningfulMessage,
+      osc: {
+        address: oscMappings.curves.info,
+        response: response.payload
       }
-    ]
+    }
   } as ToolExecutionResult;
 }
 

--- a/src/tools/diagnostics/index.ts
+++ b/src/tools/diagnostics/index.ts
@@ -101,12 +101,9 @@ export const eosEnableLoggingTool: ToolDefinition<typeof loggingInputSchema> = {
         {
           type: 'text',
           text: summary
-        },
-        {
-          type: 'object',
-          data: { logging: state }
         }
-      ]
+      ],
+      structuredContent: { logging: state }
     };
   }
 };
@@ -139,12 +136,9 @@ export const eosGetDiagnosticsTool: ToolDefinition<typeof emptyInputSchema> = {
         {
           type: 'text',
           text: summary
-        },
-        {
-          type: 'object',
-          data: diagnostics
         }
-      ]
+      ],
+      structuredContent: diagnostics
     };
   }
 };

--- a/src/tools/directSelects/__tests__/directSelects.test.ts
+++ b/src/tools/directSelects/__tests__/directSelects.test.ts
@@ -7,7 +7,7 @@ import {
   eosDirectSelectPageTool,
   eosDirectSelectPressTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 function formatPattern(pattern: string, values: Record<string, string | number>): string {
   return pattern.replace(/\{(\w+)\}/g, (match, key) => {
@@ -109,12 +109,12 @@ describe('direct select tools', () => {
     );
     expect(forwardMessage.args ?? []).toEqual([]);
 
-    const forwardData = nextPageResult.content.find(isObjectContent);
+    const forwardData = getStructuredContent(nextPageResult);
     expect(forwardData).toBeDefined();
     if (!forwardData) {
-      throw new Error('Expected object content');
+      throw new Error('Expected structured content');
     }
-    expect(forwardData.data).toMatchObject({ previousPage: 1, page: 3 });
+    expect(forwardData).toMatchObject({ previousPage: 1, page: 3 });
 
     service.sentMessages.length = 0;
 
@@ -129,12 +129,12 @@ describe('direct select tools', () => {
     );
     expect(backMessage.args ?? []).toEqual([]);
 
-    const backData = backResult.content.find(isObjectContent);
+    const backData = getStructuredContent(backResult);
     expect(backData).toBeDefined();
     if (!backData) {
-      throw new Error('Expected object content');
+      throw new Error('Expected structured content');
     }
-    expect(backData.data).toMatchObject({ previousPage: 3, page: 0 });
+    expect(backData).toMatchObject({ previousPage: 3, page: 0 });
 
     service.sentMessages.length = 0;
 

--- a/src/tools/directSelects/index.ts
+++ b/src/tools/directSelects/index.ts
@@ -104,12 +104,10 @@ function extractTargetOptions(options: DirectSelectTargetOptions): DirectSelectT
   return target;
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/dmx/__tests__/dmx.test.ts
+++ b/src/tools/dmx/__tests__/dmx.test.ts
@@ -6,7 +6,7 @@ import {
   eosAddressSetLevelTool,
   eosAddressSetDmxTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -65,12 +65,12 @@ describe('dmx address tools', () => {
     const payload = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
     expect(payload).toEqual({ address: '2/041' });
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data.status).toBe('ok');
+    expect(structuredContent.status).toBe('ok');
   });
 
   it('convertit full en 100% pour le niveau', async () => {

--- a/src/tools/dmx/index.ts
+++ b/src/tools/dmx/index.ts
@@ -39,12 +39,10 @@ function extractTargetOptions(options: { targetAddress?: string; targetPort?: nu
   return target;
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/effects/__tests__/effects.test.ts
+++ b/src/tools/effects/__tests__/effects.test.ts
@@ -7,7 +7,7 @@ import {
   eosEffectSelectTool,
   eosEffectStopTool
 } from '../index';
-import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -112,13 +112,13 @@ describe('effect tools', () => {
     }
     expect(textContent.text).toBe('Effet 907 "Dyn Circle" (Relative Dynamic, rate 120, scale 150%).');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'effect_get_info',
       status: 'ok',
       request: { effect: 907 },
@@ -186,12 +186,12 @@ describe('effect tools', () => {
     }
     expect(textContent.text).toBe('Effet 99 introuvable (Effect not found).');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'effect_get_info',
       status: 'error',
       error: 'Effect not found',

--- a/src/tools/effects/index.ts
+++ b/src/tools/effects/index.ts
@@ -143,21 +143,16 @@ function createSimpleResult(
   oscAddress: string
 ): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      {
-        type: 'object',
-        data: {
-          action,
-          effect_number: effectNumber,
-          request: payload,
-          osc: {
-            address: oscAddress,
-            args: payload
-          }
-        }
+    content: [{ type: 'text', text }],
+    structuredContent: {
+      action,
+      effect_number: effectNumber,
+      request: payload,
+      osc: {
+        address: oscAddress,
+        args: payload
       }
-    ]
+    }
   } as ToolExecutionResult;
 }
 
@@ -507,23 +502,18 @@ function buildEffectInfoResult(
   const text = formatEffectInfoText(details, response.status, errorMessage);
 
   return {
-    content: [
-      { type: 'text', text },
-      {
-        type: 'object',
-        data: {
-          action: 'effect_get_info',
-          status: response.status,
-          request: payload,
-          effect: details,
-          error: errorMessage,
-          osc: {
-            address: oscMappings.effects.info,
-            response: response.payload
-          }
-        }
+    content: [{ type: 'text', text }],
+    structuredContent: {
+      action: 'effect_get_info',
+      status: response.status,
+      request: payload,
+      effect: details,
+      error: errorMessage,
+      osc: {
+        address: oscMappings.effects.info,
+        response: response.payload
       }
-    ]
+    }
   } as ToolExecutionResult;
 }
 

--- a/src/tools/faders/__tests__/faders.test.ts
+++ b/src/tools/faders/__tests__/faders.test.ts
@@ -9,7 +9,7 @@ import {
   eosFaderUnloadTool,
   eosFaderPageTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -69,12 +69,12 @@ describe('fader tools', () => {
     await runTool(eosFaderPageTool, { bank_index: 3, delta: 1 });
 
     const pageResult = await runTool(eosFaderPageTool, { bank_index: 3, delta: -2 });
-    const pageData = pageResult.content.find(isObjectContent);
+    const pageData = getStructuredContent(pageResult);
     expect(pageData).toBeDefined();
     if (!pageData) {
-      throw new Error('Expected object content');
+      throw new Error('Expected structured content');
     }
-    expect(pageData.data).toMatchObject({ page: 1 });
+    expect(pageData).toMatchObject({ page: 1 });
 
     service.sentMessages.length = 0;
 
@@ -97,11 +97,11 @@ describe('fader tools', () => {
     expect(message.address).toBe(`${oscMappings.faders.base}/7/page/1`);
     expect(message.args).toBeUndefined();
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({ previousPage: 0, page: 1 });
+    expect(structuredContent).toMatchObject({ previousPage: 0, page: 1 });
   });
 });

--- a/src/tools/faders/index.ts
+++ b/src/tools/faders/index.ts
@@ -106,12 +106,10 @@ function buildFloatArgs(value: number): OscMessageArgument[] {
   ];
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/fpe/__tests__/fpe.test.ts
+++ b/src/tools/fpe/__tests__/fpe.test.ts
@@ -6,7 +6,7 @@ import {
   eosFpeGetSetInfoTool,
   eosFpeGetPointInfoTool
 } from '../index';
-import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -70,10 +70,10 @@ describe('fpe tools', () => {
 
     const result = await promise;
     const textContent = result.content.find(isTextContent);
-    const objectContent = result.content.find(isObjectContent);
+    const structuredContent = getStructuredContent(result);
 
     expect(textContent?.text).toBe('Nombre de sets FPE: 5.');
-    expect(objectContent?.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'get_set_count',
       set_count: 5,
       status: 'ok'
@@ -119,10 +119,10 @@ describe('fpe tools', () => {
 
     const result = await promise;
     const textContent = result.content.find(isTextContent);
-    const objectContent = result.content.find(isObjectContent);
+    const structuredContent = getStructuredContent(result);
 
     expect(textContent?.text).toBe('Set FPE 3 "Main Stage" - 2 points.');
-    expect(objectContent?.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'get_set_info',
       status: 'ok',
       set_number: 3,
@@ -195,12 +195,12 @@ describe('fpe tools', () => {
 
     const result = await promise;
     const textContent = result.content.find(isTextContent);
-    const objectContent = result.content.find(isObjectContent);
+    const structuredContent = getStructuredContent(result);
 
     expect(textContent?.text).toBe(
       'Point FPE 4.2 "Right Balcony" - Palette focus 202 - Position (4.5, 6.1, 0).'
     );
-    expect(objectContent?.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'get_point_info',
       status: 'ok',
       set_number: 4,
@@ -237,10 +237,10 @@ describe('fpe tools', () => {
 
     const result = await promise;
     const textContent = result.content.find(isTextContent);
-    const objectContent = result.content.find(isObjectContent);
+    const structuredContent = getStructuredContent(result);
 
     expect(textContent?.text).toBe('Set FPE 12 introuvable.');
-    expect(objectContent?.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'error',
       set_number: 12,
       error: 'Set not found'

--- a/src/tools/fpe/index.ts
+++ b/src/tools/fpe/index.ts
@@ -508,23 +508,18 @@ function buildSetCountResult(
     : `Nombre de sets FPE: ${setCount}.`;
 
   return {
-    content: [
-      { type: 'text', text: message },
-      {
-        type: 'object',
-        data: {
-          action: 'get_set_count',
-          status: response.status,
-          set_count: setCount,
-          data: response.data,
-          error: response.error ?? null,
-          osc: {
-            address: oscAddress,
-            args: payload
-          }
-        }
+    content: [{ type: 'text', text: message }],
+    structuredContent: {
+      action: 'get_set_count',
+      status: response.status,
+      set_count: setCount,
+      data: response.data,
+      error: response.error ?? null,
+      osc: {
+        address: oscAddress,
+        args: payload
       }
-    ]
+    }
   } as ToolExecutionResult;
 }
 
@@ -555,24 +550,19 @@ function buildSetInfoResult(
   }
 
   return {
-    content: [
-      { type: 'text', text },
-      {
-        type: 'object',
-        data: {
-          action: 'get_set_info',
-          status: response.status,
-          set_number: setNumber,
-          set: details,
-          data: response.data,
-          error: rawMessage,
-          osc: {
-            address: oscAddress,
-            args: payload
-          }
-        }
+    content: [{ type: 'text', text }],
+    structuredContent: {
+      action: 'get_set_info',
+      status: response.status,
+      set_number: setNumber,
+      set: details,
+      data: response.data,
+      error: rawMessage,
+      osc: {
+        address: oscAddress,
+        args: payload
       }
-    ]
+    }
   } as ToolExecutionResult;
 }
 
@@ -624,26 +614,21 @@ function buildPointInfoResult(
   }
 
   return {
-    content: [
-      { type: 'text', text },
-      {
-        type: 'object',
-        data: {
-          action: 'get_point_info',
-          status: response.status,
-          set_number: setNumber,
-          point_number: pointNumber,
-          point: pointInfo,
-          set: setInfo,
-          data: response.data,
-          error: rawMessage,
-          osc: {
-            address: oscAddress,
-            args: payload
-          }
-        }
+    content: [{ type: 'text', text }],
+    structuredContent: {
+      action: 'get_point_info',
+      status: response.status,
+      set_number: setNumber,
+      point_number: pointNumber,
+      point: pointInfo,
+      set: setInfo,
+      data: response.data,
+      error: rawMessage,
+      osc: {
+        address: oscAddress,
+        args: payload
       }
-    ]
+    }
   } as ToolExecutionResult;
 }
 

--- a/src/tools/groups/__tests__/groups.test.ts
+++ b/src/tools/groups/__tests__/groups.test.ts
@@ -8,7 +8,7 @@ import {
   eosGroupGetInfoTool,
   eosGroupListAllTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -92,13 +92,13 @@ describe('group tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'get_info',
       status: 'ok',
       group: {
@@ -143,13 +143,13 @@ describe('group tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'list_all',
       status: 'ok',
       groups: [

--- a/src/tools/groups/index.ts
+++ b/src/tools/groups/index.ts
@@ -59,12 +59,10 @@ function annotate(osc: string): Record<string, unknown> {
   };
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/keys/__tests__/keys.test.ts
+++ b/src/tools/keys/__tests__/keys.test.ts
@@ -5,7 +5,7 @@ import {
   eosKeyPressTool,
   eosSoftkeyPressTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 describe('key tools', () => {
   class FakeOscService implements OscGateway {
@@ -98,13 +98,13 @@ describe('key tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
+    const structuredContent = getStructuredContent(result);
 
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'get_softkey_labels',
       status: 'ok',
       labels: {

--- a/src/tools/keys/index.ts
+++ b/src/tools/keys/index.ts
@@ -59,12 +59,10 @@ function normaliseButtonState(value: ButtonStateInput): 0 | 1 {
   return 1;
 }
 
-function buildResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function buildResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/macros/__tests__/macros.test.ts
+++ b/src/tools/macros/__tests__/macros.test.ts
@@ -6,7 +6,7 @@ import {
   eosMacroGetInfoTool,
   eosMacroSelectTool
 } from '../index';
-import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -97,13 +97,13 @@ describe('macro tools', () => {
     }
     expect(textContent.text).toBe('Macro 12 "Blackout" (3 commandes).');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'ok',
       error: null,
       macro: {
@@ -148,12 +148,12 @@ describe('macro tools', () => {
     }
     expect(textContent.text).toBe('Macro 99 introuvable.');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'error',
       error: 'Macro not found',
       macro: {

--- a/src/tools/macros/index.ts
+++ b/src/tools/macros/index.ts
@@ -75,21 +75,16 @@ function createSimpleResult(
   oscArgs: OscMessageArgument[]
 ): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      {
-        type: 'object',
-        data: {
-          action,
-          macro_number: macroNumber,
-          request: payload,
-          osc: {
-            address: oscAddress,
-            args: oscArgs
-          }
-        }
+    content: [{ type: 'text', text }],
+    structuredContent: {
+      action,
+      macro_number: macroNumber,
+      request: payload,
+      osc: {
+        address: oscAddress,
+        args: oscArgs
       }
-    ]
+    }
   } as ToolExecutionResult;
 }
 
@@ -311,23 +306,18 @@ function buildMacroInfoResult(
   }
 
   return {
-    content: [
-      { type: 'text', text },
-      {
-        type: 'object',
-        data: {
-          action: 'macro_get_info',
-          status: response.status,
-          request: payload,
-          macro: details,
-          error: meaningfulMessage,
-          osc: {
-            address: oscMappings.macros.info,
-            response: response.payload
-          }
-        }
+    content: [{ type: 'text', text }],
+    structuredContent: {
+      action: 'macro_get_info',
+      status: response.status,
+      request: payload,
+      macro: details,
+      error: meaningfulMessage,
+      osc: {
+        address: oscMappings.macros.info,
+        response: response.payload
       }
-    ]
+    }
   } as ToolExecutionResult;
 }
 

--- a/src/tools/magicSheets/__tests__/magicSheets.test.ts
+++ b/src/tools/magicSheets/__tests__/magicSheets.test.ts
@@ -6,7 +6,7 @@ import {
   eosMagicSheetOpenTool,
   eosMagicSheetSendStringTool
 } from '../index';
-import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -86,12 +86,12 @@ describe('magic sheet tools', () => {
     }
     expect(textContent.text).toContain('connexion Primary');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'magic_sheet_send_string',
       required_role: 'Primary',
       provided_role: 'Secondary'
@@ -123,13 +123,13 @@ describe('magic sheet tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'ok',
       magic_sheet: {
         ms_number: 7,
@@ -167,12 +167,12 @@ describe('magic sheet tools', () => {
     }
     expect(textContent.text).toContain('introuvable');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'error',
       magic_sheet: {
         ms_number: 42

--- a/src/tools/magicSheets/index.ts
+++ b/src/tools/magicSheets/index.ts
@@ -80,12 +80,10 @@ function extractTargetOptions(options: { targetAddress?: string; targetPort?: nu
   return target;
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/palettes/__tests__/palettes.test.ts
+++ b/src/tools/palettes/__tests__/palettes.test.ts
@@ -8,7 +8,7 @@ import {
   eosIntensityPaletteFireTool,
   eosPaletteGetInfoTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 function assertHasPalette(
   data: Record<string, unknown>
@@ -102,14 +102,14 @@ describe('palette tools', () => {
 
     const result = await promise;
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    assertHasPalette(objectContent.data);
-    const paletteInfo = objectContent.data.palette as Record<string, unknown> & {
+    assertHasPalette(structuredContent);
+    const paletteInfo = structuredContent.palette as Record<string, unknown> & {
       paletteType: string;
       paletteNumber: number;
       label: string | null;

--- a/src/tools/palettes/index.ts
+++ b/src/tools/palettes/index.ts
@@ -87,12 +87,10 @@ function annotate(osc: string): Record<string, unknown> {
   };
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 
@@ -510,22 +508,17 @@ export const eosPaletteGetInfoTool: ToolDefinition<typeof paletteGetInfoInputSch
         const text = formatPaletteDescription(info);
 
         const result: ToolExecutionResult = {
-          content: [
-            { type: 'text', text },
-            {
-              type: 'object',
-              data: {
-                action: 'palette_get_info',
-                status: response.status,
-                request: payload,
-                palette: info,
-                osc: {
-                  address: mapping,
-                  response: response.payload
-                }
-              }
+          content: [{ type: 'text', text }],
+          structuredContent: {
+            action: 'palette_get_info',
+            status: response.status,
+            request: payload,
+            palette: info,
+            osc: {
+              address: mapping,
+              response: response.payload
             }
-          ]
+          }
         } as ToolExecutionResult;
 
         return result;

--- a/src/tools/parameters/__tests__/parameters.test.ts
+++ b/src/tools/parameters/__tests__/parameters.test.ts
@@ -10,7 +10,7 @@ import {
   eosWheelSwitchContinuousTool,
   eosWheelTickTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 function assertHasWheelData(
   data: Record<string, unknown>
@@ -157,15 +157,15 @@ describe('parameter tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    assertHasWheelData(objectContent.data);
-    expect(objectContent.data.status).toBe('ok');
-    expect(objectContent.data.wheels).toEqual([
+    assertHasWheelData(structuredContent);
+    expect(structuredContent.status).toBe('ok');
+    expect(structuredContent.wheels).toEqual([
       {
         wheelIndex: 1,
         parameter: 'Pan',

--- a/src/tools/parameters/index.ts
+++ b/src/tools/parameters/index.ts
@@ -154,12 +154,10 @@ function normaliseCoordinate(value: unknown, label: string): number {
   return roundTo(numeric.value, 3);
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/patch/__tests__/patch.test.ts
+++ b/src/tools/patch/__tests__/patch.test.ts
@@ -7,7 +7,7 @@ import {
   eosPatchGetChannelInfoTool
 } from '../index';
 import type { ToolExecutionResult } from '../../types';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -30,9 +30,8 @@ class FakeOscService implements OscGateway {
   }
 }
 
-function extractObjectContent(result: ToolExecutionResult): Record<string, unknown> | null {
-  const objectContent = result.content.find(isObjectContent);
-  return objectContent?.data ?? null;
+function extractStructuredContent(result: ToolExecutionResult): Record<string, unknown> | null {
+  return getStructuredContent(result) ?? null;
 }
 
 describe('patch tools', () => {
@@ -121,9 +120,9 @@ describe('patch tools', () => {
     });
 
     const result = await promise;
-    const objectContent = extractObjectContent(result);
+    const structuredContent = extractStructuredContent(result);
 
-    expect(objectContent).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'ok',
       channel: {
         channel_number: 205,
@@ -188,9 +187,9 @@ describe('patch tools', () => {
     });
 
     const result = await promise;
-    const objectContent = extractObjectContent(result);
+    const structuredContent = extractStructuredContent(result);
 
-    expect(objectContent).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'ok',
       augment3d: {
         channel_number: 12,
@@ -237,9 +236,9 @@ describe('patch tools', () => {
     });
 
     const result = await promise;
-    const objectContent = extractObjectContent(result);
+    const structuredContent = extractStructuredContent(result);
 
-    expect(objectContent).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'ok',
       augment3d: {
         channel_number: 12,

--- a/src/tools/patch/index.ts
+++ b/src/tools/patch/index.ts
@@ -174,12 +174,10 @@ function annotate(osc: string): Record<string, unknown> {
   };
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/pixelMaps/__tests__/pixelMaps.test.ts
+++ b/src/tools/pixelMaps/__tests__/pixelMaps.test.ts
@@ -3,7 +3,7 @@ import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } 
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosPixmapGetInfoTool, eosPixmapSelectTool } from '../index';
 import largePixmapFixture from './fixtures/pixmap-large.json';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -90,13 +90,13 @@ describe('pixel map tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'ok',
       pixmap: {
         pixmap_number: 7,
@@ -138,13 +138,13 @@ describe('pixel map tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'ok',
       pixmap: {
         pixmap_number: 205,

--- a/src/tools/pixelMaps/index.ts
+++ b/src/tools/pixelMaps/index.ts
@@ -118,12 +118,10 @@ function annotate(osc: string): Record<string, unknown> {
   };
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/presets/__tests__/presets.test.ts
+++ b/src/tools/presets/__tests__/presets.test.ts
@@ -6,7 +6,7 @@ import {
   eosPresetSelectTool,
   eosPresetGetInfoTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -153,13 +153,13 @@ describe('preset tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    const data = objectContent.data;
+    const data = structuredContent;
     assertHasPresetDetails(data);
 
     expect(data).toMatchObject({

--- a/src/tools/presets/index.ts
+++ b/src/tools/presets/index.ts
@@ -125,12 +125,10 @@ function annotate(osc: string): Record<string, unknown> {
   };
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 
@@ -595,22 +593,17 @@ export const eosPresetGetInfoTool: ToolDefinition<typeof presetGetInfoInputSchem
         const text = formatPresetDescription(info);
 
         const result: ToolExecutionResult = {
-          content: [
-            { type: 'text', text },
-            {
-              type: 'object',
-              data: {
-                action: 'preset_get_info',
-                status: response.status,
-                request: payload,
-                preset: info,
-                osc: {
-                  address: oscMappings.presets.info,
-                  response: response.payload
-                }
-              }
+          content: [{ type: 'text', text }],
+          structuredContent: {
+            action: 'preset_get_info',
+            status: response.status,
+            request: payload,
+            preset: info,
+            osc: {
+              address: oscMappings.presets.info,
+              response: response.payload
             }
-          ]
+          }
         } as ToolExecutionResult;
 
         return result;

--- a/src/tools/queries/__tests__/queries.test.ts
+++ b/src/tools/queries/__tests__/queries.test.ts
@@ -2,7 +2,7 @@ import type { OscMessage } from '../../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosGetCountTool, eosGetListAllTool } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -57,12 +57,12 @@ describe('query tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'get_count',
       status: 'ok',
       target_type: 'fx',
@@ -94,13 +94,13 @@ describe('query tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'list_all',
       status: 'ok',
       target_type: 'cue',
@@ -133,13 +133,13 @@ describe('query tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'list_all',
       status: 'ok',
       target_type: 'macro',
@@ -172,13 +172,13 @@ describe('query tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       target_type: 'ms',
       items: [
         { number: '1', uid: 'ms:1', label: 'Layout' },

--- a/src/tools/queries/index.ts
+++ b/src/tools/queries/index.ts
@@ -349,12 +349,10 @@ function annotate(mode: 'count' | 'list'): Record<string, unknown> {
   };
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/session/__tests__/session.test.ts
+++ b/src/tools/session/__tests__/session.test.ts
@@ -4,7 +4,7 @@ import {
   sessionGetCurrentUserTool,
   sessionSetCurrentUserTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 describe('session tools', () => {
   beforeEach(() => {
@@ -15,23 +15,23 @@ describe('session tools', () => {
     const result = await runTool(sessionSetCurrentUserTool, { user: 7 });
 
     expect(getCurrentUserId()).toBe(7);
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toEqual({ user: 7 });
+    expect(structuredContent).toEqual({ user: 7 });
   });
 
   it('renvoie null lorsqu aucun utilisateur nest defini', async () => {
     const result = await runTool(sessionGetCurrentUserTool, undefined);
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toEqual({ user: null });
+    expect(structuredContent).toEqual({ user: null });
   });
 
   it('renvoie l utilisateur courant memorise', async () => {
@@ -39,11 +39,11 @@ describe('session tools', () => {
     await runTool(sessionSetCurrentUserTool, { user: 3 });
 
     const result = await runTool(sessionGetCurrentUserTool, undefined);
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toEqual({ user: 3 });
+    expect(structuredContent).toEqual({ user: 3 });
   });
 });

--- a/src/tools/session/index.ts
+++ b/src/tools/session/index.ts
@@ -51,14 +51,11 @@ export const sessionSetCurrentUserTool: ToolDefinition<typeof setCurrentUserInpu
         {
           type: 'text',
           text: `Utilisateur courant defini sur ${options.user}`
-        },
-        {
-          type: 'object',
-          data: {
-            user: options.user
-          }
         }
-      ]
+      ],
+      structuredContent: {
+        user: options.user
+      }
     } as ToolExecutionResult;
   }
 };
@@ -86,14 +83,11 @@ export const sessionGetCurrentUserTool: ToolDefinition = {
         {
           type: 'text',
           text: typeof user === 'number' ? `Utilisateur courant: ${user}` : 'Aucun utilisateur courant defini'
-        },
-        {
-          type: 'object',
-          data: {
-            user: user ?? null
-          }
         }
-      ]
+      ],
+      structuredContent: {
+        user: user ?? null
+      }
     } as ToolExecutionResult;
   }
 };

--- a/src/tools/showControl/__tests__/showControl.test.ts
+++ b/src/tools/showControl/__tests__/showControl.test.ts
@@ -8,7 +8,7 @@ import {
   eosSetCueSendStringTool,
   eosSetCueReceiveStringTool
 } from '../index';
-import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -71,12 +71,12 @@ describe('show control tools', () => {
     }
     expect(textContent.text).toContain('Festival 2024');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data.show_name).toBe('Festival 2024');
+    expect(structuredContent.show_name).toBe('Festival 2024');
   });
 
   it('normalise et valide le mode Live/Blind', async () => {
@@ -102,12 +102,12 @@ describe('show control tools', () => {
     }
     expect(textContent.text).toContain('Blind');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data.state).toEqual({ numeric: 0, label: 'Blind' });
+    expect(structuredContent.state).toEqual({ numeric: 0, label: 'Blind' });
   });
 
   it('renvoie une erreur lisible quand le mode Live/Blind est invalide', async () => {
@@ -126,12 +126,12 @@ describe('show control tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data.error).toContain('Etat Live/Blind invalide');
+    expect(structuredContent.error).toContain('Etat Live/Blind invalide');
   });
 
   it('bascule le mode staging et retourne un accusé', async () => {
@@ -179,12 +179,12 @@ describe('show control tools', () => {
     const payload = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
     expect(payload).toEqual({ format: 'Cue %1 -> %2 (%3)' });
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data.format).toBe('Cue %1 -> %2 (%3)');
+    expect(structuredContent.format).toBe('Cue %1 -> %2 (%3)');
   });
 
   it('refuse les placeholders invalides pour le format d\'envoi', async () => {

--- a/src/tools/showControl/index.ts
+++ b/src/tools/showControl/index.ts
@@ -30,12 +30,10 @@ function extractTargetOptions(options: { targetAddress?: string; targetPort?: nu
   return target;
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/snapshots/__tests__/snapshots.test.ts
+++ b/src/tools/snapshots/__tests__/snapshots.test.ts
@@ -2,7 +2,7 @@ import type { OscMessage } from '../../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
 import { eosSnapshotGetInfoTool, eosSnapshotRecallTool } from '../index';
-import { isObjectContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, isTextContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -97,12 +97,12 @@ describe('snapshot tools', () => {
     }
     expect(textContent.text).toBe('Snapshot 12 "Ballet Acte II" (UID 1.2.3.4.5).');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'ok',
       snapshot: {
         snapshot_number: 12,
@@ -140,12 +140,12 @@ describe('snapshot tools', () => {
     }
     expect(textContent.text).toBe('Snapshot 99 introuvable.');
 
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       status: 'error',
       error: 'Snapshot missing',
       snapshot: {

--- a/src/tools/snapshots/index.ts
+++ b/src/tools/snapshots/index.ts
@@ -77,21 +77,16 @@ function createRecallResult(
   oscAddress: string
 ): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text: `Snapshot ${snapshotNumber} rappelle.` },
-      {
-        type: 'object',
-        data: {
-          action: 'snapshot_recall',
-          snapshot_number: snapshotNumber,
-          request: payload,
-          osc: {
-            address: oscAddress,
-            args: payload
-          }
-        }
+    content: [{ type: 'text', text: `Snapshot ${snapshotNumber} rappelle.` }],
+    structuredContent: {
+      action: 'snapshot_recall',
+      snapshot_number: snapshotNumber,
+      request: payload,
+      osc: {
+        address: oscAddress,
+        args: payload
       }
-    ]
+    }
   } as ToolExecutionResult;
 }
 
@@ -266,23 +261,18 @@ function buildSnapshotInfoResult(
   }
 
   return {
-    content: [
-      { type: 'text', text },
-      {
-        type: 'object',
-        data: {
-          action: 'snapshot_get_info',
-          status: response.status,
-          request: payload,
-          snapshot: details,
-          error: errorMessage,
-          osc: {
-            address: oscMappings.snapshots.info,
-            response: response.payload
-          }
-        }
+    content: [{ type: 'text', text }],
+    structuredContent: {
+      action: 'snapshot_get_info',
+      status: response.status,
+      request: payload,
+      snapshot: details,
+      error: errorMessage,
+      osc: {
+        address: oscMappings.snapshots.info,
+        response: response.payload
       }
-    ]
+    }
   } as ToolExecutionResult;
 }
 

--- a/src/tools/submasters/__tests__/submasters.test.ts
+++ b/src/tools/submasters/__tests__/submasters.test.ts
@@ -6,7 +6,7 @@ import {
   eosSubmasterBumpTool,
   eosSubmasterGetInfoTool
 } from '../index';
-import { isObjectContent, runTool } from '../../__tests__/helpers/runTool';
+import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -100,13 +100,13 @@ describe('submaster tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       action: 'submaster_get_info',
       status: 'ok',
       submaster: {
@@ -157,13 +157,13 @@ describe('submaster tools', () => {
     });
 
     const result = await promise;
-    const objectContent = result.content.find(isObjectContent);
-    expect(objectContent).toBeDefined();
-    if (!objectContent) {
-      throw new Error('Expected object content');
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
     }
 
-    expect(objectContent.data).toMatchObject({
+    expect(structuredContent).toMatchObject({
       submaster: {
         submasterNumber: 4,
         label: 'Side Light',

--- a/src/tools/submasters/index.ts
+++ b/src/tools/submasters/index.ts
@@ -91,12 +91,10 @@ function annotate(osc: string): Record<string, unknown> {
   };
 }
 
-function createResult(text: string, data: Record<string, unknown>): ToolExecutionResult {
+function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return {
-    content: [
-      { type: 'text', text },
-      { type: 'object', data }
-    ]
+    content: [{ type: 'text', text }],
+    structuredContent
   } as ToolExecutionResult;
 }
 

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -7,6 +7,7 @@ export interface ToolResultContent {
 
 export interface ToolExecutionResult {
   content: ToolResultContent[];
+  structuredContent?: Record<string, unknown>;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- move tool helper results to use a structuredContent payload alongside text summaries
- update all affected tool handlers and connection utilities to populate structuredContent
- refresh unit tests to assert against structuredContent and align bootstrap handshake expectations with configured ports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd8065c180832a9abd778d2a55d572