### PR TITLE
Enhance channel info mapping

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -152,7 +152,13 @@ oscsend 127.0.0.1 8001 /eos/bp/fire s:'{"palette_number":1}'
 | `targetPort` | number | Non | — |
 | `timeoutMs` | number | Non | — |
 
-**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec :
+
+- Un résumé texte indiquant le nombre de canaux trouvés et manquants.
+- Un `structuredContent` détaillant :
+  - `channels` (liste ordonnée des canaux demandés avec les clés `channel`, `exists` et `info`).
+  - `summary` (`{ requested, found, missing }`).
+  - Les champs `request`, `status`, `data`, `error` et `osc` pour analyse et suivi.
 
 **Exemples :**
 


### PR DESCRIPTION
## Summary
- map EOS channel info responses into per-channel structures with presence flags and summary counts
- update the `eos_channel_get_info` handler to compute summaries from actual hits/misses and expose the structured data
- cover complete, partial, and empty responses in tests and document the structured payload shape

## Testing
- npm test -- channels

------
https://chatgpt.com/codex/tasks/task_e_69078edaa674832abc307ea8126dbbdb