### PR TITLE
Add IncomingMessage import for HTTP gateway

### DIFF
--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import {
   createServer,
   type IncomingHttpHeaders,
+  type IncomingMessage,
   type Server
 } from 'node:http';
 import { randomUUID } from 'node:crypto';


### PR DESCRIPTION
## Summary
- include IncomingMessage in the httpGateway imports from node:http to satisfy type usage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ff56e827d0832a8b9f2dad4b6d397c