### PR TITLE
Mark manual section resources as read when accessed

### DIFF
--- a/src/resources/registerManual.ts
+++ b/src/resources/registerManual.ts
@@ -167,7 +167,10 @@ async function registerManualSections(
       title: section.title,
       description: section.description,
       base64Data,
-      metadata
+      metadata,
+      onRead: ({ sessionId }) => {
+        markManualDocumentationRead(sessionId);
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- ensure each manual subsection resource updates the manual read tracker when accessed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907f06de470832a8ed8952398c637a6