### PR TITLE
Réorganise le cookbook MCP autour des sections critiques du manuel

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,51 +1,109 @@
 # Cookbook d'automatisation Eos MCP
 
-Ce guide rassemble des scénarios prêts à l'emploi pour piloter la console ETC Eos via la passerelle MCP. Chaque section combine un rappel métier, un exemple JSON directement exploitable dans un client MCP et la commande OSC correspondante (commentée) pour vos tests manuels. Les fiches d'outils détaillées sont disponibles dans [docs/tools.md](tools.md) ; les ancres sont rappelées ci-dessous pour passer rapidement de la recette à la référence complète.
+Ce guide rassemble des scénarios prêts à l'emploi pour piloter la console ETC Eos via la passerelle MCP. Chaque fiche combine un rappel métier, un exemple JSON, la commande OSC correspondante et un encart « Référence Eos » pointant vers la bonne section du manuel (`docs/eos_serie.pdf`). Consultez également [docs/tools.md](tools.md) pour les schémas complets de chaque outil MCP.
 
-## Déclencher et rattraper une cue
+## Préparer les circuits avant `Record`
 
 ### Objectif
-Assurer un top lumière depuis un LLM ou un workflow d'automatisation, tout en gardant la main pour annuler/rattraper immédiatement si nécessaire.
+Valider une sélection de canaux depuis un workflow automatisé avant toute commande `Record` manuelle sur la console.
+
+### Check-list
+- [ ] S'assurer que la sélection courante correspond aux circuits visés (p. 172–174).
+- [ ] Vérifier les niveaux d'intensité affichés avant enregistrement (p. 177).
+- [ ] Utiliser `Home` si nécessaire pour repartir d'un état neutre (p. 193).
+
+> 📘 **Référence Eos** : [Sélection de circuits & intensité (p. 172–178)](manual://eos#selection-circuits)
 
 ### Outils MCP mobilisés
-- [`eos_cue_go`](tools.md#eos-cue-go) : lance la prochaine cue d'une liste.
-- [`eos_cue_stop_back`](tools.md#eos-cue-stop-back) : stoppe la lecture en cours ou revient à la cue précédente.
+- [`eos_channel_select`](tools.md#eos-channel-select) : prépare la sélection de circuits côté console.
+- [`eos_channel_get_info`](tools.md#eos-channel-get-info) : audite les niveaux en cours avant `Record`.
 
 ### Requête MCP (JSON)
 ```json
 {
   "type": "call_tool",
-  "tool": "eos_cue_go",
+  "tool": "eos_channel_select",
   "arguments": {
-    "cuelist_number": 1
+    "channels": [101, 102, 201],
+    "exclusive": true
   }
 }
 ```
 
-> 💡 Ajustez `cuelist_number` si vous utilisez plusieurs listes dans le show. Combinez cette requête avec un ID de conversation côté LLM pour tracer vos déclenchements.
+> 💡 Chaînez immédiatement `eos_channel_get_info` pour journaliser les niveaux retournés dans votre orchestrateur.
 
 ### Commandes OSC commentées
 ```bash
-# GO sur la liste 1 (port UDP sortant par défaut : 8001)
-oscsend 127.0.0.1 8001 /eos/cue/1/go s:'{"cuelist_number":1}'
+# Sélection exclusive des canaux 101, 102 et 201
+oscsend 127.0.0.1 8001 /eos/cmd s:'Chan 101 Thru 102 + 201 Enter'
 
-# STOP/BACK sur la même liste pour annuler le top
-oscsend 127.0.0.1 8001 /eos/cue/1/stop_back s:'{"cuelist_number":1}'
+# Lecture des informations de niveau sur les mêmes canaux
+oscsend 127.0.0.1 8001 /eos/get/channel s:'{"channels":[101,102,201]}'
 ```
 
 ### Astuces d'intégration
-- Encapsulez `eos_cue_go` dans une commande « safe » côté LLM : demandez une confirmation écrite avant l'appel final.
-- Connectez un webhook de monitoring sur le log `ToolExecutionResult` pour tracer qui a déclenché le GO et à quelle heure.
+- Stockez le résultat `structuredContent.channels` de `eos_channel_get_info` pour garder une trace des niveaux au moment du `Record`.
+- Combinez cette étape avec une validation humaine (« OK pour enregistrer ? ») dans votre chatbot afin de respecter les procédures de plateau.
 
-## Orchestrer vos presets
+## Capturer et rappeler une palette couleur
 
 ### Objectif
-Rappeler, présélectionner ou auditer un preset lumière pour préparer un tableau sans casser la balance actuelle.
+Automatiser la préparation ou le rappel d'une palette couleur tout en respectant les prérequis du manuel avant un `Record Palette`.
+
+### Check-list
+- [ ] Sélectionner les circuits et attributs concernés (p. 172–174).
+- [ ] Confirmer le type de palette (`Color`, `Focus`, etc.) et les options associées (p. 228–229).
+- [ ] Vérifier les valeurs capturées en Live avant l'enregistrement (p. 230–233).
+
+> 📘 **Référence Eos** : [Palettes : enregistrement et rappel (p. 228–235)](manual://eos#palettes-live)
 
 ### Outils MCP mobilisés
-- [`eos_preset_get_info`](tools.md#eos-preset-get-info) : récupère label, niveaux et métadonnées du preset.
-- [`eos_preset_select`](tools.md#eos-preset-select) : prépare le preset sur le clavier virtuel Eos.
-- [`eos_preset_fire`](tools.md#eos-preset-fire) : applique immédiatement le preset aux canaux concernés.
+- [`eos_palette_get_info`](tools.md#eos-palette-get-info) : audit d'une palette existante.
+- [`eos_color_palette_fire`](tools.md#eos-color-palette-fire) : rappel immédiat d'une palette couleur.
+
+### Requête MCP (JSON)
+```json
+{
+  "type": "call_tool",
+  "tool": "eos_palette_get_info",
+  "arguments": {
+    "palette_type": "cp",
+    "palette_number": 21
+  }
+}
+```
+
+> 💡 Vérifiez le champ `absolute` dans la réponse pour confirmer si la palette référence encore des presets (p. 229).
+
+### Commandes OSC commentées
+```bash
+# Audit de la palette couleur 21
+oscsend 127.0.0.1 8001 /eos/get/palette s:'{"palette_type":"cp","palette_number":21}'
+
+# Rappel immédiat de la palette couleur 21
+oscsend 127.0.0.1 8001 /eos/cp/fire s:'{"palette_number":21}'
+```
+
+### Astuces d'intégration
+- Ajoutez une étape automatique pour vérifier que les circuits LED sont bien sélectionnés avant d'afficher la fenêtre `Record Palette`.
+- Exploitez la réponse JSON pour générer une fiche rappelant les canaux et le mode (absolu/relatif) avant de déclencher un `Record` manuel.
+
+## Enregistrer et vérifier un preset
+
+### Objectif
+Préparer un preset à enregistrer ou à rappeler en orchestrant les vérifications recommandées par le manuel.
+
+### Check-list
+- [ ] Relire les options de preset (mode absolu/relatif, attributs inclus) avant enregistrement (p. 242–243).
+- [ ] Confirmer la sélection de canaux et les niveaux prévus (p. 244–246).
+- [ ] Nettoyer les circuits superflus via `Delete` ou `Record Only` si besoin (p. 250).
+
+> 📘 **Référence Eos** : [Presets : enregistrement et rappel (p. 242–247)](manual://eos#presets-live)
+
+### Outils MCP mobilisés
+- [`eos_preset_get_info`](tools.md#eos-preset-get-info) : contrôle des contenus avant modification.
+- [`eos_preset_select`](tools.md#eos-preset-select) : préparation du preset sur le clavier virtuel.
+- [`eos_preset_fire`](tools.md#eos-preset-fire) : rappel immédiat une fois validé.
 
 ### Requête MCP (JSON)
 ```json
@@ -59,31 +117,82 @@ Rappeler, présélectionner ou auditer un preset lumière pour préparer un tabl
 }
 ```
 
-> 💡 Débutez toujours par `eos_preset_get_info` pour vérifier l'état avant rappel. Les champs optionnels permettent de limiter la taille de la réponse si vous intégrez le résultat dans une interface.
+> 💡 Utilisez `fields` pour limiter la taille de la réponse si vous affichez le résultat dans une interface de supervision.
 
 ### Commandes OSC commentées
 ```bash
-# Inspection du preset 12 (réponse JSON renvoyée sur le port UDP entrant du serveur MCP)
-oscsend 127.0.0.1 8001 /eos/preset/info s:'{"preset_number":12}'
+# Inspection du preset 12
+oscsend 127.0.0.1 8001 /eos/get/preset s:'{"preset_number":12}'
 
-# Mise en sélection du preset 12 pour prévisualiser au clavier
-oscsend 127.0.0.1 8001 /eos/preset/12/select s:'{"preset_number":12}'
+# Préparation du preset 12 sur le clavier virtuel
+oscsend 127.0.0.1 8001 /eos/preset s:'{"preset_number":12}'
 
-# Rappel immédiat du preset 12 sur scène
-oscsend 127.0.0.1 8001 /eos/preset/12/fire s:'{"preset_number":12}'
+# Rappel immédiat du preset 12
+oscsend 127.0.0.1 8001 /eos/preset/fire s:'{"preset_number":12}'
 ```
 
 ### Astuces d'intégration
-- Enchaînez la sélection (`select`) puis le rappel (`fire`) dans un même script MCP si vous souhaitez valider la balance avec un opérateur avant application.
-- Enregistrez la réponse de `eos_preset_get_info` pour alimenter vos fiches régie ou générer un rapport de focale.
+- Programmez un résumé automatique (label, canaux, effets) à afficher au pupitreur avant l'enregistrement.
+- Archivez la réponse `structuredContent` pour retracer l'historique de vos presets et faciliter les retours arrière.
+
+## Déclencher et rattraper une cue
+
+### Objectif
+Assurer un top lumière depuis un LLM ou un workflow d'automatisation, tout en gardant la main pour annuler/rattraper immédiatement si nécessaire.
+
+### Check-list
+- [ ] Identifier la cuelist active et son mode d'enregistrement (p. 255–258).
+- [ ] Vérifier les temps, follows et attributs associés à la cue cible (p. 261–264, p. 269).
+- [ ] Contrôler le Playback Status Display ou les faders assignés avant de lancer le GO (p. 323–326).
+
+> 📘 **Référence Eos** :
+> - [Temps & attributs de cue (p. 261–269)](manual://eos#cue-timing)
+> - [Restitution des cues (p. 315–328)](manual://eos#cue-playback)
+
+### Outils MCP mobilisés
+- [`eos_cue_go`](tools.md#eos-cue-go) : lance la prochaine cue d'une liste.
+- [`eos_cue_stop_back`](tools.md#eos-cue-stop-back) : stoppe ou recule la lecture en cours.
+
+### Requête MCP (JSON)
+```json
+{
+  "type": "call_tool",
+  "tool": "eos_cue_go",
+  "arguments": {
+    "cuelist_number": 1
+  }
+}
+```
+
+> 💡 Ajustez `cuelist_number` pour cibler la liste pertinente et tracez l'appel via un identifiant de conversation dans votre orchestrateur.
+
+### Commandes OSC commentées
+```bash
+# GO sur la liste 1 (port UDP sortant par défaut : 8001)
+oscsend 127.0.0.1 8001 /eos/cue/1/go s:'{"cuelist_number":1}'
+
+# STOP/BACK sur la même liste pour annuler le top
+oscsend 127.0.0.1 8001 /eos/cue/1/stop_back s:'{"cuelist_number":1}'
+```
+
+### Astuces d'intégration
+- Encapsulez `eos_cue_go` dans une commande « safe » (double confirmation, timer de sécurité) pour éviter tout déclenchement intempestif.
+- Connectez un webhook de monitoring sur le log `ToolExecutionResult` pour tracer qui a déclenché le GO et à quelle heure.
 
 ## Ajuster l'intensité en live
 
 ### Objectif
-Réaliser un « fade » rapide ou un ajustement ponctuel de niveau depuis un assistant conversationnel sans ouvrir le clavier physique.
+Réaliser un « fade » rapide ou un ajustement ponctuel de niveau depuis un assistant conversationnel sans ouvrir le clavier physique.
+
+### Check-list
+- [ ] Sélectionner les circuits visés avant l'ajustement (p. 172–174).
+- [ ] Confirmer la valeur cible ou utiliser `Sneak` pour un retour progressif (p. 177, p. 201).
+- [ ] Vérifier que les circuits ne sont pas capturés ou exclus d'un Master (p. 310, p. 376).
+
+> 📘 **Référence Eos** : [Sélection de circuits & intensité (p. 172–178)](manual://eos#selection-circuits)
 
 ### Outil MCP mobilisé
-- [`eos_channel_set_level`](tools.md#eos-channel-set-level) : fixe la valeur (0–100 %) d'un canal.
+- [`eos_channel_set_level`](tools.md#eos-channel-set-level) : fixe la valeur (0–100 %) d'un canal.
 
 ### Requête MCP (JSON)
 ```json
@@ -97,11 +206,11 @@ Réaliser un « fade » rapide ou un ajustement ponctuel de niveau depuis un a
 }
 ```
 
-> 💡 Vous pouvez fournir un seul canal (`"channels": 101`) ou une plage (`"channels": "101-110"`) selon vos besoins. Le champ `level` accepte une valeur numérique ou des mots-clés (`"FULL"`, `"OUT"`).
+> 💡 Fournissez une plage (`"101-110"`) pour piloter une rampe complète ou utilisez `"FULL"`/`"OUT"` pour appliquer les raccourcis mentionnés dans le manuel (p. 197).
 
 ### Commande OSC commentée
 ```bash
-# Mise à 65 % des canaux 101 et 102
+# Mise à 65 % des canaux 101 et 102
 oscsend 127.0.0.1 8001 /eos/cmd s:"Chan 101 Thru 102 Sneak 65 Enter"
 ```
 
@@ -109,8 +218,8 @@ oscsend 127.0.0.1 8001 /eos/cmd s:"Chan 101 Thru 102 Sneak 65 Enter"
 - Combinez cette recette avec `eos_group_set_level` si vous pilotez des groupes plutôt que des canaux individuels.
 - Pour animer un fade, déclenchez plusieurs appels `eos_channel_set_level` espacés dans le temps (par exemple via un workflow n8n) en ajustant la valeur progressivement.
 
-## Aller plus loin
+## Ressources complémentaires
 - Les commandes CLI générées automatiquement sont disponibles dans [`docs/tools.md`](tools.md) pour chaque outil.
-- Ajoutez des validations côté LLM (ex. : confirmation vocale) avant d'exécuter une commande critique.
+- Ajoutez des validations côté LLM (ex. : confirmation vocale) avant d'exécuter une commande critique.
 - Utilisez les champs `targetAddress` / `targetPort` lorsque le serveur MCP doit router des messages vers une console distante spécifique.
-- Pour affiner le choix du transport OSC lors des requêtes JSON, ajoutez `transportPreference` (`"reliability"`, `"speed"` ou `"auto"`) et, si besoin, un `toolId` personnalisé : ces options sont transmises au client OSC pour sélectionner le canal TCP/UDP adéquat.
+- Pour affiner le choix du transport OSC lors des requêtes JSON, ajoutez `transportPreference` (`"reliability"`, `"speed"` ou `"auto"`) et, si besoin, un `toolId` personnalisé : ces options sont transmises au client OSC pour sélectionner le canal TCP/UDP adéquat.

--- a/src/resources/registerManual.ts
+++ b/src/resources/registerManual.ts
@@ -20,7 +20,43 @@ interface ManualSection {
   extractContent?: ManualSectionExtractor;
 }
 
-const manualSections: readonly ManualSection[] = [];
+const manualSections: readonly ManualSection[] = [
+  {
+    id: 'selection-circuits',
+    uri: `${MANUAL_URI}#selection-circuits`,
+    title: 'Sélection de circuits et réglage des niveaux',
+    description: 'Sélection de circuits, réglage d’intensité et gestion des paramètres manuels.',
+    pageRange: { start: 172, end: 178 }
+  },
+  {
+    id: 'palettes-live',
+    uri: `${MANUAL_URI}#palettes-live`,
+    title: 'Palettes : enregistrement et rappel',
+    description: 'Types de palettes, options et enregistrement en Live ou en Blind.',
+    pageRange: { start: 228, end: 235 }
+  },
+  {
+    id: 'presets-live',
+    uri: `${MANUAL_URI}#presets-live`,
+    title: 'Presets : enregistrement et rappel',
+    description: 'Options de preset, enregistrement en Live et édition.',
+    pageRange: { start: 242, end: 247 }
+  },
+  {
+    id: 'cue-timing',
+    uri: `${MANUAL_URI}#cue-timing`,
+    title: 'Temps et attributs de cue',
+    description: 'Gestion des temps, follows et attributs de cue.',
+    pageRange: { start: 261, end: 269 }
+  },
+  {
+    id: 'cue-playback',
+    uri: `${MANUAL_URI}#cue-playback`,
+    title: 'Restitution des cues',
+    description: 'Commandes de playback, contrôle manuel et navigation dans les cuelists.',
+    pageRange: { start: 315, end: 328 }
+  }
+];
 
 let cachedManual: { buffer: Buffer; filePath: string } | undefined;
 


### PR DESCRIPTION
## Summary
- restructure `docs/cookbook.md` en ajoutant de nouvelles fiches scénarios, des check-lists et des encarts « Référence Eos » alignés sur les étapes critiques du manuel
- met à jour les renvois vers les outils MCP existants pour couvrir la sélection de circuits, les palettes couleur, les presets et le pilotage des cues
- enregistre dans `registerManual.ts` les sections PDF `manual://eos#…` correspondantes avec leurs plages de pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907e57bee04832a92add0cffaf11824