### PR TITLE
Add workflow tool `eos_workflow_create_effect`

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -3387,6 +3387,40 @@ _OSC_
 
 _Pas de mapping OSC documenté._
 
+<a id="eos-workflow-create-effect"></a>
+## Workflow creation d'effet (`eos_workflow_create_effect`)
+
+**Description :** Enregistre un groupe optionnel, assigne un effet a des canaux, applique speed/size/direction puis enregistre l'effet.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `channels` | string | Oui | — |
+| `direction` | enum(left_to_right, right_to_left, center_out) | Non | — |
+| `dry_run` | boolean | Non | — |
+| `effect_number` | number | Oui | — |
+| `group_number` | number | Non | — |
+| `size` | number | Non | — |
+| `speed` | number | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `user` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_workflow_create_effect --args '{"channels":"exemple","effect_number":1}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
 <a id="eos-workflow-create-look"></a>
 ## Workflow creation de look (`eos_workflow_create_look`)
 

--- a/src/tools/workflows/__tests__/workflows.test.ts
+++ b/src/tools/workflows/__tests__/workflows.test.ts
@@ -7,6 +7,7 @@ import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } 
 import { runTool, getStructuredContent } from '../../__tests__/helpers/runTool';
 import {
   eosWorkflowCreateLookTool,
+  eosWorkflowCreateEffectTool,
   eosWorkflowCreateCueSeriesTool,
   eosWorkflowAutopatchBandTool,
   eosWorkflowPatchFixtureTool,
@@ -96,6 +97,67 @@ describe('workflow tools', () => {
       'Record Cue 2/101',
       'Cue 2/101 Label "Look Intro"'
     ]);
+  });
+
+  it('orchestre eos_workflow_create_effect avec groupe optionnel et parametres', async () => {
+    const result = await runTool(eosWorkflowCreateEffectTool, {
+      channels: '1 Thru 6',
+      effect_number: 21,
+      group_number: 3,
+      direction: 'right_to_left',
+      speed: 1.5,
+      size: 75
+    });
+
+    const structured = getStructuredContent(result);
+    expect(structured?.status).toBe('ok');
+    expect(structured?.commandsSent).toEqual([
+      'Chan 1 Thru 6 Record Group 3',
+      'Chan 1 Thru 6 Effect 21',
+      'Effect 21 Speed 1.5',
+      'Effect 21 Size 75',
+      'Effect 21 Direction Right To Left',
+      'Record Effect 21'
+    ]);
+    expect(structured?.effect).toEqual({
+      effect_number: 21,
+      channels: '1 Thru 6',
+      group_number: 3,
+      parameters: {
+        direction: 'right_to_left',
+        speed: 1.5,
+        size: 75
+      }
+    });
+  });
+
+  it('applique les valeurs par defaut et dry_run pour create_effect', async () => {
+    const result = await runTool(eosWorkflowCreateEffectTool, {
+      channels: '10',
+      effect_number: 22,
+      dry_run: true
+    });
+
+    expect(service.sentMessages).toHaveLength(0);
+    const structured = getStructuredContent(result);
+    expect(structured?.status).toBe('ok');
+    expect(structured?.commands_preview).toEqual([
+      'Chan 10 Effect 22',
+      'Effect 22 Speed 1',
+      'Effect 22 Size 100',
+      'Effect 22 Direction Left To Right',
+      'Record Effect 22'
+    ]);
+    expect(structured?.effect).toEqual({
+      effect_number: 22,
+      channels: '10',
+      group_number: null,
+      parameters: {
+        direction: 'left_to_right',
+        speed: 1,
+        size: 100
+      }
+    });
   });
 
   it('retourne un echec partiel sur erreur intermediaire de workflow create_look', async () => {

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -96,6 +96,28 @@ const createLookInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+
+const effectDirectionSchema = z.enum(['left_to_right', 'right_to_left', 'center_out']);
+
+type EffectDirection = z.infer<typeof effectDirectionSchema>;
+
+const effectDirectionCommandLabels: Record<EffectDirection, string> = {
+  left_to_right: 'Left To Right',
+  right_to_left: 'Right To Left',
+  center_out: 'Center Out'
+};
+
+const createEffectInputSchema = {
+  channels: z.string().trim().min(1).max(256),
+  effect_number: z.coerce.number().int().min(1).max(9999),
+  group_number: z.coerce.number().int().min(1).max(99999).optional(),
+  direction: effectDirectionSchema.optional().default('left_to_right'),
+  speed: z.coerce.number().finite().positive().max(999).optional().default(1),
+  size: z.coerce.number().finite().positive().max(1000).optional().default(100),
+  dry_run: z.boolean().optional(),
+  ...targetOptionsSchema
+} satisfies ZodRawShape;
+
 /**
  * @tool eos_workflow_create_look
  * @summary Workflow creation de look
@@ -157,6 +179,97 @@ export const eosWorkflowCreateLookTool: ToolDefinition<typeof createLookInputSch
     );
   }
 };
+
+/**
+ * @tool eos_workflow_create_effect
+ * @summary Workflow creation d'effet
+ * @description Enregistre un groupe optionnel, assigne un effet a des canaux, applique speed/size/direction puis enregistre l'effet.
+ * @arguments Voir docs/tools.md#eos-workflow-create-effect pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-workflow-create-effect pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-workflow-create-effect pour un exemple OSC.
+ */
+export const eosWorkflowCreateEffectTool: ToolDefinition<typeof createEffectInputSchema> = {
+  name: 'eos_workflow_create_effect',
+  config: {
+    title: "Workflow creation d'effet",
+    description: "Enregistre un groupe optionnel, assigne un effet a des canaux, applique speed/size/direction puis enregistre l'effet.",
+    inputSchema: createEffectInputSchema
+  },
+  handler: async (args) => {
+    const options = z.object(createEffectInputSchema).strict().parse(args ?? {});
+    const dryRun = options.dry_run === true;
+    const steps: WorkflowStepLog[] = [];
+    const partialErrors: Array<{ step: string; error: string }> = [];
+    const commandsPreview: string[] = [];
+    const directionLabel = effectDirectionCommandLabels[options.direction];
+
+    const commands = [
+      ...(options.group_number != null
+        ? [{ step: 'record_group', command: `Chan ${options.channels} Record Group ${options.group_number}` }]
+        : []),
+      { step: 'assign_effect_to_channels', command: `Chan ${options.channels} Effect ${options.effect_number}` },
+      { step: 'apply_speed', command: `Effect ${options.effect_number} Speed ${options.speed}` },
+      { step: 'apply_size', command: `Effect ${options.effect_number} Size ${options.size}` },
+      { step: 'apply_direction', command: `Effect ${options.effect_number} Direction ${directionLabel}` },
+      { step: 'record_effect', command: `Record Effect ${options.effect_number}` }
+    ];
+
+    for (const commandStep of commands) {
+      commandsPreview.push(commandStep.command);
+      if (dryRun) {
+        steps.push({ step: commandStep.step, status: 'skipped', command: commandStep.command, detail: 'dry_run' });
+        continue;
+      }
+
+      const ok = await runCommandStep(steps, partialErrors, commandStep.step, commandStep.command, options);
+      if (!ok) {
+        return buildWorkflowResult(
+          'eos_workflow_create_effect',
+          'partial_failure',
+          `Workflow creation effet interrompu a l'etape ${commandStep.step}.`,
+          steps,
+          partialErrors,
+          {
+            effect: {
+              effect_number: options.effect_number,
+              channels: options.channels,
+              group_number: options.group_number ?? null,
+              parameters: {
+                direction: options.direction,
+                speed: options.speed,
+                size: options.size
+              }
+            },
+            ...(dryRun ? { commands_preview: commandsPreview } : {})
+          }
+        );
+      }
+    }
+
+    return buildWorkflowResult(
+      'eos_workflow_create_effect',
+      'ok',
+      dryRun ? 'Dry run creation effet genere.' : 'Workflow creation effet execute avec succes.',
+      steps,
+      partialErrors,
+      {
+        effect: {
+          effect_number: options.effect_number,
+          channels: options.channels,
+          group_number: options.group_number ?? null,
+          parameters: {
+            direction: options.direction,
+            speed: options.speed,
+            size: options.size
+          }
+        },
+        ...(dryRun ? { commands_preview: commandsPreview } : {})
+      }
+    );
+  }
+};
+
 
 const createCueSeriesInputSchema = {
   base_cuelist_number: cuelistNumberSchema.optional(),
@@ -780,6 +893,7 @@ export const eosWorkflowUpdateCueLookTool: ToolDefinition<typeof updateCueLookIn
 
 export const workflowTools = [
   eosWorkflowCreateLookTool,
+  eosWorkflowCreateEffectTool,
   eosWorkflowCreateCueSeriesTool,
   eosWorkflowPatchFixtureTool,
   eosWorkflowAutopatchBandTool,


### PR DESCRIPTION
### Motivation
- Ajouter un workflow pour créer et paramétrer rapidement un effet sur une sélection de canaux, avec option d'enregistrer un groupe préalable, appliquer direction/speed/size et produire un retour structuré lisible par LLM.

### Description
- Ajout du schéma d'entrée `createEffectInputSchema` et de l'énumération `direction` avec valeurs par défaut sûres (`left_to_right`, `speed: 1`, `size: 100`).
- Implémentation du tool `eos_workflow_create_effect` qui orchestre : enregistrement optionnel du groupe, assignation de l'effet aux `channels`, application de `speed`/`size`/`direction` et `Record Effect` final, avec support `dry_run` (preview des commandes).
- Le handler retourne un objet structuré contenant le `effect_number`, `channels`, `group_number` (ou `null`) et les `parameters` appliqués, et inclut `commands_preview` en cas de `dry_run`.
- Enregistrement du tool dans `workflowTools`, ajout de la documentation CLI/JSON schema dans `docs/tools.md` et tests unitaires d'orchestration/dry-run dans `src/tools/workflows/__tests__/workflows.test.ts`.

### Testing
- Type-check : `npm run tsc` — réussi.
- Tests ciblés : `npx jest src/tools/workflows/__tests__/workflows.test.ts src/schemas/__tests__/tool_schemas.test.ts --runInBand` — réussi (les deux suites passent).
- Génération/validation docs : `npm run docs:generate` et `npm run docs:check` — réussi.
- Lint : `npm run lint` — réussi.
- Suite complète : `npm test` — échoue sur suites existantes non liées (diverses erreurs liées à `OscClient.requestJson` allowlists, règles de sécurité des commandes et snapshots), tandis que les tests ajoutés et le schéma passent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa61e9b780832aab7dace948b4908c)