### PR TITLE
Add explicit types for HTTP gateway session callbacks

### DIFF
--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -706,12 +706,12 @@ class HttpGateway {
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       enableJsonResponse: true,
-      onsessioninitialized: async (sessionId) => {
+      onsessioninitialized: async (sessionId: string) => {
         record.id = sessionId;
         record.lastActivityAt = Date.now();
         this.sessions.set(sessionId, record);
       },
-      onsessionclosed: async (sessionId) => {
+      onsessionclosed: async (sessionId: string) => {
         if (sessionId) {
           this.sessions.delete(sessionId);
         }


### PR DESCRIPTION
## Summary
- annotate the HTTP gateway session callbacks with explicit string parameter types
- ensure session management continues to treat session identifiers as strings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69020d7276d0832a9ba64a351642684f