### PR TITLE
Handle missing preset info responses

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2210,7 +2210,7 @@ oscsend 127.0.0.1 8001 /eos/preset/fire s:'{"preset_number":1}'
 | `targetPort` | number | Non | — |
 | `timeoutMs` | number | Non | — |
 
-**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS. Le champ `structuredContent.preset.exists` indique si les détails du preset ont été fournis (`false` lorsque le preset est introuvable).
 
 **Exemples :**
 


### PR DESCRIPTION
## Summary
- detect missing preset containers and surface them as `exists: false`
- show a "Preset … introuvable" summary and structured payload when details are absent
- extend preset tool tests and docs to cover the new `exists` flag

## Testing
- npm test -- src/tools/presets/__tests__/presets.test.ts

------
https://chatgpt.com/codex/tasks/task_e_6907850056b8832a8a83386088ce42e6