### PR TITLE
Make workflow tools tolerate unknown args (use Zod passthrough for workflows)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -15,6 +15,23 @@ Les outils critiques des familles **cues**, **patch**, **palettes** et **command
 
 En mode `strict`/`standard`, les actions sensibles (`record`, `update`, `delete`, `live fire`, et declenchements `fire`) sont bloquees sans `require_confirmation=true`.
 
+## Politique d'arguments inconnus
+
+Les workflows `eos_workflow_*` sont tolerants : leurs schemas Zod utilisent `passthrough()` pour accepter les champs MCP inconnus. Ces champs sont conserves par la validation mais ne sont pas lus par la logique metier, ce qui permet d'ignorer des metadonnees clientes sans modifier les commandes OSC generees.
+
+Les tools bas niveau et sensibles restent stricts (`strict()`) afin de rejeter les arguments non prevus avant toute action directe : GO brut (`eos_cue_go`), patch brut (`eos_patch_*`, `eos_programming_patch_set_channel`), show control (`eos_show_*`), commandes texte et reglages directs.
+
+Workflows tolerants recenses :
+
+- `eos_workflow_autopatch_band`
+- `eos_workflow_build_groups_and_palettes`
+- `eos_workflow_create_cue_series`
+- `eos_workflow_create_effect`
+- `eos_workflow_create_look`
+- `eos_workflow_patch_fixture`
+- `eos_workflow_rehearsal_go_safe`
+- `eos_workflow_update_cue_look`
+
 ## Outils mis en avant
 
 | Outil | Résumé | Lien |

--- a/scripts/toolDocs.ts
+++ b/scripts/toolDocs.ts
@@ -59,7 +59,16 @@ function patchModuleResolution(): () => void {
   };
 }
 
-function createZodSchema(schemaLike: unknown): z.ZodTypeAny | undefined {
+function isWorkflowTool(tool: ToolDefinition): boolean {
+  return tool.name.startsWith('eos_workflow_');
+}
+
+function createZodObject(shape: Record<string, ZodTypeAny>, tool: ToolDefinition): z.ZodObject<Record<string, ZodTypeAny>> {
+  const objectSchema = z.object(shape);
+  return isWorkflowTool(tool) ? objectSchema.passthrough() : objectSchema.strict();
+}
+
+function createZodSchema(tool: ToolDefinition, schemaLike: unknown): z.ZodTypeAny | undefined {
   if (!schemaLike) {
     return undefined;
   }
@@ -71,7 +80,7 @@ function createZodSchema(schemaLike: unknown): z.ZodTypeAny | undefined {
   if (typeof schemaLike === 'object' && schemaLike != null && !Array.isArray(schemaLike)) {
     const entries = Object.entries(schemaLike as Record<string, unknown>);
     if (entries.length === 0) {
-      return z.object({}).strict();
+      return createZodObject({}, tool);
     }
 
     const shape: Record<string, ZodTypeAny> = {};
@@ -82,7 +91,7 @@ function createZodSchema(schemaLike: unknown): z.ZodTypeAny | undefined {
     }
 
     if (Object.keys(shape).length > 0) {
-      return z.object(shape).strict();
+      return createZodObject(shape, tool);
     }
   }
 
@@ -454,7 +463,7 @@ function buildDocumentation(tools: ToolDefinition[]): { markdown: string; metada
   const sortedTools = [...tools].sort((a, b) => a.name.localeCompare(b.name));
 
   for (const tool of sortedTools) {
-    const schema = createZodSchema(tool.config.inputSchema);
+    const schema = createZodSchema(tool, tool.config.inputSchema);
     const properties = buildProperties(schema);
     const exampleArgs = buildExample(schema);
     metadata.set(tool.name, { tool, schema, properties, exampleArgs });
@@ -477,6 +486,18 @@ function buildDocumentation(tools: ToolDefinition[]): { markdown: string; metada
   lines.push("- `safety_level` (`strict` | `standard` | `off`) : niveau de garde-fou applique (par defaut `strict`).");
   lines.push('');
   lines.push('En mode `strict`/`standard`, les actions sensibles (`record`, `update`, `delete`, `live fire`, et declenchements `fire`) sont bloquees sans `require_confirmation=true`.');
+  lines.push('');
+  lines.push("## Politique d'arguments inconnus");
+  lines.push('');
+  lines.push("Les workflows `eos_workflow_*` sont tolerants : leurs schemas Zod utilisent `passthrough()` pour accepter les champs MCP inconnus. Ces champs sont conserves par la validation mais ne sont pas lus par la logique metier, ce qui permet d'ignorer des metadonnees clientes sans modifier les commandes OSC generees.");
+  lines.push('');
+  lines.push("Les tools bas niveau et sensibles restent stricts (`strict()`) afin de rejeter les arguments non prevus avant toute action directe : GO brut (`eos_cue_go`), patch brut (`eos_patch_*`, `eos_programming_patch_set_channel`), show control (`eos_show_*`), commandes texte et reglages directs.");
+  lines.push('');
+  lines.push('Workflows tolerants recenses :');
+  lines.push('');
+  for (const tool of sortedTools.filter(isWorkflowTool)) {
+    lines.push(`- \`${tool.name}\``);
+  }
   lines.push('');
 
   const highlightedTools = sortedTools.filter((tool) =>

--- a/src/schemas/__tests__/tool_schemas.test.ts
+++ b/src/schemas/__tests__/tool_schemas.test.ts
@@ -32,4 +32,16 @@ describe('tool JSON schemas', () => {
     }
   });
 
+
+  it('publie des schemas tolerants uniquement pour les workflows', () => {
+    const workflowSchema = toolJsonSchemas.find((schema) => schema.name === 'eos_workflow_create_look')?.schema;
+    const cueGoSchema = toolJsonSchemas.find((schema) => schema.name === 'eos_cue_go')?.schema;
+
+    expect(workflowSchema).toBeDefined();
+    expect(cueGoSchema).toBeDefined();
+
+    expect((workflowSchema?.definitions as Record<string, { additionalProperties?: boolean }>).eos_workflow_create_look.additionalProperties).toBe(true);
+    expect((cueGoSchema?.definitions as Record<string, { additionalProperties?: boolean }>).eos_cue_go.additionalProperties).toBe(false);
+  });
+
 });

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -25,16 +25,17 @@ type ZodToJsonSchema = (
 
 const toJsonSchema = zodToJsonSchema as ZodToJsonSchema;
 
-function toZodObject(shape: ZodRawShape | undefined): z.ZodObject<ZodRawShape> {
-  if (!shape) {
-    return z.object({}).strict();
-  }
+function isWorkflowTool(definition: ToolDefinition): boolean {
+  return definition.name.startsWith('eos_workflow_');
+}
 
-  return z.object(shape).strict();
+function toZodObject(shape: ZodRawShape | undefined, options: { passthrough: boolean }): z.ZodObject<ZodRawShape> {
+  const objectSchema = z.object(shape ?? {});
+  return options.passthrough ? objectSchema.passthrough() : objectSchema.strict();
 }
 
 function buildSchema(definition: ToolDefinition): ToolJsonSchemaDefinition {
-  const zodSchema = toZodObject(definition.config.inputSchema);
+  const zodSchema = toZodObject(definition.config.inputSchema, { passthrough: isWorkflowTool(definition) });
   const jsonSchema = toJsonSchema(zodSchema, {
     name: definition.name,
     $refStrategy: 'none'

--- a/src/tools/workflows/__tests__/workflows.test.ts
+++ b/src/tools/workflows/__tests__/workflows.test.ts
@@ -15,6 +15,7 @@ import {
   eosWorkflowBuildGroupsAndPalettesTool,
   eosWorkflowUpdateCueLookTool
 } from '../index';
+import { eosCueGoTool } from '../../cues/index';
 
 class FakeOscService implements OscGateway {
   public readonly sentMessages: OscMessage[] = [];
@@ -173,6 +174,41 @@ describe('workflow tools', () => {
     const structured = getStructuredContent(result);
     expect(structured?.status).toBe('partial_failure');
     expect(structured?.partialErrors).toEqual([{ step: 'apply_color_palette', error: 'Echec simule envoi #2' }]);
+  });
+
+
+  it('ignore les champs inconnus sur les workflows sans modifier la logique metier', async () => {
+    const result = await runTool(eosWorkflowCreateCueSeriesTool, {
+      looks: [
+        {
+          channels: '7',
+          cue_label: 'Solo',
+          client_note: 'metadata ignored'
+        }
+      ],
+      dry_run: true,
+      client_request_id: 'abc-123'
+    });
+
+    expect(service.sentMessages).toHaveLength(0);
+    const structured = getStructuredContent(result);
+    expect(structured?.status).toBe('ok');
+    expect(structured?.commands_preview).toEqual([
+      'Chan 7',
+      'Record Cue 1',
+      'Cue 1 Label "Solo"'
+    ]);
+    expect(structured).not.toHaveProperty('client_request_id');
+  });
+
+  it('conserve strict sur les tools bas niveau sensibles', async () => {
+    await expect(
+      runTool(eosCueGoTool, {
+        cuelist_number: 1,
+        dry_run: true,
+        client_request_id: 'abc-123'
+      })
+    ).rejects.toThrow(/Unrecognized key/);
   });
 
   it('orchestre eos_workflow_create_cue_series avec increment automatique des cues', async () => {

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -27,6 +27,10 @@ const targetOptionsSchema = {
   user: z.coerce.number().int().min(0).optional()
 } satisfies ZodRawShape;
 
+function workflowObject<T extends ZodRawShape>(shape: T): z.ZodObject<T, 'passthrough'> {
+  return z.object(shape).passthrough();
+}
+
 type WorkflowStepStatus = 'ok' | 'error' | 'skipped';
 
 interface WorkflowStepLog {
@@ -135,7 +139,7 @@ export const eosWorkflowCreateLookTool: ToolDefinition<typeof createLookInputSch
     inputSchema: createLookInputSchema
   },
   handler: async (args) => {
-    const options = z.object(createLookInputSchema).strict().parse(args ?? {});
+    const options = workflowObject(createLookInputSchema).parse(args ?? {});
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
 
@@ -197,7 +201,7 @@ export const eosWorkflowCreateEffectTool: ToolDefinition<typeof createEffectInpu
     inputSchema: createEffectInputSchema
   },
   handler: async (args) => {
-    const options = z.object(createEffectInputSchema).strict().parse(args ?? {});
+    const options = workflowObject(createEffectInputSchema).parse(args ?? {});
     const dryRun = options.dry_run === true;
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
@@ -274,7 +278,7 @@ export const eosWorkflowCreateEffectTool: ToolDefinition<typeof createEffectInpu
 const createCueSeriesInputSchema = {
   base_cuelist_number: cuelistNumberSchema.optional(),
   start_cue_number: cueNumberSchema.optional().default(1),
-  looks: z.array(z.object({
+  looks: z.array(workflowObject({
     channels: z.string().trim().min(1).max(256),
     color_palette: z.coerce.number().int().min(1).max(99999).optional(),
     focus_palette: z.coerce.number().int().min(1).max(99999).optional(),
@@ -302,7 +306,7 @@ export const eosWorkflowCreateCueSeriesTool: ToolDefinition<typeof createCueSeri
     inputSchema: createCueSeriesInputSchema
   },
   handler: async (args) => {
-    const options = z.object(createCueSeriesInputSchema).strict().parse(args ?? {});
+    const options = workflowObject(createCueSeriesInputSchema).parse(args ?? {});
     const dryRun = options.dry_run === true;
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
@@ -399,7 +403,7 @@ export const eosWorkflowPatchFixtureTool: ToolDefinition<typeof patchFixtureInpu
     inputSchema: patchFixtureInputSchema
   },
   handler: async (args) => {
-    const options = z.object(patchFixtureInputSchema).strict().parse(args ?? {});
+    const options = workflowObject(patchFixtureInputSchema).parse(args ?? {});
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
     const execution = buildPatchSequence(options);
@@ -447,7 +451,7 @@ export const eosWorkflowPatchFixtureTool: ToolDefinition<typeof patchFixtureInpu
 };
 
 const autopatchBandInputSchema = {
-  fixtures: z.array(z.object({
+  fixtures: z.array(workflowObject({
     count: z.coerce.number().int().min(1).max(999),
     fixture_query: z.string().trim().min(1).max(128).optional(),
     fixture_manufacturer: z.string().trim().min(1).max(128).optional(),
@@ -486,7 +490,7 @@ export const eosWorkflowAutopatchBandTool: ToolDefinition<typeof autopatchBandIn
     inputSchema: autopatchBandInputSchema
   },
   handler: async (args) => {
-    const options = z.object(autopatchBandInputSchema).strict().parse(args ?? {});
+    const options = workflowObject(autopatchBandInputSchema).parse(args ?? {});
     const dryRun = options.dry_run === true;
     const logs: Array<Record<string, unknown>> = [];
     const commandsPreview: string[] = [];
@@ -589,19 +593,19 @@ const rehearsalGoSafeInputSchema = {
 } satisfies ZodRawShape;
 
 const buildGroupsAndPalettesInputSchema = {
-  groups: z.array(z.object({
+  groups: z.array(workflowObject({
     number: z.coerce.number().int().min(1).max(99999),
     label: z.string().trim().min(1).max(128),
     channels: z.string().trim().min(1).max(256)
   })).optional(),
-  color_palettes: z.array(z.object({
+  color_palettes: z.array(workflowObject({
     number: z.coerce.number().int().min(1).max(99999),
     label: z.string().trim().min(1).max(128),
     channels: z.string().trim().min(1).max(256),
     hue: z.string().trim().min(1).max(128).optional(),
     saturation: z.coerce.number().finite().optional()
   })).optional(),
-  focus_palettes: z.array(z.object({
+  focus_palettes: z.array(workflowObject({
     number: z.coerce.number().int().min(1).max(99999),
     label: z.string().trim().min(1).max(128),
     channels: z.string().trim().min(1).max(256),
@@ -639,9 +643,7 @@ export const eosWorkflowRehearsalGoSafeTool: ToolDefinition<typeof rehearsalGoSa
     inputSchema: rehearsalGoSafeInputSchema
   },
   handler: async (args) => {
-    const options = z
-      .object(rehearsalGoSafeInputSchema)
-      .strict()
+    const options = workflowObject(rehearsalGoSafeInputSchema)
       .superRefine((value, ctx) => {
         validateCueArgumentsPair(value, ctx);
         if (value.rollback_cuelist_number != null && value.rollback_cue_number == null) {
@@ -757,7 +759,7 @@ export const eosWorkflowBuildGroupsAndPalettesTool: ToolDefinition<typeof buildG
     inputSchema: buildGroupsAndPalettesInputSchema
   },
   handler: async (args) => {
-    const options = z.object(buildGroupsAndPalettesInputSchema).strict().parse(args ?? {});
+    const options = workflowObject(buildGroupsAndPalettesInputSchema).parse(args ?? {});
     const dryRun = options.dry_run === true;
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
@@ -820,9 +822,7 @@ export const eosWorkflowUpdateCueLookTool: ToolDefinition<typeof updateCueLookIn
     inputSchema: updateCueLookInputSchema
   },
   handler: async (args) => {
-    const options = z
-      .object(updateCueLookInputSchema)
-      .strict()
+    const options = workflowObject(updateCueLookInputSchema)
       .superRefine((value, ctx) => {
         validateCueArgumentsPair(value, ctx);
       })


### PR DESCRIPTION
### Motivation

- Les workflows `eos_workflow_*` doivent accepter et ignorer proprement des champs MCP inconnus (métadonnées clientes) sans casser la logique métier ni modifier les commandes OSC générées.  
- Les outils bas‑niveau sensibles doivent en revanche conserver une validation stricte pour éviter l'exécution d'actions inattendues (GO brut, patchs bruts, show control, commandes texte, etc.).  
- La distinction doit être visible dans la documentation et dans les JSON schemas publiés pour les consommateurs externes.

### Description

- Ajout d'un helper `workflowObject(...)` dans `src/tools/workflows/index.ts` qui crée des `z.object(...).passthrough()` et remplacement des usages `z.object(...).strict()` par `workflowObject(...).parse(...)` pour tous les workflows listés (create look/effect/cue series/patch fixture/autopatch band/rehearsal go safe/build groups and palettes/update cue look), ainsi que pour leurs objets imbriqués.  
- Générateur de schémas mis à jour dans `src/schemas/index.ts` et `scripts/toolDocs.ts` pour publier les JSON schemas des workflows avec `additionalProperties=true` (passthrough) tandis que les outils non‑workflow conservent `strict()` (pas d'`additionalProperties`).  
- Documentation ajoutée et enrichie dans `docs/tools.md` pour expliquer la politique « workflows tolérants vs tools stricts » et lister automatiquement les workflows tolérants, et génération de la doc adaptée via `scripts/toolDocs.ts`.  
- Tests ajoutés/étendus : nouveau cas dans `src/tools/workflows/__tests__/workflows.test.ts` vérifiant que les champs inconnus sont ignorés par les workflows et que les outils bas‑niveau (ex. `eos_cue_go`) restent stricts, et un test dans `src/schemas/__tests__/tool_schemas.test.ts` vérifiant que le schéma JSON des workflows est tolérant tandis que `eos_cue_go` reste strict.

### Testing

- Génération de documentation avec `npm run docs:generate` — réussite.  
- Vérification de la doc/génération de schémas avec `npm run docs:check` — réussite.  
- Typecheck/build via `npm run tsc` — réussite.  
- Lint via `npm run lint` — réussite.  
- Tests ciblés `npx jest --runTestsByPath src/tools/workflows/__tests__/workflows.test.ts src/schemas/__tests__/tool_schemas.test.ts` — réussite (tous les tests ciblés sont passés).  
- Exécution du script `npm test` avec filtres globaux a exposé des échecs sur d'autres suites non modifiées (préexistants), donc la validation complète de la suite unitaire complète n'a pas été utilisée pour valider ces changements de scope limité.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa64ad30dc832aad27796e4699f051)