### PR TITLE
Update group OSC endpoints

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1573,7 +1573,7 @@ _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/group/info s:'{"group_number":1}'
+oscsend 127.0.0.1 8001 /eos/get/group s:'{"group_number":1}'
 ```
 
 <a id="eos-group-list-all"></a>
@@ -1603,7 +1603,7 @@ _OSC_
 
 ```bash
 # Exemple d'envoi OSC via oscsend
-oscsend 127.0.0.1 8001 /eos/group/list s:'{"timeoutMs":1}'
+oscsend 127.0.0.1 8001 /eos/get/group/list s:'{"timeoutMs":1}'
 ```
 
 <a id="eos-group-select"></a>

--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -14,8 +14,8 @@ export const oscMappings = {
   groups: {
     select: '/eos/group',
     level: '/eos/group/{group}/level',
-    info: '/eos/group/info',
-    list: '/eos/group/list'
+    info: '/eos/get/group',
+    list: '/eos/get/group/list'
   },
   palettes: {
     info: '/eos/get/palette',


### PR DESCRIPTION
## Summary
- update OSC group info and list mappings to use /eos/get endpoints
- align group documentation examples with the new OSC addresses

## Testing
- npm test -- groups

------
https://chatgpt.com/codex/tasks/task_e_69078260e538832a8f1493b0e3226d82