### PR TITLE
Handle missing group data responses

### DIFF
--- a/src/tools/groups/__tests__/groups.test.ts
+++ b/src/tools/groups/__tests__/groups.test.ts
@@ -101,6 +101,7 @@ describe('group tools', () => {
     expect(structuredContent).toMatchObject({
       action: 'get_info',
       status: 'ok',
+      exists: true,
       group: {
         group_number: 3,
         label: 'Chorus',
@@ -167,6 +168,38 @@ describe('group tools', () => {
           members: []
         }
       ]
+    });
+  });
+
+  it('signale un groupe introuvable lorsque la console ne renvoie pas de bloc', async () => {
+    const promise = runTool(eosGroupGetInfoTool, { group_number: 9 });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: oscMappings.groups.info,
+        args: [
+          {
+            type: 's',
+            value: JSON.stringify({
+              status: 'ok'
+            })
+          }
+        ]
+      });
+    });
+
+    const result = await promise;
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
+    }
+
+    expect(structuredContent).toMatchObject({
+      action: 'get_info',
+      status: 'ok',
+      exists: false,
+      group: null
     });
   });
 


### PR DESCRIPTION
## Summary
- include both `group` and `group_number` keys when requesting group info over OSC
- stop synthesising empty group responses and surface an `exists` flag with "introuvable" messaging
- add coverage for consoles that omit the group block entirely

## Testing
- npm test -- --runTestsByPath src/tools/groups/__tests__/groups.test.ts

------
https://chatgpt.com/codex/tasks/task_e_690783b43258832ab3a4abaca159df44