### PR TITLE
Add .js suffix to MCP SDK imports

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z, type ZodRawShape } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import toolDefinitions from '../tools/index';

--- a/src/server/__tests__/bootstrapHandshake.test.ts
+++ b/src/server/__tests__/bootstrapHandshake.test.ts
@@ -15,11 +15,11 @@ const MockMcpServer = jest.fn().mockImplementation(() => ({
   sendToolListChanged: mockSendToolListChanged
 }));
 
-jest.mock('@modelcontextprotocol/sdk/server/mcp', () => ({
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
   McpServer: MockMcpServer
 }));
 
-jest.mock('@modelcontextprotocol/sdk/server/stdio', () => ({
+jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
   StdioServerTransport: jest.fn().mockImplementation(() => ({}))
 }));
 

--- a/src/server/__tests__/healthAfterConfigure.test.ts
+++ b/src/server/__tests__/healthAfterConfigure.test.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createHttpGateway, type HttpGateway } from '../httpGateway';
 import { ToolRegistry } from '../toolRegistry';
 import type { ToolDefinition } from '../../tools/types';

--- a/src/server/__tests__/httpGateway.test.ts
+++ b/src/server/__tests__/httpGateway.test.ts
@@ -1,5 +1,5 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
-import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { createHttpGateway, type HttpGateway } from '../httpGateway';
 import { ToolRegistry } from '../toolRegistry';

--- a/src/server/__tests__/serverVersion.test.ts
+++ b/src/server/__tests__/serverVersion.test.ts
@@ -15,11 +15,11 @@ const MockMcpServer = jest.fn().mockImplementation(() => ({
   sendToolListChanged: mockSendToolListChanged
 }));
 
-jest.mock('@modelcontextprotocol/sdk/server/mcp', () => ({
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
   McpServer: MockMcpServer
 }));
 
-jest.mock('@modelcontextprotocol/sdk/server/stdio', () => ({
+jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
   StdioServerTransport: jest.fn().mockImplementation(() => ({}))
 }));
 

--- a/src/server/__tests__/toolRegistry.test.ts
+++ b/src/server/__tests__/toolRegistry.test.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ToolRegistry } from '../toolRegistry';
 import type { ToolDefinition, ToolExecutionResult, ToolMiddleware } from '../../tools/types';
 import {

--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -16,9 +16,9 @@ import express, {
   type ErrorRequestHandler,
   Router
 } from 'express';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp';
-import { ErrorCode as JsonRpcErrorCode, isInitializeRequest } from '@modelcontextprotocol/sdk/types';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { ErrorCode as JsonRpcErrorCode, isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger } from './logger';
 import type {
   OscConnectionStateProvider,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,8 +3,8 @@ import { initialiseEnv } from '../config/env';
 initialiseEnv();
 
 import type { AddressInfo } from 'node:net';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { getConfig, type AppConfig } from '../config/index';
 import {
   createOscGatewayFromEnv,

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type {
   ToolDefinition,
   ToolExecutionResult,

--- a/src/types/modelcontextprotocol__sdk.d.ts
+++ b/src/types/modelcontextprotocol__sdk.d.ts
@@ -3,7 +3,17 @@ declare module '@modelcontextprotocol/sdk/server/mcp' {
   export { McpServer } from '@modelcontextprotocol/sdk/dist/esm/server/mcp.js';
 }
 
+declare module '@modelcontextprotocol/sdk/server/mcp.js' {
+  export * from '@modelcontextprotocol/sdk/dist/esm/server/mcp.js';
+  export { McpServer } from '@modelcontextprotocol/sdk/dist/esm/server/mcp.js';
+}
+
 declare module '@modelcontextprotocol/sdk/server/stdio' {
+  export * from '@modelcontextprotocol/sdk/dist/esm/server/stdio.js';
+  export { StdioServerTransport } from '@modelcontextprotocol/sdk/dist/esm/server/stdio.js';
+}
+
+declare module '@modelcontextprotocol/sdk/server/stdio.js' {
   export * from '@modelcontextprotocol/sdk/dist/esm/server/stdio.js';
   export { StdioServerTransport } from '@modelcontextprotocol/sdk/dist/esm/server/stdio.js';
 }
@@ -13,7 +23,17 @@ declare module '@modelcontextprotocol/sdk/server/streamableHttp' {
   export { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js';
 }
 
+declare module '@modelcontextprotocol/sdk/server/streamableHttp.js' {
+  export * from '@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js';
+  export { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js';
+}
+
 declare module '@modelcontextprotocol/sdk/types' {
+  export * from '@modelcontextprotocol/sdk/dist/esm/types.js';
+  export { ErrorCode, isInitializeRequest } from '@modelcontextprotocol/sdk/dist/esm/types.js';
+}
+
+declare module '@modelcontextprotocol/sdk/types.js' {
   export * from '@modelcontextprotocol/sdk/dist/esm/types.js';
   export { ErrorCode, isInitializeRequest } from '@modelcontextprotocol/sdk/dist/esm/types.js';
 }


### PR DESCRIPTION
## Summary
- update server and test imports to include the .js suffix when loading MCP SDK runtime modules
- extend the MCP SDK ambient module declarations to cover the new .js-suffixed entry points
- rebuild the project to refresh the dist output

## Testing
- npm run build
- npm start

------
https://chatgpt.com/codex/tasks/task_e_690227ae69bc832a8c7e125d4910cb5d