### PR TITLE
Refactor HTTP gateway to JSON-RPC MCP transport

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,8 +16,7 @@
             "manifest": "/manifest.json",
             "health": "/health",
             "tools": "/tools",
-            "invoke": "/tools/{toolName}",
-            "websocket": "/ws"
+            "mcp": "/mcp"
           }
         }
       }
@@ -25,7 +24,6 @@
     "capabilities": {
       "tools": {
         "list_endpoint": "/tools",
-        "invoke_endpoint": "/tools/{toolName}",
         "schema_catalogs": [
           "/schemas/tools/index.json"
         ],

--- a/src/server/__tests__/healthAfterConfigure.test.ts
+++ b/src/server/__tests__/healthAfterConfigure.test.ts
@@ -90,6 +90,13 @@ const tool: ToolDefinition = {
   })
 };
 
+const createSessionServer = (): McpServer => {
+  const instance = new McpServer({ name: 'health-session', version: '0.0.0-test' });
+  const sessionRegistry = new ToolRegistry(instance);
+  sessionRegistry.register(tool);
+  return instance;
+};
+
 describe('HTTP /health after eos_configure', () => {
   let server: McpServer;
   let registry: ToolRegistry;
@@ -137,6 +144,7 @@ describe('HTTP /health after eos_configure', () => {
     gateway = createHttpGateway(registry, {
       port: 0,
       oscConnectionProvider: connectionState,
+      serverFactory: () => createSessionServer(),
       oscGateway: {
         getDiagnostics: () => {
           const diagnostics = getOscGateway().getDiagnostics?.();


### PR DESCRIPTION
## Summary
- replace the custom HTTP/WS gateway with a Streamable HTTP JSON-RPC implementation that manages MCP sessions and security requirements
- expose the MCP endpoint in the manifest and document the JSON-RPC workflow in the README
- update bootstrap wiring and tests to exercise the new initialize/tools.call flow with required headers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fead1aef34832a9426915f902cb83c