### PR TITLE
Fix manual resource handler typings

### DIFF
--- a/src/resources/registerManual.ts
+++ b/src/resources/registerManual.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import { readFile } from 'node:fs/promises';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sdk/types.js';
 import { markManualDocumentationRead } from './manualReadTracker';
 
 const MANUAL_FILENAME = 'eos_serie.pdf';
@@ -129,7 +131,10 @@ function registerPdfResource(
       description,
       mimeType: MANUAL_MIME_TYPE
     },
-    async (_uri, extra) => {
+    async (
+      _uri: URL,
+      extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+    ) => {
       onRead?.({ sessionId: extra?.sessionId });
 
       return {

--- a/src/types/modelcontextprotocol__sdk.d.ts
+++ b/src/types/modelcontextprotocol__sdk.d.ts
@@ -31,9 +31,17 @@ declare module '@modelcontextprotocol/sdk/server/streamableHttp.js' {
 declare module '@modelcontextprotocol/sdk/types' {
   export * from '@modelcontextprotocol/sdk/dist/esm/types.js';
   export { ErrorCode, isInitializeRequest } from '@modelcontextprotocol/sdk/dist/esm/types.js';
+  export type {
+    ServerNotification,
+    ServerRequest
+  } from '@modelcontextprotocol/sdk/dist/esm/types.js';
 }
 
 declare module '@modelcontextprotocol/sdk/types.js' {
   export * from '@modelcontextprotocol/sdk/dist/esm/types.js';
   export { ErrorCode, isInitializeRequest } from '@modelcontextprotocol/sdk/dist/esm/types.js';
+  export type {
+    ServerNotification,
+    ServerRequest
+  } from '@modelcontextprotocol/sdk/dist/esm/types.js';
 }


### PR DESCRIPTION
## Summary
- import the MCP request handler types required to annotate the manual resource callback
- annotate the manual resource handler parameters to remove implicit any warnings
- update the local SDK module declarations to export the server request/notification types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6907f1c0fb7c832a82b93097ad8a82c2