### PR TITLE
Add resource registration mocks to MCP server tests

### DIFF
--- a/src/server/__tests__/bootstrapHandshake.test.ts
+++ b/src/server/__tests__/bootstrapHandshake.test.ts
@@ -5,6 +5,8 @@ const mockConnect = jest.fn();
 const mockClose = jest.fn().mockResolvedValue(undefined);
 const mockRegisterTool = jest.fn();
 const mockSendToolListChanged = jest.fn();
+const mockRegisterResource = jest.fn().mockReturnValue({ dispose: jest.fn() });
+const mockSendResourceListChanged = jest.fn();
 const mockAssertTcpPortAvailable = jest.fn();
 const mockAssertUdpPortAvailable = jest.fn();
 
@@ -12,7 +14,9 @@ const MockMcpServer = jest.fn().mockImplementation(() => ({
   connect: jest.fn().mockResolvedValue(undefined),
   close: mockClose,
   registerTool: mockRegisterTool,
-  sendToolListChanged: mockSendToolListChanged
+  sendToolListChanged: mockSendToolListChanged,
+  registerResource: mockRegisterResource,
+  sendResourceListChanged: mockSendResourceListChanged
 }));
 
 jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({

--- a/src/server/__tests__/serverVersion.test.ts
+++ b/src/server/__tests__/serverVersion.test.ts
@@ -5,6 +5,8 @@ const mockConnect = jest.fn();
 const mockClose = jest.fn().mockResolvedValue(undefined);
 const mockRegisterTool = jest.fn();
 const mockSendToolListChanged = jest.fn();
+const mockRegisterResource = jest.fn().mockReturnValue({ dispose: jest.fn() });
+const mockSendResourceListChanged = jest.fn();
 const mockAssertTcpPortAvailable = jest.fn();
 const mockAssertUdpPortAvailable = jest.fn();
 
@@ -12,7 +14,9 @@ const MockMcpServer = jest.fn().mockImplementation(() => ({
   connect: mockConnect,
   close: mockClose,
   registerTool: mockRegisterTool,
-  sendToolListChanged: mockSendToolListChanged
+  sendToolListChanged: mockSendToolListChanged,
+  registerResource: mockRegisterResource,
+  sendResourceListChanged: mockSendResourceListChanged
 }));
 
 jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({


### PR DESCRIPTION
## Summary
- extend MockMcpServer in bootstrapHandshake.test to include resource registration stubs
- mirror resource registration methods in serverVersion.test mocks to support manual resource registration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907eb9087bc832aa19051fbf5e4ec9e