### PR TITLE
Coerce numeric tool schemas to accept string inputs

### DIFF
--- a/src/tools/channels/__tests__/channels.test.ts
+++ b/src/tools/channels/__tests__/channels.test.ts
@@ -52,6 +52,16 @@ describe('channel tools', () => {
     expect(message?.args?.[0]?.value).toBe('Chan 1 Thru 2 Sneak 0 Enter');
   });
 
+  it('accepte les numeros de canal fournis en chaine', async () => {
+    await runTool(eosChannelSetLevelTool, { channels: ['001', '002'], level: 50 });
+
+    expect(service.sentMessages).toHaveLength(1);
+    expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.channels.command });
+
+    const message = service.sentMessages[0];
+    expect(message?.args?.[0]?.value).toBe('Chan 1 Thru 2 Sneak 50 Enter');
+  });
+
   it('transforme full en 255 pour le DMX', async () => {
     await runTool(eosSetDmxTool, { addresses: [101], value: 'full' });
 
@@ -60,6 +70,16 @@ describe('channel tools', () => {
 
     const message = service.sentMessages[0];
     expect(message?.args?.[0]?.value).toBe('Address 101 At 255 Enter');
+  });
+
+  it('accepte les adresses DMX en chaine', async () => {
+    await runTool(eosSetDmxTool, { addresses: ['010', '011'], value: 10 });
+
+    expect(service.sentMessages).toHaveLength(1);
+    expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.dmx.command });
+
+    const message = service.sentMessages[0];
+    expect(message?.args?.[0]?.value).toBe('Address 10 Thru 11 At 10 Enter');
   });
 
   it('parse la reponse JSON pour la commande get_info', async () => {

--- a/src/tools/channels/index.ts
+++ b/src/tools/channels/index.ts
@@ -12,10 +12,10 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const channelNumberSchema = z.number().int().min(1).max(99999);
+const channelNumberSchema = z.coerce.number().int().min(1).max(99999);
 const channelListSchema = z
   .union([channelNumberSchema, z.array(channelNumberSchema).min(1)])
   .describe('Un numero de canal ou une liste de canaux');
@@ -204,7 +204,7 @@ const setLevelSchema = {
 } satisfies ZodRawShape;
 
 const setDmxSchema = {
-  addresses: z.union([z.number().int().min(1).max(65535), z.array(z.number().int().min(1).max(65535)).min(1)]),
+  addresses: z.union([z.coerce.number().int().min(1).max(65535), z.array(z.coerce.number().int().min(1).max(65535)).min(1)]),
   value: dmxValueSchema,
   ...targetOptionsSchema
 } satisfies ZodRawShape;
@@ -219,7 +219,7 @@ const setParameterSchema = {
 const getInfoSchema = {
   channels: channelListSchema,
   fields: z.array(z.string().min(1)).optional(),
-  timeoutMs: z.number().int().min(50).optional(),
+  timeoutMs: z.coerce.number().int().min(50).optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 

--- a/src/tools/commands/command_tools.ts
+++ b/src/tools/commands/command_tools.ts
@@ -7,7 +7,7 @@ type SubstitutionValue = string | number | boolean;
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 };
 
 const substitutionsSchema = z.array(z.union([z.string(), z.number(), z.boolean()])).optional();
@@ -104,7 +104,7 @@ function resolveUserId(requested?: number | null): number | undefined {
 const commandInputSchema = {
   command: z.string().min(1, 'La commande ne peut pas etre vide'),
   terminateWithEnter: z.boolean().optional(),
-  user: z.number().int().min(0).optional(),
+  user: z.coerce.number().int().min(0).optional(),
   ...targetOptionsSchema
 };
 
@@ -148,7 +148,7 @@ const newCommandInputSchema = {
   substitutions: substitutionsSchema,
   terminateWithEnter: z.boolean().optional(),
   clearLine: z.boolean().optional(),
-  user: z.number().int().min(0).optional(),
+  user: z.coerce.number().int().min(0).optional(),
   ...targetOptionsSchema
 };
 
@@ -202,7 +202,7 @@ const substitutionCommandInputSchema = {
   template: z.string().min(1, 'Le gabarit ne peut pas etre vide'),
   values: substitutionsSchema,
   terminateWithEnter: z.boolean().optional(),
-  user: z.number().int().min(0).optional(),
+  user: z.coerce.number().int().min(0).optional(),
   ...targetOptionsSchema
 };
 
@@ -243,8 +243,8 @@ export const eosCommandWithSubstitutionTool: ToolDefinition<typeof substitutionC
 };
 
 const commandLineInputSchema = {
-  user: z.number().int().min(0).optional(),
-  timeoutMs: z.number().int().positive().optional(),
+  user: z.coerce.number().int().min(0).optional(),
+  timeoutMs: z.coerce.number().int().positive().optional(),
   ...targetOptionsSchema
 };
 

--- a/src/tools/connection/eos_configure.ts
+++ b/src/tools/connection/eos_configure.ts
@@ -10,9 +10,9 @@ import type { ToolDefinition } from '../types';
 
 const inputSchema = {
   remoteAddress: z.string().min(1, 'remoteAddress doit etre une adresse valide.'),
-  remotePort: z.number().int().min(1).max(65535),
-  localPort: z.number().int().min(1).max(65535),
-  tcpPort: z.number().int().min(1).max(65535).optional()
+  remotePort: z.coerce.number().int().min(1).max(65535),
+  localPort: z.coerce.number().int().min(1).max(65535),
+  tcpPort: z.coerce.number().int().min(1).max(65535).optional()
 };
 
 /**

--- a/src/tools/connection/eos_connect.ts
+++ b/src/tools/connection/eos_connect.ts
@@ -4,10 +4,10 @@ import type { ToolDefinition } from '../types';
 
 const inputSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional(),
+  targetPort: z.coerce.number().int().min(1).max(65535).optional(),
   preferredProtocols: z.array(z.string().min(1)).min(1).optional(),
-  handshakeTimeoutMs: z.number().int().positive().optional(),
-  protocolTimeoutMs: z.number().int().positive().optional(),
+  handshakeTimeoutMs: z.coerce.number().int().positive().optional(),
+  protocolTimeoutMs: z.coerce.number().int().positive().optional(),
   clientId: z.string().min(1).optional(),
   transportPreference: z.enum(['reliability', 'speed', 'auto']).optional()
 };

--- a/src/tools/connection/eos_reset.ts
+++ b/src/tools/connection/eos_reset.ts
@@ -4,9 +4,9 @@ import type { ToolDefinition } from '../types';
 
 const inputSchema = {
   full: z.boolean().optional(),
-  timeoutMs: z.number().int().positive().optional(),
+  timeoutMs: z.coerce.number().int().positive().optional(),
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional(),
+  targetPort: z.coerce.number().int().min(1).max(65535).optional(),
   transportPreference: z.enum(['reliability', 'speed', 'auto']).optional()
 };
 

--- a/src/tools/connection/eos_subscribe.ts
+++ b/src/tools/connection/eos_subscribe.ts
@@ -6,9 +6,9 @@ const inputSchema = {
   path: z.string().min(1),
   enable: z.boolean().optional(),
   rateHz: z.number().positive().optional(),
-  timeoutMs: z.number().int().positive().optional(),
+  timeoutMs: z.coerce.number().int().positive().optional(),
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional(),
+  targetPort: z.coerce.number().int().min(1).max(65535).optional(),
   transportPreference: z.enum(['reliability', 'speed', 'auto']).optional()
 };
 

--- a/src/tools/cues/common.ts
+++ b/src/tools/cues/common.ts
@@ -5,14 +5,14 @@ import type { CueIdentifier } from './types';
 
 export const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-export const cuelistNumberSchema = z.number().int().min(1).max(99999);
+export const cuelistNumberSchema = z.coerce.number().int().min(1).max(99999);
 
 export const cueNumberSchema = z.union([z.string().min(1), z.number()]);
 
-export const cuePartSchema = z.number().int().min(0).max(99);
+export const cuePartSchema = z.coerce.number().int().min(0).max(99);
 
 export interface CueCommandOptions {
   cuelist_number?: number | null;

--- a/src/tools/cues/cuelist_bank_create.ts
+++ b/src/tools/cues/cuelist_bank_create.ts
@@ -11,11 +11,11 @@ import {
 } from './common';
 
 const bankCreateInputSchema = {
-  bank_index: z.number().int().min(0),
+  bank_index: z.coerce.number().int().min(0),
   cuelist_number: cuelistNumberSchema,
-  num_prev_cues: z.number().int().min(0),
-  num_pending_cues: z.number().int().min(0),
-  offset: z.number().int().optional(),
+  num_prev_cues: z.coerce.number().int().min(0),
+  num_pending_cues: z.coerce.number().int().min(0),
+  offset: z.coerce.number().int().optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 

--- a/src/tools/cues/cuelist_bank_page.ts
+++ b/src/tools/cues/cuelist_bank_page.ts
@@ -5,8 +5,8 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 import { extractTargetOptions, targetOptionsSchema } from './common';
 
 const bankPageInputSchema = {
-  bank_index: z.number().int().min(0),
-  delta: z.number().int(),
+  bank_index: z.coerce.number().int().min(0),
+  delta: z.coerce.number().int(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 

--- a/src/tools/curves/index.ts
+++ b/src/tools/curves/index.ts
@@ -12,17 +12,17 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const curveNumberSchema = z
+const curveNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
   .max(9999)
   .describe('Numero de courbe (1-9999).');
 
-const timeoutSchema = z.number().int().min(50).optional();
+const timeoutSchema = z.coerce.number().int().min(50).optional();
 
 const selectInputSchema = {
   curve_number: curveNumberSchema,

--- a/src/tools/directSelects/index.ts
+++ b/src/tools/directSelects/index.ts
@@ -134,22 +134,22 @@ function normaliseTargetType(value: string): string | null {
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const bankIndexSchema = z
+const bankIndexSchema = z.coerce
   .number()
   .int()
   .min(0)
   .describe("Index du bank de direct selects (0 pour le premier bank).");
 
-const buttonIndexSchema = z
+const buttonIndexSchema = z.coerce
   .number()
   .int()
   .min(1)
   .describe('Position du bouton dans le bank (1-n).');
 
-const stateValueSchema = z
+const stateValueSchema = z.coerce
   .number()
   .finite()
   .min(0)
@@ -174,14 +174,14 @@ const targetTypeSchema = z
 const bankCreateInputSchema = {
   bank_index: bankIndexSchema,
   target_type: targetTypeSchema,
-  button_count: z
+  button_count: z.coerce
     .number()
     .int()
     .min(1)
     .max(100)
     .describe('Nombre de boutons a creer dans le bank (1-100).'),
   flexi_mode: z.boolean().describe('Active ou non le mode Flexi pour le bank.'),
-  page_number: z
+  page_number: z.coerce
     .number()
     .int()
     .min(0)
@@ -199,7 +199,7 @@ const pressInputSchema = {
 
 const pageInputSchema = {
   bank_index: bankIndexSchema,
-  delta: z.number().int(),
+  delta: z.coerce.number().int(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 

--- a/src/tools/dmx/index.ts
+++ b/src/tools/dmx/index.ts
@@ -5,11 +5,11 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
 const dmxAddressSchema = z
-  .union([z.string().min(1), z.number().int().min(1).max(65535)])
+  .union([z.string().min(1), z.coerce.number().int().min(1).max(65535)])
   .describe("Adresse DMX au format 'univers/adresse' ou numero absolu.");
 
 const levelValueSchema = z.union([z.number(), z.string().min(1)]);

--- a/src/tools/effects/index.ts
+++ b/src/tools/effects/index.ts
@@ -12,17 +12,17 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const effectNumberSchema = z
+const effectNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
   .max(9999)
   .describe("Numero d'effet (1-9999)");
 
-const timeoutSchema = z.number().int().min(50).optional();
+const timeoutSchema = z.coerce.number().int().min(50).optional();
 
 const selectInputSchema = {
   effect_number: effectNumberSchema,

--- a/src/tools/faders/index.ts
+++ b/src/tools/faders/index.ts
@@ -22,16 +22,16 @@ export function __resetFaderBankCacheForTests(): void {
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const bankIndexSchema = z
+const bankIndexSchema = z.coerce
   .number()
   .int()
   .min(0)
   .describe('Index du bank de faders (0 = Main, 1 = Mains, etc.).');
 
-const faderIndexSchema = z
+const faderIndexSchema = z.coerce
   .number()
   .int()
   .min(1)
@@ -41,13 +41,13 @@ const levelValueSchema = z.union([z.number(), z.string().min(1)]);
 
 const bankCreateInputSchema = {
   bank_index: bankIndexSchema,
-  fader_count: z
+  fader_count: z.coerce
     .number()
     .int()
     .min(1)
     .max(100)
     .describe('Nombre de faders a creer dans le bank.'),
-  page_number: z
+  page_number: z.coerce
     .number()
     .int()
     .min(0)
@@ -71,7 +71,7 @@ const loadInputSchema = {
 
 const pageInputSchema = {
   bank_index: bankIndexSchema,
-  delta: z.number().int(),
+  delta: z.coerce.number().int(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 

--- a/src/tools/fpe/index.ts
+++ b/src/tools/fpe/index.ts
@@ -5,19 +5,19 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const timeoutSchema = z.number().int().min(50).optional();
+const timeoutSchema = z.coerce.number().int().min(50).optional();
 
-const setNumberSchema = z
+const setNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
   .max(9999)
   .describe('Numero de set FPE (1-9999).');
 
-const pointNumberSchema = z
+const pointNumberSchema = z.coerce
   .number()
   .int()
   .min(1)

--- a/src/tools/groups/index.ts
+++ b/src/tools/groups/index.ts
@@ -12,10 +12,10 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const groupNumberSchema = z
+const groupNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
@@ -41,7 +41,7 @@ interface NormalisedGroup {
 }
 
 const groupMemberOutputSchema = z.object({
-  channel: z.number().int().min(1),
+  channel: z.coerce.number().int().min(1),
   label: z.string().nullable()
 });
 
@@ -202,12 +202,12 @@ const setLevelInputSchema = {
 
 const getInfoInputSchema = {
   group_number: groupNumberSchema,
-  timeoutMs: z.number().int().min(50).optional(),
+  timeoutMs: z.coerce.number().int().min(50).optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
 const listAllInputSchema = {
-  timeoutMs: z.number().int().min(50).optional(),
+  timeoutMs: z.coerce.number().int().min(50).optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 

--- a/src/tools/keys/index.ts
+++ b/src/tools/keys/index.ts
@@ -5,10 +5,10 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const buttonStateSchema = z.union([z.number().int().min(0).max(1), z.boolean()]).optional();
+const buttonStateSchema = z.union([z.coerce.number().int().min(0).max(1), z.boolean()]).optional();
 
 type ButtonStateInput = z.infer<typeof buttonStateSchema>;
 
@@ -86,7 +86,7 @@ const keyPressInputSchema = {
 } satisfies ZodRawShape;
 
 const softkeyPressInputSchema = {
-  softkey_number: z
+  softkey_number: z.coerce
     .number()
     .int()
     .min(1, 'Le numero de softkey doit etre compris entre 1 et 12')
@@ -96,7 +96,7 @@ const softkeyPressInputSchema = {
 } satisfies ZodRawShape;
 
 const softkeyLabelsInputSchema = {
-  timeoutMs: z.number().int().min(50).optional(),
+  timeoutMs: z.coerce.number().int().min(50).optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 

--- a/src/tools/macros/index.ts
+++ b/src/tools/macros/index.ts
@@ -12,20 +12,20 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const macroNumberSchema = z
+const macroNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
   .max(9999)
   .describe('Numero de macro (1-9999)');
 
-const timeoutSchema = z.number().int().min(50).optional();
+const timeoutSchema = z.coerce.number().int().min(50).optional();
 
 const macroCommandOutputSchema = z.object({
-  index: z.number().int().min(1),
+  index: z.coerce.number().int().min(1),
   text: z.string()
 });
 

--- a/src/tools/magicSheets/index.ts
+++ b/src/tools/magicSheets/index.ts
@@ -12,24 +12,24 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const magicSheetNumberSchema = z
+const magicSheetNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
   .max(9999)
   .describe('Numero du magic sheet (1-9999).');
 
-const viewNumberSchema = z
+const viewNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
   .max(99)
   .describe('Numero de vue (1-99).');
 
-const timeoutSchema = z.number().int().min(50).optional();
+const timeoutSchema = z.coerce.number().int().min(50).optional();
 
 const openInputSchema = {
   ms_number: magicSheetNumberSchema,

--- a/src/tools/palettes/index.ts
+++ b/src/tools/palettes/index.ts
@@ -12,10 +12,10 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const paletteNumberSchema = z
+const paletteNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
@@ -61,7 +61,7 @@ const paletteGetInfoInputSchema = {
   palette_type: paletteTypeSchema,
   palette_number: paletteNumberSchema,
   fields: z.array(z.string().min(1)).optional(),
-  timeoutMs: z.number().int().min(50).optional(),
+  timeoutMs: z.coerce.number().int().min(50).optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 

--- a/src/tools/parameters/index.ts
+++ b/src/tools/parameters/index.ts
@@ -6,7 +6,7 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
 const numericInputSchema = z.union([z.number(), z.string().min(1)]);
@@ -342,7 +342,7 @@ const xyzInputSchema = {
 } satisfies ZodRawShape;
 
 const getActiveWheelsSchema = {
-  timeoutMs: z.number().int().min(50).optional(),
+  timeoutMs: z.coerce.number().int().min(50).optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 

--- a/src/tools/patch/index.ts
+++ b/src/tools/patch/index.ts
@@ -11,26 +11,26 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const timeoutSchema = z.number().int().min(50).optional();
+const timeoutSchema = z.coerce.number().int().min(50).optional();
 
-const channelNumberSchema = z
+const channelNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
   .max(99999)
   .describe('Numero de canal (1-99999).');
 
-const partNumberSchema = z
+const partNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
   .max(99)
   .describe('Numero de partie (1-99).');
 
-const partNumberWithAllSchema = z
+const partNumberWithAllSchema = z.coerce
   .number()
   .int()
   .min(0)
@@ -136,7 +136,7 @@ export const patchChannelPartOutputSchema = z.object({
 export const patchChannelInfoOutputSchema = z.object({
   channel_number: channelNumberSchema,
   label: z.string().nullable(),
-  part_count: z.number().int().min(0).nullable(),
+  part_count: z.coerce.number().int().min(0).nullable(),
   notes: z.string().nullable(),
   parts: z.array(patchChannelPartOutputSchema)
 });
@@ -152,7 +152,7 @@ export const augment3dPositionOutputSchema = z.object({
   part_number: partNumberSchema,
   position: augment3dVectorOutputSchema,
   orientation: augment3dVectorOutputSchema,
-  fpe_set: z.number().int().min(0).nullable()
+  fpe_set: z.coerce.number().int().min(0).nullable()
 });
 
 export const augment3dBeamOutputSchema = z.object({

--- a/src/tools/pixelMaps/index.ts
+++ b/src/tools/pixelMaps/index.ts
@@ -12,17 +12,17 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const pixmapNumberSchema = z
+const pixmapNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
   .max(9999)
   .describe('Numero du pixel map (1-9999).');
 
-const timeoutSchema = z.number().int().min(50).optional();
+const timeoutSchema = z.coerce.number().int().min(50).optional();
 
 const selectInputSchema = {
   pixmap_number: pixmapNumberSchema,
@@ -66,22 +66,22 @@ interface PixelMapInfo {
 }
 
 const pixelMapFixtureSegmentOutputShape = {
-  start_pixel: z.number().int().min(0).nullable(),
-  end_pixel: z.number().int().min(0).nullable(),
-  pixel_count: z.number().int().min(0).nullable(),
-  universe: z.number().int().min(0).nullable(),
-  address: z.number().int().min(0).nullable(),
-  string_number: z.number().int().min(0).nullable()
+  start_pixel: z.coerce.number().int().min(0).nullable(),
+  end_pixel: z.coerce.number().int().min(0).nullable(),
+  pixel_count: z.coerce.number().int().min(0).nullable(),
+  universe: z.coerce.number().int().min(0).nullable(),
+  address: z.coerce.number().int().min(0).nullable(),
+  string_number: z.coerce.number().int().min(0).nullable()
 } satisfies ZodRawShape;
 
 export const pixelMapFixtureSegmentOutputSchema = z.object(pixelMapFixtureSegmentOutputShape);
 
 const pixelMapFixtureOutputShape = {
-  channel: z.number().int().min(1),
+  channel: z.coerce.number().int().min(1),
   label: z.string().nullable(),
-  start_pixel: z.number().int().min(0).nullable(),
-  end_pixel: z.number().int().min(0).nullable(),
-  pixel_count: z.number().int().min(0).nullable(),
+  start_pixel: z.coerce.number().int().min(0).nullable(),
+  end_pixel: z.coerce.number().int().min(0).nullable(),
+  pixel_count: z.coerce.number().int().min(0).nullable(),
   segments: z.array(pixelMapFixtureSegmentOutputSchema)
 } satisfies ZodRawShape;
 
@@ -90,12 +90,12 @@ export const pixelMapFixtureOutputSchema = z.object(pixelMapFixtureOutputShape);
 const pixelMapInfoOutputShape = {
   pixmap_number: pixmapNumberSchema,
   label: z.string().nullable(),
-  server_channel: z.number().int().min(0).nullable(),
+  server_channel: z.coerce.number().int().min(0).nullable(),
   interface: z.string().nullable(),
-  width: z.number().int().min(0).nullable(),
-  height: z.number().int().min(0).nullable(),
-  pixel_count: z.number().int().min(0).nullable(),
-  fixture_count: z.number().int().min(0).nullable(),
+  width: z.coerce.number().int().min(0).nullable(),
+  height: z.coerce.number().int().min(0).nullable(),
+  pixel_count: z.coerce.number().int().min(0).nullable(),
+  fixture_count: z.coerce.number().int().min(0).nullable(),
   fixtures: z.array(pixelMapFixtureOutputSchema)
 } satisfies ZodRawShape;
 

--- a/src/tools/presets/index.ts
+++ b/src/tools/presets/index.ts
@@ -12,10 +12,10 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const presetNumberSchema = z
+const presetNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
@@ -30,7 +30,7 @@ const presetFireInputSchema = {
 const presetGetInfoInputSchema = {
   preset_number: presetNumberSchema,
   fields: z.array(z.string().min(1)).optional(),
-  timeoutMs: z.number().int().min(50).optional(),
+  timeoutMs: z.coerce.number().int().min(50).optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 

--- a/src/tools/queries/index.ts
+++ b/src/tools/queries/index.ts
@@ -132,7 +132,7 @@ const listItemOutputSchema = z.object({
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
 const targetTypeSchema = z
@@ -152,13 +152,13 @@ const targetTypeSchema = z
 
 const countInputSchema = {
   target_type: targetTypeSchema,
-  timeoutMs: z.number().int().min(50).optional(),
+  timeoutMs: z.coerce.number().int().min(50).optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
 const listInputSchema = {
   target_type: targetTypeSchema,
-  timeoutMs: z.number().int().min(50).optional(),
+  timeoutMs: z.coerce.number().int().min(50).optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
@@ -166,7 +166,7 @@ const countOutputSchema = {
   action: z.literal('get_count'),
   status: statusSchema,
   target_type: z.string(),
-  count: z.number().int().min(0),
+  count: z.coerce.number().int().min(0),
   data: z.unknown(),
   error: z.string().nullable(),
   osc: z.object({

--- a/src/tools/session/index.ts
+++ b/src/tools/session/index.ts
@@ -21,7 +21,7 @@ export function clearCurrentUserId(): void {
 }
 
 const setCurrentUserInputSchema = {
-  user: z.number().int().min(0, "L'identifiant utilisateur doit etre positif")
+  user: z.coerce.number().int().min(0, "L'identifiant utilisateur doit etre positif")
 };
 
 /**

--- a/src/tools/showControl/index.ts
+++ b/src/tools/showControl/index.ts
@@ -5,10 +5,10 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const timeoutSchema = z
+const timeoutSchema = z.coerce
   .number()
   .int()
   .min(50)

--- a/src/tools/snapshots/index.ts
+++ b/src/tools/snapshots/index.ts
@@ -12,10 +12,10 @@ import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const snapshotNumberSchema = z
+const snapshotNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
@@ -30,7 +30,7 @@ const recallInputSchema = {
 const getInfoInputSchema = {
   snapshot_number: snapshotNumberSchema,
   fields: z.array(z.string().min(1)).optional(),
-  timeoutMs: z.number().int().min(50).optional(),
+  timeoutMs: z.coerce.number().int().min(50).optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 

--- a/src/tools/submasters/index.ts
+++ b/src/tools/submasters/index.ts
@@ -32,10 +32,10 @@ export interface SubmasterInfo {
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
 } satisfies ZodRawShape;
 
-const submasterNumberSchema = z
+const submasterNumberSchema = z.coerce
   .number()
   .int()
   .min(1)
@@ -56,7 +56,7 @@ const bumpInputSchema = {
 
 const getInfoInputSchema = {
   submaster_number: submasterNumberSchema,
-  timeoutMs: z.number().int().min(50).optional(),
+  timeoutMs: z.coerce.number().int().min(50).optional(),
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 


### PR DESCRIPTION
## Summary
- coerce integer tool inputs across the EOS toolset so digit strings are parsed correctly
- ensure channel and DMX handlers normalise coerced identifiers and addresses when building OSC commands
- expand channel tool tests to cover string-based channel and DMX arguments

## Testing
- npm test -- channels

------
https://chatgpt.com/codex/tasks/task_e_68fec34fe4d0832a92049f89cd1b38d4