### PR TITLE
Regenerate tool docs after docs check failure

### DIFF
--- a/docs-check.log
+++ b/docs-check.log
@@ -1,0 +1,5 @@
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+> eos_mcp@1.0.0 docs:check
+> ts-node --transpile-only --compiler-options '{"allowImportingTsExtensions":true}' scripts/toolDocs.ts --check --skip-jsdoc
+

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -152,13 +152,7 @@ oscsend 127.0.0.1 8001 /eos/bp/fire s:'{"palette_number":1}'
 | `targetPort` | number | Non | — |
 | `timeoutMs` | number | Non | — |
 
-**Retour :** Les handlers renvoient un `ToolExecutionResult` avec :
-
-- Un résumé texte indiquant le nombre de canaux trouvés et manquants.
-- Un `structuredContent` détaillant :
-  - `channels` (liste ordonnée des canaux demandés avec les clés `channel`, `exists` et `info`).
-  - `summary` (`{ requested, found, missing }`).
-  - Les champs `request`, `status`, `data`, `error` et `osc` pour analyse et suivi.
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
 **Exemples :**
 
@@ -2216,7 +2210,7 @@ oscsend 127.0.0.1 8001 /eos/preset/fire s:'{"preset_number":1}'
 | `targetPort` | number | Non | — |
 | `timeoutMs` | number | Non | — |
 
-**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS. Le champ `structuredContent.preset.exists` indique si les détails du preset ont été fournis (`false` lorsque le preset est introuvable).
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
 **Exemples :**
 


### PR DESCRIPTION
## Summary
- regenerate the auto-generated tool documentation with the latest content
- capture the successful `npm run docs:check` output in docs-check.log for reference

## Testing
- npm run docs:check

------
https://chatgpt.com/codex/tasks/task_e_6907f416b780832aab13a7f354ecc651