### PR TITLE
fix: remove .js suffix from MCP SDK imports

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
 import { z, type ZodRawShape } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import toolDefinitions from '../tools/index';

--- a/src/server/__tests__/bootstrapHandshake.test.ts
+++ b/src/server/__tests__/bootstrapHandshake.test.ts
@@ -15,11 +15,11 @@ const MockMcpServer = jest.fn().mockImplementation(() => ({
   sendToolListChanged: mockSendToolListChanged
 }));
 
-jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+jest.mock('@modelcontextprotocol/sdk/server/mcp', () => ({
   McpServer: MockMcpServer
 }));
 
-jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+jest.mock('@modelcontextprotocol/sdk/server/stdio', () => ({
   StdioServerTransport: jest.fn().mockImplementation(() => ({}))
 }));
 

--- a/src/server/__tests__/healthAfterConfigure.test.ts
+++ b/src/server/__tests__/healthAfterConfigure.test.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
 import { createHttpGateway, type HttpGateway } from '../httpGateway';
 import { ToolRegistry } from '../toolRegistry';
 import type { ToolDefinition } from '../../tools/types';

--- a/src/server/__tests__/httpGateway.test.ts
+++ b/src/server/__tests__/httpGateway.test.ts
@@ -1,5 +1,5 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types';
 import { z } from 'zod';
 import { createHttpGateway, type HttpGateway } from '../httpGateway';
 import { ToolRegistry } from '../toolRegistry';

--- a/src/server/__tests__/serverVersion.test.ts
+++ b/src/server/__tests__/serverVersion.test.ts
@@ -15,11 +15,11 @@ const MockMcpServer = jest.fn().mockImplementation(() => ({
   sendToolListChanged: mockSendToolListChanged
 }));
 
-jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+jest.mock('@modelcontextprotocol/sdk/server/mcp', () => ({
   McpServer: MockMcpServer
 }));
 
-jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+jest.mock('@modelcontextprotocol/sdk/server/stdio', () => ({
   StdioServerTransport: jest.fn().mockImplementation(() => ({}))
 }));
 

--- a/src/server/__tests__/toolRegistry.test.ts
+++ b/src/server/__tests__/toolRegistry.test.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
 import { ToolRegistry } from '../toolRegistry';
 import type { ToolDefinition, ToolExecutionResult, ToolMiddleware } from '../../tools/types';
 import {

--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -16,9 +16,9 @@ import express, {
   type ErrorRequestHandler,
   Router
 } from 'express';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { ErrorCode as JsonRpcErrorCode, isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp';
+import { ErrorCode as JsonRpcErrorCode, isInitializeRequest } from '@modelcontextprotocol/sdk/types';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
 import { createLogger } from './logger';
 import type {
   OscConnectionStateProvider,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,8 +3,8 @@ import { initialiseEnv } from '../config/env';
 initialiseEnv();
 
 import type { AddressInfo } from 'node:net';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio';
 import { getConfig, type AppConfig } from '../config/index';
 import {
   createOscGatewayFromEnv,

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
 import type {
   ToolDefinition,
   ToolExecutionResult,


### PR DESCRIPTION
## Summary
- drop the .js extension from @modelcontextprotocol/sdk imports in server and schema sources
- update associated unit test imports and mocks to use the same extensionless specifiers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69020a0601f0832ab207fa83ea3deaa9