### PR TITLE
feat: centraliser la matrice de compatibilité EOS et exposer son statut

### DIFF
--- a/src/server/__tests__/toolRegistry.test.ts
+++ b/src/server/__tests__/toolRegistry.test.ts
@@ -306,6 +306,54 @@ describe('ToolRegistry schema-less tools', () => {
     expect(payload.result).toMatchObject({ message: 'boom', name: 'Error' });
     expect(payload.durationMs).toEqual(expect.any(Number));
   });
+
+  it('bloque un outil critique si le role requis est incompatible', async () => {
+    const server = createMockServer();
+    const registry = new ToolRegistry(server);
+
+    registry.register({
+      name: 'eos_magic_sheet_send_string',
+      config: { inputSchema: { text: z.string() } },
+      handler: async () => ({
+        content: [{ type: 'text', text: 'ok' }]
+      })
+    });
+
+    const [, , registeredHandler] = server.registerTool.mock.calls[0];
+
+    await expect(
+      (registeredHandler as RegisteredTestHandler)(
+        { text: 'hello' },
+        { connection: { role: 'Secondary' } }
+      )
+    ).rejects.toThrow('incompatible avec le contexte EOS courant');
+  });
+
+  it('autorise un outil critique lorsque le contexte est compatible', async () => {
+    const server = createMockServer();
+    const registry = new ToolRegistry(server);
+
+    const handler = jest.fn(async () => ({
+      content: [{ type: 'text', text: 'ok' }]
+    }));
+
+    registry.register({
+      name: 'eos_magic_sheet_send_string',
+      config: { inputSchema: { text: z.string() } },
+      handler
+    });
+
+    const [, , registeredHandler] = server.registerTool.mock.calls[0];
+
+    await expect(
+      (registeredHandler as RegisteredTestHandler)(
+        { text: 'hello', eos_version: '3.2.0' },
+        { connection: { role: 'Primary' } }
+      )
+    ).resolves.toBeDefined();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
 });
 
 type RegisteredTestHandler = (first: unknown, second?: unknown) => Promise<ToolExecutionResult>;

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -13,6 +13,10 @@ import type {
   ToolContext
 } from '../tools/types';
 import { setCapabilitiesToolNamesProvider } from '../tools/capabilities/context';
+import {
+  evaluateToolCompatibility,
+  resolveCompatibilityContext
+} from '../services/osc/compatibilityMatrix';
 
 const logger = createLogger('tool-registry');
 
@@ -278,8 +282,16 @@ class ToolRegistry {
       address: asObject(args).targetAddress,
       port: asObject(args).targetPort
     };
+    const compatibilityContext = resolveCompatibilityContext(args, extra);
+    const compatibilityStatus = evaluateToolCompatibility(toolName, compatibilityContext);
 
     try {
+      if (this.shouldEnforceCompatibilityGate(toolName) && !compatibilityStatus.compatible) {
+        throw new Error(
+          `Outil ${toolName} incompatible avec le contexte EOS courant: ${compatibilityStatus.reasons.join(' ')}`
+        );
+      }
+
       const result = await runWithRequestContext(
         {
           correlationId,
@@ -300,6 +312,7 @@ class ToolRegistry {
         result: sanitizeValue(result),
         sensitiveAction,
         safetyMode,
+        compatibility: compatibilityStatus,
         durationMs: Date.now() - startedAt,
         status: 'ok'
       });
@@ -317,11 +330,31 @@ class ToolRegistry {
         result: sanitizeValue(error instanceof Error ? { message: error.message, name: error.name } : error),
         sensitiveAction,
         safetyMode,
+        compatibility: compatibilityStatus,
         durationMs: Date.now() - startedAt,
         status: 'error'
       });
       throw error;
     }
+  }
+
+  private shouldEnforceCompatibilityGate(toolName: string): boolean {
+    if (!toolName.startsWith('eos_')) {
+      return false;
+    }
+
+    if (
+      toolName.startsWith('eos_connect') ||
+      toolName.startsWith('eos_configure') ||
+      toolName.startsWith('eos_ping') ||
+      toolName.startsWith('eos_reset') ||
+      toolName.startsWith('eos_subscribe') ||
+      toolName === 'eos_capabilities_get'
+    ) {
+      return false;
+    }
+
+    return true;
   }
 
   private compose(

--- a/src/services/osc/__tests__/compatibilityMatrix.test.ts
+++ b/src/services/osc/__tests__/compatibilityMatrix.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  evaluateToolCompatibility,
+  resolveCompatibilityContext
+} from '../compatibilityMatrix';
+
+describe('compatibilityMatrix', () => {
+  it('applique la regle Primary pour eos_magic_sheet_send_string', () => {
+    const status = evaluateToolCompatibility('eos_magic_sheet_send_string', {
+      eosVersion: '3.2.0',
+      role: 'Backup'
+    });
+
+    expect(status.compatible).toBe(false);
+    expect(status.reasons.join(' ')).toContain('Role requis: Primary');
+  });
+
+  it('applique la regle baseline pour un outil eos standard', () => {
+    const status = evaluateToolCompatibility('eos_cue_go', {
+      eosVersion: '3.1.0',
+      role: 'Unknown'
+    });
+
+    expect(status.compatible).toBe(true);
+    expect(status.requirements.minEosVersion).toBe('3.0.0');
+  });
+
+  it('reconstruit le contexte a partir de args et extra', () => {
+    const context = resolveCompatibilityContext(
+      { eos_version: '3.3.0' },
+      { connection: { role: 'Primary' } }
+    );
+
+    expect(context).toEqual({
+      eosVersion: '3.3.0',
+      role: 'Primary'
+    });
+  });
+});

--- a/src/services/osc/compatibilityMatrix.ts
+++ b/src/services/osc/compatibilityMatrix.ts
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type EosNodeRole = 'Primary' | 'Backup' | 'Unknown';
+
+export interface CompatibilityContext {
+  eosVersion: string | null;
+  role: EosNodeRole;
+}
+
+export interface CompatibilityRule {
+  id: string;
+  minEosVersion: string | null;
+  requiredRole: 'Primary' | 'Backup' | 'Any';
+  functionalAvailability: 'available' | 'limited' | 'unavailable';
+  notes?: string;
+}
+
+interface RuleEntry {
+  matches: (toolName: string) => boolean;
+  rule: CompatibilityRule;
+}
+
+export interface CompatibilityStatus {
+  tool: string;
+  compatible: boolean;
+  reasons: string[];
+  requirements: CompatibilityRule;
+  context: CompatibilityContext;
+}
+
+const BASELINE_RULE: CompatibilityRule = {
+  id: 'baseline-eos-osc-tools',
+  minEosVersion: '3.0.0',
+  requiredRole: 'Any',
+  functionalAvailability: 'available',
+  notes: 'Compatibilite par defaut pour les outils OSC eos_*.'
+};
+
+const COMPATIBILITY_RULES: RuleEntry[] = [
+  {
+    matches: (toolName) => toolName === 'eos_magic_sheet_send_string',
+    rule: {
+      id: 'magic-sheet-send-string-primary-only',
+      minEosVersion: '3.2.0',
+      requiredRole: 'Primary',
+      functionalAvailability: 'available',
+      notes: 'Necessite un noeud Primary pour pouvoir injecter du texte.'
+    }
+  },
+  {
+    matches: (toolName) => toolName.startsWith('eos_connect') || toolName.startsWith('eos_configure') || toolName.startsWith('eos_ping') || toolName.startsWith('eos_reset') || toolName.startsWith('eos_subscribe'),
+    rule: {
+      id: 'connection-tools-bootstrap',
+      minEosVersion: null,
+      requiredRole: 'Any',
+      functionalAvailability: 'available',
+      notes: 'Outils de connexion utilisables meme avant detection de version EOS.'
+    }
+  },
+  {
+    matches: (toolName) => toolName === 'eos_capabilities_get',
+    rule: {
+      id: 'capabilities-meta-tool',
+      minEosVersion: null,
+      requiredRole: 'Any',
+      functionalAvailability: 'available',
+      notes: 'Outil meta; ne doit jamais etre bloque par la matrice.'
+    }
+  }
+];
+
+function parseVersion(version: string): number[] | null {
+  const cleaned = version.trim().replace(/^v/i, '');
+  if (!cleaned) {
+    return null;
+  }
+
+  const parsed = cleaned
+    .split('.')
+    .map((segment) => Number.parseInt(segment.replace(/[^0-9].*$/, ''), 10));
+
+  if (parsed.some((segment) => Number.isNaN(segment))) {
+    return null;
+  }
+
+  return [parsed[0] ?? 0, parsed[1] ?? 0, parsed[2] ?? 0];
+}
+
+function compareVersions(left: string, right: string): number | null {
+  const leftParsed = parseVersion(left);
+  const rightParsed = parseVersion(right);
+
+  if (!leftParsed || !rightParsed) {
+    return null;
+  }
+
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParsed[index]! > rightParsed[index]!) {
+      return 1;
+    }
+    if (leftParsed[index]! < rightParsed[index]!) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function isOscTool(toolName: string): boolean {
+  return toolName.startsWith('eos_');
+}
+
+function resolveRule(toolName: string): CompatibilityRule {
+  const matching = COMPATIBILITY_RULES.find((entry) => entry.matches(toolName));
+  if (matching) {
+    return matching.rule;
+  }
+
+  if (isOscTool(toolName)) {
+    return BASELINE_RULE;
+  }
+
+  return {
+    id: 'non-osc-tool',
+    minEosVersion: null,
+    requiredRole: 'Any',
+    functionalAvailability: 'available',
+    notes: 'Outil non OSC: pas de contrainte de compatibilite EOS.'
+  };
+}
+
+export function evaluateToolCompatibility(toolName: string, context: CompatibilityContext): CompatibilityStatus {
+  const requirements = resolveRule(toolName);
+  const reasons: string[] = [];
+
+  if (requirements.functionalAvailability === 'unavailable') {
+    reasons.push('Fonctionnalite marquee comme indisponible dans la matrice.');
+  }
+
+  if (requirements.requiredRole !== 'Any' && context.role !== 'Unknown' && context.role !== requirements.requiredRole) {
+    reasons.push(`Role requis: ${requirements.requiredRole}, role detecte: ${context.role}.`);
+  }
+
+  if (requirements.requiredRole !== 'Any' && context.role === 'Unknown') {
+    reasons.push(`Role requis: ${requirements.requiredRole}, role detecte: inconnu.`);
+  }
+
+  if (requirements.minEosVersion && context.eosVersion) {
+    const comparison = compareVersions(context.eosVersion, requirements.minEosVersion);
+    if (comparison === null) {
+      reasons.push(`Version EOS non interpretable (${context.eosVersion}). Minimum requis: ${requirements.minEosVersion}.`);
+    } else if (comparison < 0) {
+      reasons.push(`Version EOS detectee ${context.eosVersion} inferieure au minimum ${requirements.minEosVersion}.`);
+    }
+  }
+
+  return {
+    tool: toolName,
+    compatible: reasons.length === 0,
+    reasons,
+    requirements,
+    context
+  };
+}
+
+export function getCompatibilityRulesForTools(toolNames: string[]): Array<{ tool: string; rule: CompatibilityRule }> {
+  return toolNames
+    .map((tool) => ({ tool, rule: resolveRule(tool) }))
+    .sort((left, right) => left.tool.localeCompare(right.tool));
+}
+
+function parseRole(raw: unknown): EosNodeRole {
+  if (typeof raw !== 'string') {
+    return 'Unknown';
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === 'primary') {
+    return 'Primary';
+  }
+  if (normalized === 'backup' || normalized === 'secondary') {
+    return 'Backup';
+  }
+
+  return 'Unknown';
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+export function resolveCompatibilityContext(args: unknown, extra: unknown): CompatibilityContext {
+  const argRecord = asObject(args);
+  const extraRecord = asObject(extra);
+
+  const argConnection = asObject(argRecord.connection);
+  const extraConnection = asObject(extraRecord.connection);
+
+  const eosVersionCandidate =
+    argRecord.eosVersion ??
+    argRecord.eos_version ??
+    extraRecord.eosVersion ??
+    extraRecord.eos_version ??
+    argConnection.eosVersion ??
+    argConnection.eos_version ??
+    extraConnection.eosVersion ??
+    extraConnection.eos_version;
+
+  const roleCandidate =
+    argRecord.role ??
+    argRecord.connectionRole ??
+    argRecord.connection_role ??
+    extraRecord.role ??
+    extraRecord.connectionRole ??
+    extraRecord.connection_role ??
+    argConnection.role ??
+    extraConnection.role;
+
+  return {
+    eosVersion: typeof eosVersionCandidate === 'string' && eosVersionCandidate.trim().length > 0
+      ? eosVersionCandidate.trim()
+      : null,
+    role: parseRole(roleCandidate)
+  };
+}

--- a/src/tools/capabilities/__tests__/capabilities.test.ts
+++ b/src/tools/capabilities/__tests__/capabilities.test.ts
@@ -2,12 +2,9 @@
  * Copyright 2026 Florian Ribes (NairolfConcept)
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { OscMessage } from '../../../services/osc';
 import {
-  OscClient,
   setOscClient,
-  type OscGateway,
-  type OscGatewaySendOptions
+  type OscClient
 } from '../../../services/osc/client';
 import { OscConnectionStateProvider } from '../../../services/osc/connectionState';
 import { setCurrentUserId, clearCurrentUserId } from '../../session';
@@ -16,38 +13,31 @@ import { eosCapabilitiesGetTool } from '../index';
 import { setCapabilitiesToolNamesProvider } from '../context';
 import { oscMappings } from '../../../services/osc/mappings';
 
-class FakeGateway implements OscGateway {
-  public readonly sentMessages: OscMessage[] = [];
-
-  private readonly listeners = new Set<(message: OscMessage) => void>();
-
+class FakeConnectionAwareClient {
   public readonly connectionProvider = new OscConnectionStateProvider();
-
-  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
-    this.sentMessages.push(message);
-  }
-
-  public onMessage(listener: (message: OscMessage) => void): () => void {
-    this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
-  }
-
-  public emit(message: OscMessage): void {
-    this.listeners.forEach((listener) => listener(message));
-  }
 
   public getConnectionStateProvider(): OscConnectionStateProvider {
     return this.connectionProvider;
   }
+
+  public requestJson = jest.fn(async (address: string) => {
+    if (address === oscMappings.showControl.liveBlindState) {
+      return { status: 'ok', data: { status: 'ok', state: 'live' }, payload: null };
+    }
+    if (address === oscMappings.system.getVersion) {
+      return { status: 'ok', data: { status: 'ok', version: '3.2.1' }, payload: null };
+    }
+
+    return { status: 'ok', data: null, payload: null };
+  });
 }
 
 describe('eos_capabilities_get', () => {
-  let gateway: FakeGateway;
+  let client: FakeConnectionAwareClient;
 
   beforeEach(() => {
-    gateway = new FakeGateway();
-    const client = new OscClient(gateway, { defaultTimeoutMs: 50 });
-    setOscClient(client);
+    client = new FakeConnectionAwareClient();
+    setOscClient(client as unknown as OscClient);
 
     setCapabilitiesToolNamesProvider(() => [
       'eos_capabilities_get',
@@ -67,16 +57,7 @@ describe('eos_capabilities_get', () => {
   });
 
   it('retourne les familles, le contexte et les infos serveur', async () => {
-    const promise = runTool(eosCapabilitiesGetTool, {});
-
-    queueMicrotask(() => {
-      gateway.emit({
-        address: oscMappings.showControl.liveBlindState,
-        args: [{ type: 's', value: JSON.stringify({ status: 'ok', state: 'live' }) }]
-      });
-    });
-
-    const result = await promise;
+    const result = await runTool(eosCapabilitiesGetTool, {});
     const structured = getStructuredContent(result);
 
     expect(structured).toBeDefined();
@@ -91,5 +72,14 @@ describe('eos_capabilities_get', () => {
     expect(structured.context.mode.live_blind).toBe('live');
     expect(structured.server.version).toBeDefined();
     expect(structured.server.compatibility.osc_protocol).toBe('ETCOSC');
+    expect(structured.osc_compatibility.context.eos_version).toBe('3.2.1');
+    expect(structured.osc_compatibility.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tool: 'eos_cue_go',
+          min_eos_version: '3.0.0'
+        })
+      ])
+    );
   });
 });

--- a/src/tools/capabilities/index.ts
+++ b/src/tools/capabilities/index.ts
@@ -8,6 +8,10 @@ import { getCurrentUserId } from '../session';
 import type { ToolDefinition, ToolExecutionResult } from '../types';
 import { getPackageVersion, getServerCompatibility } from '../../utils/version';
 import { getCapabilitiesToolNames } from './context';
+import {
+  evaluateToolCompatibility,
+  getCompatibilityRulesForTools
+} from '../../services/osc/compatibilityMatrix';
 
 const emptySchema = {} as const;
 
@@ -88,6 +92,21 @@ function parseLiveBlindLabel(payload: unknown): 'live' | 'blind' | 'unknown' {
   return 'unknown';
 }
 
+function parseDetectedEosVersion(payload: unknown): string | null {
+  if (typeof payload === 'string' && payload.trim().length > 0) {
+    return payload.trim();
+  }
+
+  if (payload && typeof payload === 'object') {
+    const value = (payload as Record<string, unknown>).version;
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
 /**
  * @tool eos_capabilities_get
  * @summary Capacites serveur EOS MCP
@@ -123,12 +142,20 @@ export const eosCapabilitiesGetTool: ToolDefinition<typeof emptySchema> = {
     const client = getOscClient();
     let liveBlindMode: 'live' | 'blind' | 'unknown' = 'unknown';
     let liveBlindRaw: OscJsonResponse | null = null;
+    let detectedEosVersion: string | null = null;
 
     try {
       liveBlindRaw = await client.requestJson(oscMappings.showControl.liveBlindState, { timeoutMs: 400 });
       liveBlindMode = parseLiveBlindLabel(liveBlindRaw.data);
     } catch (_error) {
       liveBlindMode = 'unknown';
+    }
+
+    try {
+      const versionResponse = await client.requestJson(oscMappings.system.getVersion, { timeoutMs: 400 });
+      detectedEosVersion = parseDetectedEosVersion(versionResponse.data);
+    } catch (_error) {
+      detectedEosVersion = null;
     }
 
     const safety = {
@@ -139,12 +166,29 @@ export const eosCapabilitiesGetTool: ToolDefinition<typeof emptySchema> = {
 
     const version = getPackageVersion();
     const compatibility = getServerCompatibility();
+    const compatibilityRules = getCompatibilityRulesForTools(tools);
+    const compatibilityStatuses = compatibilityRules.map(({ tool, rule }) =>
+      evaluateToolCompatibility(tool, {
+        eosVersion: detectedEosVersion,
+        role: 'Unknown'
+      })
+    ).map((status) => ({
+      tool: status.tool,
+      compatible: status.compatible,
+      reasons: status.reasons,
+      min_eos_version: status.requirements.minEosVersion,
+      required_role: status.requirements.requiredRole,
+      functional_availability: status.requirements.functionalAvailability,
+      rule_id: status.requirements.id,
+      notes: status.requirements.notes ?? null
+    }));
 
     const summary = [
       `Capacites disponibles: ${tools.length} outils, ${Object.keys(families).length} familles.`,
       `Connexion OSC: ${oscConnection.health}.`,
       `Utilisateur courant: ${typeof user === 'number' ? user : 'non defini'}.`,
       `Mode console: ${liveBlindMode}.`,
+      `Version EOS detectee: ${detectedEosVersion ?? 'inconnue'}.`,
       `Version serveur: ${version}.`
     ].join(' ');
 
@@ -167,6 +211,13 @@ export const eosCapabilitiesGetTool: ToolDefinition<typeof emptySchema> = {
         server: {
           version,
           compatibility
+        },
+        osc_compatibility: {
+          context: {
+            eos_version: detectedEosVersion,
+            role: 'Unknown'
+          },
+          tools: compatibilityStatuses
         }
       }
     } as ToolExecutionResult;


### PR DESCRIPTION
### Motivation
- Centraliser les règles de compatibilité par outil EOS (version minimale, rôle requis, disponibilité) pour éviter la duplication et prendre des décisions d'exécution cohérentes.
- Empêcher l'exécution d'outils OSC critiques lorsque le contexte console (version EOS / rôle Primary/Backup) ne satisfait pas les exigences.
- Rendre l'information de compatibilité accessible aux clients via l'outil `eos_capabilities_get` afin de guider l'utilisation des outils.

### Description
- Ajout de la matrice centralisée et des helpers dans `src/services/osc/compatibilityMatrix.ts` incluant les types, règles, `evaluateToolCompatibility` et `resolveCompatibilityContext`.
- Injection d'un contrôle de compatibilité dans `ToolRegistry` (`src/server/toolRegistry.ts`) qui résout le contexte, évalue la compatibilité, journalise le statut dans l'audit et bloque l'exécution pour les outils EOS critiques (exceptions pour les outils de bootstrap/diagnostic).
- Extension de `eos_capabilities_get` (`src/tools/capabilities/index.ts`) pour détecter la version EOS via `/eos/get/version` et exposer `osc_compatibility` (contexte + statut par outil) dans le `structuredContent`.
- Ajout / adaptation de tests : `src/services/osc/__tests__/compatibilityMatrix.test.ts`, mises à jour de `src/server/__tests__/toolRegistry.test.ts` et `src/tools/capabilities/__tests__/capabilities.test.ts` pour couvrir les nouveaux comportements.

### Testing
- Lancement complet via le script npm a déclenché la suite entière et a échoué sur tests non liés (comportements existants de validations/`requestJson` dans d'autres modules). Commande utilisée : `npm test -- --runTestsByPath src/tools/capabilities/__tests__/capabilities.test.ts src/server/__tests__/toolRegistry.test.ts src/services/osc/__tests__/compatibilityMatrix.test.ts` (échecs hors périmètre de cette PR).
- Tests ciblés exécutés et verts : `npx jest src/tools/capabilities/__tests__/capabilities.test.ts src/server/__tests__/toolRegistry.test.ts src/services/osc/__tests__/compatibilityMatrix.test.ts` (tous les tests ciblés passent).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3056cb7a0832a82d642db1149e922)