### PR TITLE
Ensure OSC structured content types are plain records

### DIFF
--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -107,7 +107,7 @@ export function parseLegacyHandshakeMessage(message: OscMessage): HandshakeData 
   };
 }
 
-export interface ConnectResult {
+export interface ConnectResult extends Record<string, unknown> {
   status: StepStatus;
   version: string | null;
   availableProtocols: string[];
@@ -123,7 +123,7 @@ export interface PingOptions extends TargetOptions {
   timeoutMs?: number;
 }
 
-export interface PingResult {
+export interface PingResult extends Record<string, unknown> {
   status: StepStatus;
   roundtripMs: number | null;
   echo: string | null;
@@ -136,7 +136,7 @@ export interface ResetOptions extends TargetOptions {
   timeoutMs?: number;
 }
 
-export interface ResetResult {
+export interface ResetResult extends Record<string, unknown> {
   status: StepStatus;
   payload: unknown;
   error?: string;
@@ -149,7 +149,7 @@ export interface SubscribeOptions extends TargetOptions {
   timeoutMs?: number;
 }
 
-export interface SubscribeResult {
+export interface SubscribeResult extends Record<string, unknown> {
   status: StepStatus;
   path: string;
   payload: unknown;
@@ -168,7 +168,7 @@ export interface CommandLineRequestOptions extends TargetOptions {
   timeoutMs?: number;
 }
 
-export interface CommandLineState {
+export interface CommandLineState extends Record<string, unknown> {
   status: StepStatus;
   text: string;
   user: number | null;

--- a/src/services/osc/index.ts
+++ b/src/services/osc/index.ts
@@ -3,17 +3,17 @@ import type { Logger } from 'pino';
 import { getConfig, type OscConfig as ResolvedOscConfig } from '../../config/index';
 import { createLogger } from '../../server/logger';
 
-export interface OscMessageArgument {
+export interface OscMessageArgument extends Record<string, unknown> {
   type: string;
   value: unknown;
 }
 
-export interface OscMessage {
+export interface OscMessage extends Record<string, unknown> {
   address: string;
   args?: OscMessageArgument[];
 }
 
-export interface OscMessageSummary {
+export interface OscMessageSummary extends Record<string, unknown> {
   address: string;
   args: OscMessageArgument[];
 }
@@ -22,20 +22,20 @@ export type OscMessageListener = (message: OscMessage) => void;
 
 export type OscLogger = Pick<Logger, 'info' | 'debug' | 'error'>;
 
-export interface OscLoggingState {
+export interface OscLoggingState extends Record<string, unknown> {
   incoming: boolean;
   outgoing: boolean;
 }
 
 export type OscLoggingOptions = Partial<OscLoggingState>;
 
-export interface OscAddressDiagnostics {
+export interface OscAddressDiagnostics extends Record<string, unknown> {
   address: string;
   count: number;
   lastTimestamp: number | null;
 }
 
-export interface OscDirectionDiagnostics {
+export interface OscDirectionDiagnostics extends Record<string, unknown> {
   count: number;
   bytes: number;
   lastTimestamp: number | null;
@@ -43,7 +43,7 @@ export interface OscDirectionDiagnostics {
   addresses: OscAddressDiagnostics[];
 }
 
-export interface OscDiagnostics {
+export interface OscDiagnostics extends Record<string, unknown> {
   config: {
     localAddress: string;
     localPort: number;

--- a/src/tools/commands/command_tools.ts
+++ b/src/tools/commands/command_tools.ts
@@ -71,7 +71,7 @@ function formatSendResult(command: string, user: number | null, oscAddress: stri
         text: command
       }
     }
-  } as unknown as ToolExecutionResult;
+  };
 }
 
 function formatCommandLineState(result: CommandLineState): ToolExecutionResult {
@@ -84,8 +84,8 @@ function formatCommandLineState(result: CommandLineState): ToolExecutionResult {
           : `Lecture de la ligne de commande indisponible (${result.status})`
       }
     ],
-    structuredContent: result
-  } as unknown as ToolExecutionResult;
+    structuredContent: { ...result }
+  };
 }
 
 function resolveUserId(requested?: number | null): number | undefined {


### PR DESCRIPTION
## Summary
- update OSC client result interfaces to extend Record<string, unknown>
- mark OSC diagnostics and message-related types as plain records
- return structured command data without type casts while cloning structured content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ff593dc2b8832a9d5c01b27a9b6bb0