### PR TITLE
Route logs to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Ces commandes peuvent également être lancées sur la version compilée avec `n
 Lorsque vous démarrez réellement le serveur (sans combiner d'option utilitaire ci-dessus), plusieurs modificateurs sont disponibles :
 
 - `--verbose` active la journalisation détaillée des messages OSC (entrants/sortants).
-- `--json-logs` force l'envoi des logs au format JSON vers STDOUT, en ignorant la configuration de destinations déclarée dans l'environnement.
+- `--json-logs` force le format JSON pour toutes les destinations configurées et remplace toute sortie `stdout` par `stderr` afin de préserver le canal STDOUT pour le protocole MCP.
 - `--stats-interval <durée>` publie périodiquement les compteurs RX/TX issus d'`OscService.getDiagnostics()` dans les logs (valeurs acceptant `10s`, `5s`, `5000ms`, etc.).
 
 Exemple :
@@ -101,6 +101,10 @@ Exemple :
 ```bash
 npx ts-node src/server/index.ts --verbose --json-logs --stats-interval 30s
 ```
+
+### Journalisation et séparation STDOUT/STDERR
+
+Le protocole MCP utilise exclusivement STDOUT pour échanger avec les clients. Pour éviter toute interférence, l'intégralité des logs applicatifs est désormais routée vers STDERR (ou vers les fichiers/transports configurés). Même si la destination héritée `stdout` reste acceptée dans les variables d'environnement pour des raisons de compatibilité, elle est automatiquement redirigée vers STDERR par le serveur. Consultez vos journaux via STDERR ou en configurant `LOG_DESTINATIONS=file`/`transport` selon vos besoins.
 
 ## Configuration réseau et de la console Eos
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -10,17 +10,17 @@ Le niveau s'applique à l'ensemble des destinations configurées.
 
 ## Destinations disponibles
 
-- `LOG_DESTINATIONS` : liste de destinations séparées par des virgules parmi `stdout`, `file`, `transport`. Valeur par défaut : `file`.
+- `LOG_DESTINATIONS` : liste de destinations séparées par des virgules parmi `stdout`, `stderr`, `file`, `transport`. Valeur par défaut : `file`.
 
-En environnement de développement (`NODE_ENV` différent de `production`), la destination `stdout` est automatiquement ajoutée lorsque `LOG_DESTINATIONS` n'est pas définie explicitement. Les logs sont ainsi visibles dans la console sans configuration additionnelle. Pour désactiver cette sortie, définissez `LOG_DESTINATIONS=file`. Vous pouvez aussi combiner plusieurs destinations en les listant, par exemple `LOG_DESTINATIONS=stdout,file` ou `LOG_DESTINATIONS=file,transport`.
+En environnement de développement (`NODE_ENV` différent de `production`), la destination `stdout` est automatiquement ajoutée lorsque `LOG_DESTINATIONS` n'est pas définie explicitement. Pour préserver le canal STDOUT réservé au protocole MCP, cette valeur est immédiatement convertie en destination `stderr` par la phase de chargement de la configuration. Les logs restent visibles dans la console sans configuration additionnelle. Pour désactiver cette sortie, définissez `LOG_DESTINATIONS=file`. Vous pouvez aussi combiner plusieurs destinations en les listant, par exemple `LOG_DESTINATIONS=stdout,file` (redirigé vers STDERR + fichier) ou `LOG_DESTINATIONS=file,transport`.
 
 Lorsque `file` est présent :
 
 - `MCP_LOG_FILE` : chemin (relatif ou absolu) du fichier journal. Le répertoire est créé automatiquement et la rotation est assurée par le transport `pino/file`.
 
-Lorsque `stdout` est présent :
+Lorsque `stdout` ou `stderr` est présent :
 
-- `LOG_PRETTY` : active (`true`) ou désactive (`false`) le rendu « pretty » via `pino-pretty`. Par défaut, le format pretty est utilisé si `NODE_ENV` n'est pas `production`, sinon le format JSON est conservé.
+- `LOG_PRETTY` : active (`true`) ou désactive (`false`) le rendu « pretty » via `pino-pretty`. Par défaut, le format pretty est utilisé si `NODE_ENV` n'est pas `production`, sinon le format JSON est conservé. Quel que soit le nom déclaré (`stdout` ou `stderr`), la sortie console effective passe par STDERR.
 
 Lorsque `transport` est présent :
 
@@ -51,7 +51,7 @@ npm test -- src/config/__tests__/config.test.ts
 
 En complément des variables d'environnement, certains indicateurs peuvent être activés directement lors du démarrage du serveur :
 
-- `--json-logs` force l'utilisation du format JSON sur STDOUT et ignore les destinations configurées (pratique pour rediriger la sortie vers un collecteur).
+- `--json-logs` force l'utilisation du format JSON pour toutes les destinations et remplace toute sortie console par STDERR afin de préserver STDOUT pour le protocole MCP.
 - `--verbose` active la journalisation détaillée des messages OSC (entrants et sortants) via `OscService.setLoggingOptions()`.
 - `--stats-interval <durée>` publie périodiquement les compteurs RX/TX renvoyés par `OscService.getDiagnostics()` dans les logs (valeurs acceptant `10s`, `5s`, `5000ms`, etc.).
 

--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -29,7 +29,7 @@ describe('configuration', () => {
         format: 'pretty',
         destinations: [
           {
-            type: 'stdout'
+            type: 'stderr'
           },
           {
             type: 'file',
@@ -87,7 +87,7 @@ describe('configuration', () => {
     expect(config.logging.level).toBe('debug');
     expect(config.logging.format).toBe('pretty');
     expect(config.logging.destinations).toEqual([
-      { type: 'stdout' },
+      { type: 'stderr' },
       { type: 'file', path: resolve(process.cwd(), 'var/log/eos-mcp.log') }
     ]);
     expect(config.httpGateway.security).toEqual({
@@ -129,7 +129,7 @@ describe('configuration', () => {
         target: 'pino-syslog',
         options: { host: 'logs.internal', port: 1514 }
       },
-      { type: 'stdout' }
+      { type: 'stderr' }
     ]);
   });
 

--- a/src/server/__tests__/bootstrapHandshake.test.ts
+++ b/src/server/__tests__/bootstrapHandshake.test.ts
@@ -38,7 +38,7 @@ jest.mock('../../config/index.js', () => ({
     logging: {
       level: 'info',
       format: 'json',
-      destinations: [{ type: 'stdout' }]
+      destinations: [{ type: 'stderr' }]
     },
     httpGateway: {
       trustProxy: false,

--- a/src/server/__tests__/cli.test.ts
+++ b/src/server/__tests__/cli.test.ts
@@ -144,7 +144,41 @@ describe('override de configuration', () => {
     const overridden = applyBootstrapOverrides(baseConfig, { forceJsonLogs: true });
 
     expect(overridden.logging.format).toBe('json');
-    expect(overridden.logging.destinations).toEqual([{ type: 'stdout' }]);
+    expect(overridden.logging.destinations).toEqual([
+      { type: 'file', path: '/var/log/eos/mcp.log' }
+    ]);
     expect(baseConfig.logging.destinations).toEqual([{ type: 'file', path: '/var/log/eos/mcp.log' }]);
+  });
+
+  it('convertit la destination stdout en stderr lorsque les logs JSON sont forcés', () => {
+    const baseConfig: AppConfig = {
+      mcp: { tcpPort: undefined },
+      osc: {
+        remoteAddress: '127.0.0.1',
+        tcpPort: 3032,
+        udpOutPort: 8001,
+        udpInPort: 8000,
+        localAddress: '0.0.0.0'
+      },
+      logging: {
+        level: 'info',
+        format: 'pretty',
+        destinations: [{ type: 'stdout' }]
+      },
+      httpGateway: {
+        trustProxy: false,
+        security: {
+          apiKeys: [],
+          mcpTokens: [],
+          ipAllowlist: [],
+          allowedOrigins: [],
+          rateLimit: { windowMs: 60000, max: 60 }
+        }
+      }
+    };
+
+    const overridden = applyBootstrapOverrides(baseConfig, { forceJsonLogs: true });
+
+    expect(overridden.logging.destinations).toEqual([{ type: 'stderr' }]);
   });
 });

--- a/src/server/__tests__/serverVersion.test.ts
+++ b/src/server/__tests__/serverVersion.test.ts
@@ -38,7 +38,7 @@ jest.mock('../../config/index.js', () => ({
     logging: {
       level: 'info',
       format: 'json',
-      destinations: [{ type: 'stdout' }]
+      destinations: [{ type: 'stderr' }]
     },
     httpGateway: {
       trustProxy: false,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,7 +5,7 @@ initialiseEnv();
 import type { AddressInfo } from 'node:net';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { getConfig, type AppConfig } from '../config/index';
+import { getConfig, type AppConfig, type LoggingDestination } from '../config/index';
 import {
   createOscGatewayFromEnv,
   OscConnectionGateway,
@@ -292,12 +292,23 @@ function applyBootstrapOverrides(
     return config;
   }
 
+  const destinations: LoggingDestination[] =
+    config.logging.destinations.length > 0
+      ? config.logging.destinations.map((destination): LoggingDestination => {
+          if (destination.type === 'stdout') {
+            return { type: 'stderr' };
+          }
+
+          return destination;
+        })
+      : [{ type: 'stderr' }];
+
   return {
     ...config,
     logging: {
       ...config.logging,
       format: 'json',
-      destinations: [{ type: 'stdout' }]
+      destinations
     }
   } satisfies AppConfig;
 }

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -17,19 +17,26 @@ function createDestinationStream(
   destination: LoggingDestination,
   format: AppConfig['logging']['format']
 ): DestinationStream {
+  const createStdioDestination = (): DestinationStream => {
+    if (format === 'pretty') {
+      return pino.transport({
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+          translateTime: 'SYS:standard',
+          destination: process.stderr.fd
+        }
+      });
+    }
+
+    return pino.destination({ dest: process.stderr.fd, sync: false });
+  };
+
   switch (destination.type) {
     case 'stdout':
-      if (format === 'pretty') {
-        return pino.transport({
-          target: 'pino-pretty',
-          options: {
-            colorize: true,
-            translateTime: 'SYS:standard'
-          }
-        });
-      }
-
-      return pino.destination({ dest: process.stdout.fd, sync: false });
+      return createStdioDestination();
+    case 'stderr':
+      return createStdioDestination();
     case 'file':
       return pino.transport({
         target: 'pino/file',


### PR DESCRIPTION
## Summary
- route the stdout logging destination through process.stderr and accept an explicit stderr target
- normalize application config and CLI overrides to convert stdout destinations to stderr automatically
- document that MCP reserves STDOUT and update tests to expect stderr logging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6904b5786cf0832aaabab61a4dc3756e