### PR TITLE
Ensure early logger output uses stderr

### DIFF
--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -8,10 +8,13 @@ import type { AppConfig, LoggingDestination } from '../config/index';
 
 type LoggerFactory = () => Logger;
 
-let baseLogger: Logger = pino({
-  base: undefined,
-  timestamp: stdTimeFunctions.isoTime
-});
+let baseLogger: Logger = pino(
+  {
+    base: undefined,
+    timestamp: stdTimeFunctions.isoTime
+  },
+  pino.destination({ dest: process.stderr.fd, sync: false })
+);
 
 function createDestinationStream(
   destination: LoggingDestination,


### PR DESCRIPTION
## Summary
- create the initial base logger with a stderr destination so early logs align with the configured sink

## Testing
- OSC_TCP_PORT=abc node dist/server/index.js > /tmp/stdout.log 2> /tmp/stderr.log
- cat /tmp/stdout.log
- cat /tmp/stderr.log

------
https://chatgpt.com/codex/tasks/task_e_69079ce97088832aa7d254dc16101473