### PR TITLE
Add ambient module declarations for MCP SDK subpaths

### DIFF
--- a/src/types/modelcontextprotocol__sdk.d.ts
+++ b/src/types/modelcontextprotocol__sdk.d.ts
@@ -1,0 +1,19 @@
+declare module '@modelcontextprotocol/sdk/server/mcp' {
+  export * from '@modelcontextprotocol/sdk/dist/esm/server/mcp.js';
+  export { McpServer } from '@modelcontextprotocol/sdk/dist/esm/server/mcp.js';
+}
+
+declare module '@modelcontextprotocol/sdk/server/stdio' {
+  export * from '@modelcontextprotocol/sdk/dist/esm/server/stdio.js';
+  export { StdioServerTransport } from '@modelcontextprotocol/sdk/dist/esm/server/stdio.js';
+}
+
+declare module '@modelcontextprotocol/sdk/server/streamableHttp' {
+  export * from '@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js';
+  export { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js';
+}
+
+declare module '@modelcontextprotocol/sdk/types' {
+  export * from '@modelcontextprotocol/sdk/dist/esm/types.js';
+  export { ErrorCode, isInitializeRequest } from '@modelcontextprotocol/sdk/dist/esm/types.js';
+}


### PR DESCRIPTION
## Summary
- add ambient module declarations that re-export the MCP SDK's compiled ESM typings for the server and types subpaths so TypeScript can resolve them via the configured type roots

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690217ac294c832abc3ceb1f7dfb0965