### PR TITLE
Workflows: optional cue/cuelist defaults, per-look cue_number & explicit default logs

### DIFF
--- a/src/tools/workflows/__tests__/workflows.test.ts
+++ b/src/tools/workflows/__tests__/workflows.test.ts
@@ -174,6 +174,12 @@ describe('workflow tools', () => {
     const structured = getStructuredContent(result);
     expect(structured?.status).toBe('partial_failure');
     expect(structured?.partialErrors).toEqual([{ step: 'apply_color_palette', error: 'Echec simule envoi #2' }]);
+    expect(structured?.executedSteps).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        step: 'default_cuelist_number',
+        detail: 'cuelist_number absent: utilisation automatique de la cuelist master.'
+      })
+    ]));
   });
 
 
@@ -256,6 +262,47 @@ describe('workflow tools', () => {
       'CP 12',
       'Record Cue 2'
     ]);
+    expect(structured?.executedSteps).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        step: 'default_base_cuelist_number',
+        detail: 'base_cuelist_number absent: utilisation automatique de la cuelist master.'
+      }),
+      expect.objectContaining({
+        step: 'default_start_cue_number',
+        detail: 'start_cue_number absent: valeur par defaut 1 appliquee automatiquement.'
+      }),
+      expect.objectContaining({
+        step: 'look_1_default_cue_number',
+        detail: 'cue_number absent: auto-increment applique avec la valeur 1.'
+      })
+    ]));
+  });
+
+  it('autorise un cue_number ponctuel dans create_cue_series puis reprend l auto-increment', async () => {
+    const result = await runTool(eosWorkflowCreateCueSeriesTool, {
+      start_cue_number: 10,
+      looks: [
+        { channels: '1', cue_number: 20, cue_label: 'Jump' },
+        { channels: '2', cue_label: 'Next' }
+      ],
+      dry_run: true
+    });
+
+    const structured = getStructuredContent(result);
+    expect(structured?.commands_preview).toEqual([
+      'Chan 1',
+      'Record Cue 20',
+      'Cue 20 Label "Jump"',
+      'Chan 2',
+      'Record Cue 21',
+      'Cue 21 Label "Next"'
+    ]);
+    expect(structured?.executedSteps).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        step: 'look_2_default_cue_number',
+        detail: 'cue_number absent: auto-increment applique avec la valeur 21.'
+      })
+    ]));
   });
 
   it('orchestre eos_workflow_patch_fixture avec position 3D par defaut', async () => {
@@ -405,6 +452,33 @@ describe('workflow tools', () => {
     expect(structured?.executedSteps).toEqual(expect.arrayContaining([
       expect.objectContaining({ step: 'apply_desaturate', status: 'skipped' }),
       expect.objectContaining({ step: 'apply_warmify', status: 'skipped' })
+    ]));
+    expect(structured?.executedSteps).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        step: 'default_cue_number',
+        detail: 'cue_number absent: modification appliquee a la cue courante via Update Cue.'
+      })
+    ]));
+  });
+
+  it('applique le fallback cuelist master dans update_cue_look quand seule la cue est fournie', async () => {
+    const result = await runTool(eosWorkflowUpdateCueLookTool, {
+      cue_number: 5,
+      channels: '9',
+      dry_run: true
+    });
+
+    const structured = getStructuredContent(result);
+    expect(structured?.commands_preview).toEqual([
+      'Go To Cue 5',
+      'Chan 9',
+      'Update Cue 5'
+    ]);
+    expect(structured?.executedSteps).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        step: 'default_cuelist_number',
+        detail: 'cuelist_number absent: utilisation automatique de la cuelist master pour la cue cible.'
+      })
     ]));
   });
 });

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -62,6 +62,19 @@ function buildWorkflowResult(
   };
 }
 
+
+function pushDefaultLog(steps: WorkflowStepLog[], step: string, detail: string): void {
+  steps.push({ step, status: 'ok', detail });
+}
+
+function resolveNumericCueNumber(value: string | number, field: string): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    throw new Error(`${field} doit etre numerique pour permettre l auto-increment.`);
+  }
+  return numeric;
+}
+
 async function runCommandStep(
   steps: WorkflowStepLog[],
   partialErrors: Array<{ step: string; error: string }>,
@@ -142,6 +155,10 @@ export const eosWorkflowCreateLookTool: ToolDefinition<typeof createLookInputSch
     const options = workflowObject(createLookInputSchema).parse(args ?? {});
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
+
+    if (options.cuelist_number == null) {
+      pushDefaultLog(steps, 'default_cuelist_number', 'cuelist_number absent: utilisation automatique de la cuelist master.');
+    }
 
     const commands = [
       { step: 'select_channels', command: `Chan ${options.channels}` },
@@ -280,6 +297,7 @@ const createCueSeriesInputSchema = {
   start_cue_number: cueNumberSchema.optional().default(1),
   looks: z.array(workflowObject({
     channels: z.string().trim().min(1).max(256),
+    cue_number: cueNumberSchema.optional(),
     color_palette: z.coerce.number().int().min(1).max(99999).optional(),
     focus_palette: z.coerce.number().int().min(1).max(99999).optional(),
     beam_palette: z.coerce.number().int().min(1).max(99999).optional(),
@@ -306,16 +324,29 @@ export const eosWorkflowCreateCueSeriesTool: ToolDefinition<typeof createCueSeri
     inputSchema: createCueSeriesInputSchema
   },
   handler: async (args) => {
-    const options = workflowObject(createCueSeriesInputSchema).parse(args ?? {});
+    const rawArgs = (args ?? {}) as Record<string, unknown>;
+    const options = workflowObject(createCueSeriesInputSchema).parse(rawArgs);
     const dryRun = options.dry_run === true;
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
     const commandsPreview: string[] = [];
-    let cueNumber = Number(options.start_cue_number ?? 1);
+    let cueNumber = resolveNumericCueNumber(options.start_cue_number, 'start_cue_number');
+
+    if (rawArgs.base_cuelist_number == null) {
+      pushDefaultLog(steps, 'default_base_cuelist_number', 'base_cuelist_number absent: utilisation automatique de la cuelist master.');
+    }
+
+    if (rawArgs.start_cue_number == null) {
+      pushDefaultLog(steps, 'default_start_cue_number', 'start_cue_number absent: valeur par defaut 1 appliquee automatiquement.');
+    }
 
     for (let index = 0; index < options.looks.length; index += 1) {
       const look = options.looks[index];
-      const cueStepPrefix = `look_${index + 1}_cue_${cueNumber}`;
+      const effectiveCueNumber = look.cue_number ?? cueNumber;
+      if (look.cue_number == null) {
+        pushDefaultLog(steps, `look_${index + 1}_default_cue_number`, `cue_number absent: auto-increment applique avec la valeur ${effectiveCueNumber}.`);
+      }
+      const cueStepPrefix = `look_${index + 1}_cue_${effectiveCueNumber}`;
       const commands = [
         { step: `${cueStepPrefix}_select_channels`, command: `Chan ${look.channels}` },
         ...(look.color_palette != null ? [{ step: `${cueStepPrefix}_apply_color_palette`, command: `CP ${look.color_palette}` }] : []),
@@ -323,13 +354,13 @@ export const eosWorkflowCreateCueSeriesTool: ToolDefinition<typeof createCueSeri
         ...(look.beam_palette != null ? [{ step: `${cueStepPrefix}_apply_beam_palette`, command: `BP ${look.beam_palette}` }] : []),
         {
           step: `${cueStepPrefix}_record_cue`,
-          command: buildRecordCueCommand(cueNumber, options.base_cuelist_number)
+          command: buildRecordCueCommand(effectiveCueNumber, options.base_cuelist_number)
         },
         ...(look.cue_label
           ? [
               {
                 step: `${cueStepPrefix}_label_cue`,
-                command: `${formatCueTarget(cueNumber, options.base_cuelist_number)} Label "${look.cue_label.replace(/"/g, '\\"')}"`
+                command: `${formatCueTarget(effectiveCueNumber, options.base_cuelist_number)} Label "${look.cue_label.replace(/"/g, '\\"')}"`
               }
             ]
           : [])
@@ -355,7 +386,7 @@ export const eosWorkflowCreateCueSeriesTool: ToolDefinition<typeof createCueSeri
         }
       }
 
-      cueNumber += 1;
+      cueNumber = resolveNumericCueNumber(effectiveCueNumber, `looks[${index}].cue_number`) + 1;
     }
 
     return buildWorkflowResult(
@@ -822,23 +853,27 @@ export const eosWorkflowUpdateCueLookTool: ToolDefinition<typeof updateCueLookIn
     inputSchema: updateCueLookInputSchema
   },
   handler: async (args) => {
-    const options = workflowObject(updateCueLookInputSchema)
-      .superRefine((value, ctx) => {
-        validateCueArgumentsPair(value, ctx);
-      })
-      .parse(args ?? {});
+    const options = workflowObject(updateCueLookInputSchema).parse(args ?? {});
 
     const dryRun = options.dry_run === true;
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
     const commandsPreview: string[] = [];
-    const updateTarget = options.cuelist_number == null || options.cue_number == null
+
+    if (options.cue_number != null && options.cuelist_number == null) {
+      pushDefaultLog(steps, 'default_cuelist_number', 'cuelist_number absent: utilisation automatique de la cuelist master pour la cue cible.');
+    }
+
+    if (options.cue_number == null) {
+      pushDefaultLog(steps, 'default_cue_number', 'cue_number absent: modification appliquee a la cue courante via Update Cue.');
+    }
+    const updateTarget = options.cue_number == null
       ? 'Update Cue'
-      : `Update Cue ${options.cuelist_number}/${String(options.cue_number).trim()}`;
+      : `Update ${formatCueTarget(options.cue_number, options.cuelist_number)}`;
 
     const commands = [
-      ...(options.cuelist_number != null && options.cue_number != null
-        ? [{ step: 'go_to_cue', command: `Go To Cue ${options.cuelist_number}/${String(options.cue_number).trim()}` }]
+      ...(options.cue_number != null
+        ? [{ step: 'go_to_cue', command: `Go To ${formatCueTarget(options.cue_number, options.cuelist_number)}` }]
         : []),
       { step: 'select_channels', command: `Chan ${options.channels}` },
       ...(options.intensity_factor != null ? [{ step: 'apply_intensity_factor', command: `At * ${options.intensity_factor}` }] : []),


### PR DESCRIPTION
### Motivation
- Rendre les workflows de création/édition de cues plus souples en autorisant des paramètres `cuelist_number`/`cue_number` optionnels et en présentant clairement les valeurs par défaut appliquées automatiquement.
- Permettre l’auto-incrément dans les séries tout en acceptant un `cue_number` ponctuel par look.

### Description
- Ajout de `pushDefaultLog` et `resolveNumericCueNumber` pour journaliser et valider les valeurs par défaut appliquées automatiquement dans les workflows (`src/tools/workflows/index.ts`).
- `eos_workflow_create_look` : `cuelist_number` devient optionnel au niveau du workflow et un pas de log explicite `default_cuelist_number` est inséré quand il est omis (fallback vers la cuelist master).
- `eos_workflow_create_cue_series` : chaque `look` peut désormais fournir `cue_number` optionnel; le workflow applique `start_cue_number` par défaut (`1`) si absent, journalise `default_base_cuelist_number` / `default_start_cue_number` / `look_*_default_cue_number` et reprend l’auto-incrément après une cue fournie manuellement.
- `eos_workflow_update_cue_look` : accepte une `cue_number` sans `cuelist_number` en ciblant la cuelist master et journalise le fallback quand `cue_number` est absent; la validation stricte du couple `(cuelist_number, cue_number)` reste inchangée pour les outils bas-niveau.
- Tests mis à jour/ajoutés pour couvrir les nouveaux comportements et logs (`src/tools/workflows/__tests__/workflows.test.ts`).

### Testing
- Executed `npx jest src/tools/workflows/__tests__/workflows.test.ts --runInBand` and the suite passed (all workflow tests green).
- Ran type-check with `npm run tsc`, documentation generation/check with `npm run docs:generate` and `npm run docs:check`, and linter `npm run lint`, all of which completed successfully.
- Full `npm test -- --runInBand` was attempted but several unrelated suites failed due to existing OSC allowlist / `requestJson` / snapshot mismatches outside the workflows changes; these failures are unrelated to this PR and pre-existed in non-workflow tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa68b83e48832a90ce93dfe663d714)