### PR TITLE
Ajout du workflow eos_workflow_create_cue_series

### DIFF
--- a/src/tools/workflows/__tests__/workflows.test.ts
+++ b/src/tools/workflows/__tests__/workflows.test.ts
@@ -7,6 +7,7 @@ import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } 
 import { runTool, getStructuredContent } from '../../__tests__/helpers/runTool';
 import {
   eosWorkflowCreateLookTool,
+  eosWorkflowCreateCueSeriesTool,
   eosWorkflowAutopatchBandTool,
   eosWorkflowPatchFixtureTool,
   eosWorkflowRehearsalGoSafeTool
@@ -108,6 +109,53 @@ describe('workflow tools', () => {
     const structured = getStructuredContent(result);
     expect(structured?.status).toBe('partial_failure');
     expect(structured?.partialErrors).toEqual([{ step: 'apply_color_palette', error: 'Echec simule envoi #2' }]);
+  });
+
+  it('orchestre eos_workflow_create_cue_series avec increment automatique des cues', async () => {
+    const result = await runTool(eosWorkflowCreateCueSeriesTool, {
+      base_cuelist_number: 2,
+      start_cue_number: 10,
+      looks: [
+        { channels: '1 Thru 3', color_palette: 11, cue_label: 'Intro' },
+        { channels: '4 Thru 6', focus_palette: 20, beam_palette: 30, cue_label: 'Verse' }
+      ]
+    });
+
+    const structured = getStructuredContent(result);
+    expect(structured?.status).toBe('ok');
+    expect(structured?.commandsSent).toEqual([
+      'Chan 1 Thru 3',
+      'CP 11',
+      'Record Cue 2/10',
+      'Cue 2/10 Label "Intro"',
+      'Chan 4 Thru 6',
+      'FP 20',
+      'BP 30',
+      'Record Cue 2/11',
+      'Cue 2/11 Label "Verse"'
+    ]);
+  });
+
+  it('genere commands_preview en dry run pour create_cue_series et fallback master cuelist', async () => {
+    const result = await runTool(eosWorkflowCreateCueSeriesTool, {
+      looks: [
+        { channels: '7', cue_label: 'Solo' },
+        { channels: '8', color_palette: 12 }
+      ],
+      dry_run: true
+    });
+
+    expect(service.sentMessages).toHaveLength(0);
+    const structured = getStructuredContent(result);
+    expect(structured?.status).toBe('ok');
+    expect(structured?.commands_preview).toEqual([
+      'Chan 7',
+      'Record Cue 1',
+      'Cue 1 Label "Solo"',
+      'Chan 8',
+      'CP 12',
+      'Record Cue 2'
+    ]);
   });
 
   it('orchestre eos_workflow_patch_fixture avec position 3D par defaut', async () => {

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -159,6 +159,91 @@ export const eosWorkflowCreateLookTool: ToolDefinition<typeof createLookInputSch
   }
 };
 
+const createCueSeriesInputSchema = {
+  base_cuelist_number: cuelistNumberSchema.optional(),
+  start_cue_number: cueNumberSchema.optional().default(1),
+  looks: z.array(z.object({
+    channels: z.string().trim().min(1).max(256),
+    color_palette: z.coerce.number().int().min(1).max(99999).optional(),
+    focus_palette: z.coerce.number().int().min(1).max(99999).optional(),
+    beam_palette: z.coerce.number().int().min(1).max(99999).optional(),
+    cue_label: z.string().trim().min(1).max(128).optional()
+  })).min(1),
+  dry_run: z.boolean().optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
+export const eosWorkflowCreateCueSeriesTool: ToolDefinition<typeof createCueSeriesInputSchema> = {
+  name: 'eos_workflow_create_cue_series',
+  config: {
+    title: 'Workflow creation serie de cues',
+    description: 'Enchaine plusieurs looks et enregistre une serie de cues auto-incrementees.',
+    inputSchema: createCueSeriesInputSchema
+  },
+  handler: async (args) => {
+    const options = z.object(createCueSeriesInputSchema).strict().parse(args ?? {});
+    const dryRun = options.dry_run === true;
+    const steps: WorkflowStepLog[] = [];
+    const partialErrors: Array<{ step: string; error: string }> = [];
+    const commandsPreview: string[] = [];
+    let cueNumber = options.start_cue_number ?? 1;
+
+    for (let index = 0; index < options.looks.length; index += 1) {
+      const look = options.looks[index];
+      const cueStepPrefix = `look_${index + 1}_cue_${cueNumber}`;
+      const commands = [
+        { step: `${cueStepPrefix}_select_channels`, command: `Chan ${look.channels}` },
+        ...(look.color_palette != null ? [{ step: `${cueStepPrefix}_apply_color_palette`, command: `CP ${look.color_palette}` }] : []),
+        ...(look.focus_palette != null ? [{ step: `${cueStepPrefix}_apply_focus_palette`, command: `FP ${look.focus_palette}` }] : []),
+        ...(look.beam_palette != null ? [{ step: `${cueStepPrefix}_apply_beam_palette`, command: `BP ${look.beam_palette}` }] : []),
+        {
+          step: `${cueStepPrefix}_record_cue`,
+          command: buildRecordCueCommand(cueNumber, options.base_cuelist_number)
+        },
+        ...(look.cue_label
+          ? [
+              {
+                step: `${cueStepPrefix}_label_cue`,
+                command: `${formatCueTarget(cueNumber, options.base_cuelist_number)} Label "${look.cue_label.replace(/"/g, '\\"')}"`
+              }
+            ]
+          : [])
+      ];
+
+      for (const commandStep of commands) {
+        commandsPreview.push(commandStep.command);
+        if (dryRun) {
+          steps.push({ step: commandStep.step, status: 'skipped', command: commandStep.command, detail: 'dry_run' });
+          continue;
+        }
+
+        const ok = await runCommandStep(steps, partialErrors, commandStep.step, commandStep.command, options);
+        if (!ok) {
+          return buildWorkflowResult(
+            'eos_workflow_create_cue_series',
+            'partial_failure',
+            `Workflow creation serie cues interrompu a l'etape ${commandStep.step}.`,
+            steps,
+            partialErrors,
+            { ...(dryRun ? { commands_preview: commandsPreview } : {}) }
+          );
+        }
+      }
+
+      cueNumber += 1;
+    }
+
+    return buildWorkflowResult(
+      'eos_workflow_create_cue_series',
+      'ok',
+      dryRun ? 'Dry run creation serie cues genere.' : 'Workflow creation serie cues execute avec succes.',
+      steps,
+      partialErrors,
+      { ...(dryRun ? { commands_preview: commandsPreview } : {}) }
+    );
+  }
+};
+
 const patchFixtureInputSchema = {
   channel_number: z.coerce.number().int().min(1).max(99999),
   dmx_address: z.string().trim().min(1).max(32),
@@ -494,6 +579,7 @@ export const eosWorkflowRehearsalGoSafeTool: ToolDefinition<typeof rehearsalGoSa
 
 export const workflowTools = [
   eosWorkflowCreateLookTool,
+  eosWorkflowCreateCueSeriesTool,
   eosWorkflowPatchFixtureTool,
   eosWorkflowAutopatchBandTool,
   eosWorkflowRehearsalGoSafeTool


### PR DESCRIPTION
### Motivation
- Ajouter un outil workflow pour créer une série de cues en réutilisant la logique de création de look et en automatisant l'incrémentation des numéros de cue.
- Permettre un mode `dry_run` qui renvoie un `commands_preview` sans envoyer de commandes.

### Description
- Ajout du schéma `createCueSeriesInputSchema` avec `base_cuelist_number?`, `start_cue_number?` (défaut `1`), `looks[]` (avec `channels`, palettes optionnelles et `cue_label?`) et `dry_run?`.
- Implémentation de `eos_workflow_create_cue_series` qui boucle sur `looks`, reproduit la séquence métier de `eos_workflow_create_look` (sélection channels, application palettes, `Record Cue`, label optionnel) et incrémente automatiquement le numéro de cue à chaque item.
- Gestion du fallback vers la cuelist master lorsque `base_cuelist_number` est absent en enregistrant/étiquetant la cue sans cuelist explicite.
- Ajout de `commands_preview` et steps marqués `skipped` en mode `dry_run`, et export du nouveau tool via `workflowTools`.
- Ajout de tests unitaires couvrant l'exécution normale (incrément automatique) et le mode `dry_run` (preview + fallback master cuelist).

### Testing
- Exécution ciblée des tests du fichier avec `npx jest src/tools/workflows/__tests__/workflows.test.ts --runInBand` a donné `8 passed, 1 failed`; les deux nouveaux tests pour `create_cue_series` passent, l'échec concerne un test existant `autopatch band` en `dry_run` (attendu `ok`, reçu `partial_failure`).
- Lancer `npm test -- src/tools/workflows/__tests__/workflows.test.ts` a montré que le test ciblé échoue de la même façon et que l'exécution complète (`npm test`) fait échouer de nombreuses suites non liées dans l'environnement courant; les nouvelles assertions locales pour `create_cue_series` sont cependant validées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f7c5e014832a8736c782a9a00697)