### PR TITLE
Allow overriding OSC send targets

### DIFF
--- a/src/services/osc/gateway.ts
+++ b/src/services/osc/gateway.ts
@@ -116,13 +116,17 @@ export class OscConnectionGateway implements OscGateway {
   public async send(message: OscMessage, options: OscGatewaySendOptions = {}): Promise<void> {
     const toolId = normaliseToolId(options.toolId, message);
     const encoded = this.encodeMessage(message);
+    const overrides =
+      options.targetAddress !== undefined || options.targetPort !== undefined
+        ? { targetAddress: options.targetAddress, targetPort: options.targetPort }
+        : undefined;
 
     if (options.transportPreference) {
       this.setToolPreference(toolId, options.transportPreference);
     }
 
     const attemptSend = (): void => {
-      const transport = this.manager.send(toolId, encoded);
+      const transport = this.manager.send(toolId, encoded, undefined, overrides);
       this.updateStats('outgoing', message, encoded.byteLength);
       if (this.loggingState.outgoing) {
         this.logger.debug(


### PR DESCRIPTION
## Summary
- allow the OSC connection manager to accept optional target overrides and apply them to UDP sends
- propagate custom destination overrides through the gateway
- extend unit tests to cover sending to custom destinations

## Testing
- npm test -- gateway
- npm test -- connectionManager

------
https://chatgpt.com/codex/tasks/task_e_6904c7f7ab34832a8652e92162224a54