### PR TITLE
Copy allowed origins array when creating HTTP transport

### DIFF
--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -693,6 +693,8 @@ class HttpGateway {
       closed: false
     };
 
+    const allowedOrigins = this.options.security?.allowedOrigins;
+
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       enableJsonResponse: true,
@@ -707,7 +709,7 @@ class HttpGateway {
         }
         await this.closeServer(record);
       },
-      allowedOrigins: this.options.security?.allowedOrigins
+      allowedOrigins: allowedOrigins ? Array.from(allowedOrigins) : undefined
     });
 
     record.transport = transport;


### PR DESCRIPTION
## Summary
- copy the configured allowedOrigins array before passing it to StreamableHTTPServerTransport so the transport receives a mutable list

## Testing
- npm run build *(fails: existing TypeScript errors regarding IncomingMessage type and tool result structuredContent typing)*

------
https://chatgpt.com/codex/tasks/task_e_68ff3ad6f2bc832a92339b4007a2a3bb