### PR TITLE
Add unified dry-run support and per-command logs to workflow tools

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -5,6 +5,12 @@
 
 Chaque outil expose son nom MCP, une description, la liste des arguments attendus ainsi qu'un exemple d'appel en CLI et par OSC.
 
+## Comportement dry-run des workflows
+
+Tous les workflows `eos_workflow_*` exposent `dry_run` en option. Quand `dry_run` est absent ou vaut `false`, le workflow execute reellement la sequence EOS et retourne un journal structure commande par commande dans `structuredContent.command_log` ainsi que les commandes tentees dans `structuredContent.commandsSent`.
+
+Quand `dry_run=true`, aucune commande EOS n'est envoyee via `sendDeterministicCommand`; la sequence EOS complete est retournee dans `structuredContent.commands_preview`, et `structuredContent.commandsSent` reste vide. Les garde-fous sensibles restent portes par les tools bas niveau et ne sont pas exposes dans les schemas workflow.
+
 ## Options communes de securite (outils critiques)
 
 Les outils critiques des familles **cues**, **patch**, **palettes** et **commandes texte** exposent les options suivantes :
@@ -3317,7 +3323,7 @@ oscsend 127.0.0.1 8001 /eos/param/wheel/tick s:'{"parameter_name":"exemple","tic
 
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
-| `dry_run` | boolean | Non | — |
+| `dry_run` | boolean | Non | Si true, aucune commande EOS n'est envoyee; la sequence complete est retournee dans structuredContent.commands_preview. Si absent ou false, le workflow execute reellement les commandes et retourne un journal commande par commande. |
 | `face_trad_count` | number | Non | — |
 | `face_trad_label_prefix` | string | Non | — |
 | `face_trad_start_address` | number | Non | — |
@@ -3352,7 +3358,7 @@ _Pas de mapping OSC documenté._
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `color_palettes` | array<object> | Non | — |
-| `dry_run` | boolean | Non | — |
+| `dry_run` | boolean | Non | Si true, aucune commande EOS n'est envoyee; la sequence complete est retournee dans structuredContent.commands_preview. Si absent ou false, le workflow execute reellement les commandes et retourne un journal commande par commande. |
 | `focus_palettes` | array<object> | Non | — |
 | `groups` | array<object> | Non | — |
 | `targetAddress` | string | Non | — |
@@ -3383,7 +3389,7 @@ _Pas de mapping OSC documenté._
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `base_cuelist_number` | number | Non | — |
-| `dry_run` | boolean | Non | — |
+| `dry_run` | boolean | Non | Si true, aucune commande EOS n'est envoyee; la sequence complete est retournee dans structuredContent.commands_preview. Si absent ou false, le workflow execute reellement les commandes et retourne un journal commande par commande. |
 | `looks` | array<object> | Oui | — |
 | `start_cue_number` | string \| number | Non | — |
 | `targetAddress` | string | Non | — |
@@ -3415,7 +3421,7 @@ _Pas de mapping OSC documenté._
 | --- | --- | --- | --- |
 | `channels` | string | Oui | — |
 | `direction` | enum(left_to_right, right_to_left, center_out) | Non | — |
-| `dry_run` | boolean | Non | — |
+| `dry_run` | boolean | Non | Si true, aucune commande EOS n'est envoyee; la sequence complete est retournee dans structuredContent.commands_preview. Si absent ou false, le workflow execute reellement les commandes et retourne un journal commande par commande. |
 | `effect_number` | number | Oui | — |
 | `group_number` | number | Non | — |
 | `size` | number | Non | — |
@@ -3453,6 +3459,7 @@ _Pas de mapping OSC documenté._
 | `cue_label` | string | Non | — |
 | `cue_number` | string \| number | Oui | — |
 | `cuelist_number` | number | Non | — |
+| `dry_run` | boolean | Non | Si true, aucune commande EOS n'est envoyee; la sequence complete est retournee dans structuredContent.commands_preview. Si absent ou false, le workflow execute reellement les commandes et retourne un journal commande par commande. |
 | `focus_palette` | number | Non | — |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
@@ -3484,6 +3491,7 @@ _Pas de mapping OSC documenté._
 | `channel_number` | number | Oui | — |
 | `device_type` | string | Non | — |
 | `dmx_address` | string | Oui | — |
+| `dry_run` | boolean | Non | Si true, aucune commande EOS n'est envoyee; la sequence complete est retournee dans structuredContent.commands_preview. Si absent ou false, le workflow execute reellement les commandes et retourne un journal commande par commande. |
 | `fixture_manufacturer` | string | Non | — |
 | `fixture_mode` | string | Non | — |
 | `fixture_model` | string | Non | — |
@@ -3524,6 +3532,7 @@ _Pas de mapping OSC documenté._
 | `allow_non_empty_command_line` | boolean | Non | — |
 | `cue_number` | string \| number | Non | — |
 | `cuelist_number` | number | Oui | — |
+| `dry_run` | boolean | Non | Si true, aucune commande EOS n'est envoyee; la sequence complete est retournee dans structuredContent.commands_preview. Si absent ou false, le workflow execute reellement les commandes et retourne un journal commande par commande. |
 | `precheck_timeout_ms` | number | Non | — |
 | `rollback_cue_number` | string \| number | Non | — |
 | `rollback_cuelist_number` | number | Non | — |
@@ -3559,7 +3568,7 @@ _Pas de mapping OSC documenté._
 | `cue_number` | string \| number | Non | — |
 | `cuelist_number` | number | Non | — |
 | `desaturate` | boolean | Non | — |
-| `dry_run` | boolean | Non | — |
+| `dry_run` | boolean | Non | Si true, aucune commande EOS n'est envoyee; la sequence complete est retournee dans structuredContent.commands_preview. Si absent ou false, le workflow execute reellement les commandes et retourne un journal commande par commande. |
 | `intensity_factor` | number | Non | — |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |

--- a/scripts/toolDocs.ts
+++ b/scripts/toolDocs.ts
@@ -477,6 +477,12 @@ function buildDocumentation(tools: ToolDefinition[]): { markdown: string; metada
   lines.push('');
   lines.push("Chaque outil expose son nom MCP, une description, la liste des arguments attendus ainsi qu'un exemple d'appel en CLI et par OSC.");
   lines.push('');
+  lines.push('## Comportement dry-run des workflows');
+  lines.push('');
+  lines.push('Tous les workflows `eos_workflow_*` exposent `dry_run` en option. Quand `dry_run` est absent ou vaut `false`, le workflow execute reellement la sequence EOS et retourne un journal structure commande par commande dans `structuredContent.command_log` ainsi que les commandes tentees dans `structuredContent.commandsSent`.');
+  lines.push('');
+  lines.push("Quand `dry_run=true`, aucune commande EOS n'est envoyee via `sendDeterministicCommand`; la sequence EOS complete est retournee dans `structuredContent.commands_preview`, et `structuredContent.commandsSent` reste vide. Les garde-fous sensibles restent portes par les tools bas niveau et ne sont pas exposes dans les schemas workflow.");
+  lines.push('');
   lines.push('## Options communes de securite (outils critiques)');
   lines.push('');
   lines.push('Les outils critiques des familles **cues**, **patch**, **palettes** et **commandes texte** exposent les options suivantes :');

--- a/src/schemas/__tests__/tool_schemas.test.ts
+++ b/src/schemas/__tests__/tool_schemas.test.ts
@@ -44,4 +44,15 @@ describe('tool JSON schemas', () => {
     expect((cueGoSchema?.definitions as Record<string, { additionalProperties?: boolean }>).eos_cue_go.additionalProperties).toBe(false);
   });
 
+
+  it('publie dry_run sur tous les workflows', () => {
+    const workflowSchemas = toolJsonSchemas.filter((schema) => schema.name.startsWith('eos_workflow_'));
+
+    expect(workflowSchemas.length).toBeGreaterThan(0);
+    for (const schema of workflowSchemas) {
+      const definition = (schema.schema.definitions as Record<string, { properties?: Record<string, unknown> }>)[schema.name];
+      expect(definition.properties).toHaveProperty('dry_run');
+    }
+  });
+
 });

--- a/src/tools/workflows/__tests__/workflows.test.ts
+++ b/src/tools/workflows/__tests__/workflows.test.ts
@@ -100,6 +100,28 @@ describe('workflow tools', () => {
     ]);
   });
 
+  it('genere commands_preview en dry run pour create_look sans envoyer de commande', async () => {
+    const result = await runTool(eosWorkflowCreateLookTool, {
+      channels: '1 Thru 3',
+      cue_number: 101,
+      color_palette: 11,
+      dry_run: true
+    });
+
+    expect(service.sentMessages).toHaveLength(0);
+    const structured = getStructuredContent(result);
+    expect(structured?.commandsSent).toEqual([]);
+    expect(structured?.commands_preview).toEqual([
+      'Chan 1 Thru 3',
+      'CP 11',
+      'Record Cue 101'
+    ]);
+    expect(structured?.command_log).toEqual(expect.arrayContaining([
+      expect.objectContaining({ step: 'select_channels', status: 'skipped', command: 'Chan 1 Thru 3' })
+    ]));
+  });
+
+
   it('orchestre eos_workflow_create_effect avec groupe optionnel et parametres', async () => {
     const result = await runTool(eosWorkflowCreateEffectTool, {
       channels: '1 Thru 6',
@@ -323,6 +345,26 @@ describe('workflow tools', () => {
     ]);
   });
 
+  it('genere commands_preview en dry run pour patch_fixture', async () => {
+    const result = await runTool(eosWorkflowPatchFixtureTool, {
+      channel_number: 201,
+      dmx_address: '2/101',
+      device_type: 'LED Wash',
+      label: 'Contre',
+      dry_run: true
+    });
+
+    expect(service.sentMessages).toHaveLength(0);
+    const structured = getStructuredContent(result);
+    expect(structured?.commandsSent).toEqual([]);
+    expect(structured?.commands_preview).toEqual([
+      'Patch Chan 201 Part 1 Address 2/101 Type "LED Wash"',
+      'Chan 201 Part 1 Label "Contre"',
+      'Chan 201 Part 1 Position X 0 Y 0 Z 0'
+    ]);
+  });
+
+
   it('bloque rehearsal_go_safe si la ligne de commande est non vide', async () => {
     service.commandLineText = 'Chan 1 At Full';
 
@@ -360,6 +402,25 @@ describe('workflow tools', () => {
     expect(structured?.status).toBe('partial_failure');
     expect(structured?.commandsSent).toEqual(['Go To Cue 1/15', 'Go To Cue 10']);
   });
+
+  it('genere commands_preview en dry run pour rehearsal_go_safe sans precheck OSC', async () => {
+    service.commandLineText = 'Chan 1 At Full';
+
+    const result = await runTool(eosWorkflowRehearsalGoSafeTool, {
+      cuelist_number: 1,
+      cue_number: 15,
+      rollback_on_failure: true,
+      rollback_cue_number: 10,
+      dry_run: true
+    });
+
+    expect(service.sentMessages).toHaveLength(0);
+    const structured = getStructuredContent(result);
+    expect(structured?.status).toBe('ok');
+    expect(structured?.commandsSent).toEqual([]);
+    expect(structured?.commands_preview).toEqual(['Go To Cue 1/15', 'Go To Cue 10']);
+  });
+
 
   it('genere commands_preview en dry run pour autopatch band', async () => {
     const result = await runTool(eosWorkflowAutopatchBandTool, {

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -27,6 +27,10 @@ const targetOptionsSchema = {
   user: z.coerce.number().int().min(0).optional()
 } satisfies ZodRawShape;
 
+const workflowDryRunSchema = z.boolean().optional().describe(
+  "Si true, aucune commande EOS n'est envoyee; la sequence complete est retournee dans structuredContent.commands_preview. Si absent ou false, le workflow execute reellement les commandes et retourne un journal commande par commande."
+);
+
 function workflowObject<T extends ZodRawShape>(shape: T): z.ZodObject<T, 'passthrough'> {
   return z.object(shape).passthrough();
 }
@@ -49,13 +53,26 @@ function buildWorkflowResult(
   partialErrors: Array<{ step: string; error: string }>,
   extraStructuredContent: Record<string, unknown> = {}
 ): ToolExecutionResult {
+  const commandLog = steps
+    .filter((step) => typeof step.command === 'string')
+    .map((step) => ({
+      step: step.step,
+      status: step.status,
+      command: step.command,
+      ...(step.detail != null ? { detail: step.detail } : {}),
+      ...(step.error != null ? { error: step.error } : {})
+    }));
+
   return {
     content: [{ type: 'text', text: summary }],
     structuredContent: {
       workflow,
       status,
       executedSteps: steps,
-      commandsSent: steps.filter((step) => typeof step.command === 'string').map((step) => step.command),
+      command_log: commandLog,
+      commandsSent: commandLog
+        .filter((step) => step.status !== 'skipped')
+        .map((step) => step.command),
       partialErrors,
       ...extraStructuredContent
     }
@@ -110,6 +127,7 @@ const createLookInputSchema = {
   focus_palette: z.coerce.number().int().min(1).max(99999).optional(),
   beam_palette: z.coerce.number().int().min(1).max(99999).optional(),
   cue_label: z.string().trim().min(1).max(128).optional(),
+  dry_run: workflowDryRunSchema,
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
@@ -131,7 +149,7 @@ const createEffectInputSchema = {
   direction: effectDirectionSchema.optional().default('left_to_right'),
   speed: z.coerce.number().finite().positive().max(999).optional().default(1),
   size: z.coerce.number().finite().positive().max(1000).optional().default(100),
-  dry_run: z.boolean().optional(),
+  dry_run: workflowDryRunSchema,
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
@@ -153,8 +171,10 @@ export const eosWorkflowCreateLookTool: ToolDefinition<typeof createLookInputSch
   },
   handler: async (args) => {
     const options = workflowObject(createLookInputSchema).parse(args ?? {});
+    const dryRun = options.dry_run === true;
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
+    const commandsPreview: string[] = [];
 
     if (options.cuelist_number == null) {
       pushDefaultLog(steps, 'default_cuelist_number', 'cuelist_number absent: utilisation automatique de la cuelist master.');
@@ -179,6 +199,12 @@ export const eosWorkflowCreateLookTool: ToolDefinition<typeof createLookInputSch
         : [])
     ];
     for (const commandStep of commands) {
+      commandsPreview.push(commandStep.command);
+      if (dryRun) {
+        steps.push({ step: commandStep.step, status: 'skipped', command: commandStep.command, detail: 'dry_run' });
+        continue;
+      }
+
       const ok = await runCommandStep(steps, partialErrors, commandStep.step, commandStep.command, options);
       if (!ok) {
         return buildWorkflowResult(
@@ -194,9 +220,10 @@ export const eosWorkflowCreateLookTool: ToolDefinition<typeof createLookInputSch
     return buildWorkflowResult(
       'eos_workflow_create_look',
       'ok',
-      'Workflow creation look execute avec succes.',
+      dryRun ? 'Dry run creation look genere.' : 'Workflow creation look execute avec succes.',
       steps,
-      partialErrors
+      partialErrors,
+      { ...(dryRun ? { commands_preview: commandsPreview } : {}) }
     );
   }
 };
@@ -303,7 +330,7 @@ const createCueSeriesInputSchema = {
     beam_palette: z.coerce.number().int().min(1).max(99999).optional(),
     cue_label: z.string().trim().min(1).max(128).optional()
   })).min(1),
-  dry_run: z.boolean().optional(),
+  dry_run: workflowDryRunSchema,
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
@@ -414,6 +441,7 @@ const patchFixtureInputSchema = {
   position_x: z.coerce.number().finite().optional(),
   position_y: z.coerce.number().finite().optional(),
   position_z: z.coerce.number().finite().optional(),
+  dry_run: workflowDryRunSchema,
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
@@ -435,8 +463,10 @@ export const eosWorkflowPatchFixtureTool: ToolDefinition<typeof patchFixtureInpu
   },
   handler: async (args) => {
     const options = workflowObject(patchFixtureInputSchema).parse(args ?? {});
+    const dryRun = options.dry_run === true;
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
+    const commandsPreview: string[] = [];
     const execution = buildPatchSequence(options);
     if (execution.fixtureResolution) {
       steps.push({
@@ -447,6 +477,12 @@ export const eosWorkflowPatchFixtureTool: ToolDefinition<typeof patchFixtureInpu
     }
 
     for (const commandStep of execution.commands) {
+      commandsPreview.push(commandStep.command);
+      if (dryRun) {
+        steps.push({ step: commandStep.step, status: 'skipped', command: commandStep.command, detail: 'dry_run' });
+        continue;
+      }
+
       const ok = await runCommandStep(steps, partialErrors, commandStep.step, commandStep.command, options);
       if (!ok) {
         return buildWorkflowResult(
@@ -462,21 +498,24 @@ export const eosWorkflowPatchFixtureTool: ToolDefinition<typeof patchFixtureInpu
     return buildWorkflowResult(
       'eos_workflow_patch_fixture',
       'ok',
-      'Workflow patch fixture execute avec succes.',
+      dryRun ? 'Dry run patch fixture genere.' : 'Workflow patch fixture execute avec succes.',
       steps,
       partialErrors,
-      execution.fixtureResolution
-        ? {
-            fixture_resolution: {
-              manufacturer: execution.fixtureResolution.fixture.manufacturer,
-              model: execution.fixtureResolution.fixture.model,
-              name: execution.fixtureResolution.fixture.name,
-              mode: execution.fixtureResolution.mode.name,
-              device_type: execution.fixtureResolution.deviceType,
-              score: execution.fixtureResolution.score
+      {
+        ...(execution.fixtureResolution
+          ? {
+              fixture_resolution: {
+                manufacturer: execution.fixtureResolution.fixture.manufacturer,
+                model: execution.fixtureResolution.fixture.model,
+                name: execution.fixtureResolution.fixture.name,
+                mode: execution.fixtureResolution.mode.name,
+                device_type: execution.fixtureResolution.deviceType,
+                score: execution.fixtureResolution.score
+              }
             }
-          }
-        : {}
+          : {}),
+        ...(dryRun ? { commands_preview: commandsPreview } : {})
+      }
     );
   }
 };
@@ -500,7 +539,7 @@ const autopatchBandInputSchema = {
   face_trad_universe: z.coerce.number().int().min(1).max(999).optional(),
   face_trad_start_address: z.coerce.number().int().min(1).max(512).optional(),
   face_trad_label_prefix: z.string().trim().min(1).max(128).optional(),
-  dry_run: z.boolean().optional(),
+  dry_run: workflowDryRunSchema,
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
@@ -524,6 +563,7 @@ export const eosWorkflowAutopatchBandTool: ToolDefinition<typeof autopatchBandIn
     const options = workflowObject(autopatchBandInputSchema).parse(args ?? {});
     const dryRun = options.dry_run === true;
     const logs: Array<Record<string, unknown>> = [];
+    const steps: WorkflowStepLog[] = [];
     const commandsPreview: string[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
     let channel = 1;
@@ -564,12 +604,24 @@ export const eosWorkflowAutopatchBandTool: ToolDefinition<typeof autopatchBandIn
 
           for (const command of execution.commands) {
             commandsPreview.push(command.command);
-            if (!dryRun) {
-              const executionResult = await executePatchSequence([command], options);
-              partialErrors.push(...executionResult.partialErrors);
-              if (!executionResult.success) {
-                throw new Error(executionResult.partialErrors[executionResult.partialErrors.length - 1]?.error ?? 'Erreur patch');
-              }
+            if (dryRun) {
+              steps.push({ step: `fixture_${channel}_${command.step}`, status: 'skipped', command: command.command, detail: 'dry_run' });
+              continue;
+            }
+
+            const executionResult = await executePatchSequence([command], options);
+            steps.push(...executionResult.steps.map((step) => ({
+              step: `fixture_${channel}_${step.step}`,
+              status: step.status,
+              command: step.command,
+              ...(step.error != null ? { error: step.error } : {})
+            })));
+            partialErrors.push(...executionResult.partialErrors.map((entry) => ({
+              step: `fixture_${channel}_${entry.step}`,
+              error: entry.error
+            })));
+            if (!executionResult.success) {
+              throw new Error(executionResult.partialErrors[executionResult.partialErrors.length - 1]?.error ?? 'Erreur patch');
             }
           }
 
@@ -602,7 +654,7 @@ export const eosWorkflowAutopatchBandTool: ToolDefinition<typeof autopatchBandIn
       'eos_workflow_autopatch_band',
       hasErrors ? 'partial_failure' : 'ok',
       dryRun ? 'Dry run autopatch band genere.' : 'Workflow autopatch band execute.',
-      [],
+      steps,
       partialErrors,
       {
         fixture_logs: logs,
@@ -620,6 +672,7 @@ const rehearsalGoSafeInputSchema = {
   rollback_on_failure: z.boolean().optional(),
   precheck_timeout_ms: optionalTimeoutMsSchema.refine((value) => value == null || value <= 10000, { message: 'precheck_timeout_ms doit etre <= 10000.' }),
   allow_non_empty_command_line: z.boolean().optional(),
+  dry_run: workflowDryRunSchema,
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
@@ -642,7 +695,7 @@ const buildGroupsAndPalettesInputSchema = {
     channels: z.string().trim().min(1).max(256),
     description: z.string().trim().min(1).max(256).optional()
   })).optional(),
-  dry_run: z.boolean().optional(),
+  dry_run: workflowDryRunSchema,
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
@@ -653,7 +706,7 @@ const updateCueLookInputSchema = {
   intensity_factor: z.coerce.number().finite().positive().optional(),
   desaturate: z.boolean().optional(),
   warmify: z.boolean().optional(),
-  dry_run: z.boolean().optional(),
+  dry_run: workflowDryRunSchema,
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
@@ -686,8 +739,43 @@ export const eosWorkflowRehearsalGoSafeTool: ToolDefinition<typeof rehearsalGoSa
         }
       })
       .parse(args ?? {});
+    const dryRun = options.dry_run === true;
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
+
+    const goIdentifier = createCueIdentifierFromOptions({
+      cuelist_number: options.cuelist_number,
+      ...(options.cue_number != null ? { cue_number: options.cue_number } : {})
+    });
+
+    const goCommand = options.cue_number == null
+      ? `Cue ${options.cuelist_number} Go`
+      : `Go To Cue ${options.cuelist_number}/${String(options.cue_number).trim()}`;
+    const rollbackCommand = options.rollback_on_failure && options.rollback_cue_number != null
+      ? (options.rollback_cuelist_number == null
+          ? `Go To Cue ${String(options.rollback_cue_number).trim()}`
+          : `Go To Cue ${options.rollback_cuelist_number}/${String(options.rollback_cue_number).trim()}`)
+      : null;
+    const commandsPreview = rollbackCommand == null ? [goCommand] : [goCommand, rollbackCommand];
+
+    if (dryRun) {
+      steps.push({ step: 'precheck_console_state', status: 'skipped', detail: 'dry_run' });
+      steps.push({ step: 'go', status: 'skipped', command: goCommand, detail: 'dry_run' });
+      if (rollbackCommand != null) {
+        steps.push({ step: 'rollback', status: 'skipped', command: rollbackCommand, detail: 'dry_run_conditional_on_go_failure' });
+      } else {
+        steps.push({ step: 'rollback', status: 'skipped', detail: 'rollback_not_requested' });
+      }
+      return buildWorkflowResult(
+        'eos_workflow_rehearsal_go_safe',
+        'ok',
+        `Dry run GO safe genere pour ${formatCueDescription(goIdentifier)}.`,
+        steps,
+        partialErrors,
+        { commands_preview: commandsPreview }
+      );
+    }
+
     const client = getOscClient();
 
     const precheck = await client.getCommandLine({
@@ -725,15 +813,6 @@ export const eosWorkflowRehearsalGoSafeTool: ToolDefinition<typeof rehearsalGoSa
 
     steps.push({ step: 'precheck_console_state', status: 'ok', detail: 'command_line_empty' });
 
-    const goIdentifier = createCueIdentifierFromOptions({
-      cuelist_number: options.cuelist_number,
-      ...(options.cue_number != null ? { cue_number: options.cue_number } : {})
-    });
-
-    const goCommand = options.cue_number == null
-      ? `Cue ${options.cuelist_number} Go`
-      : `Go To Cue ${options.cuelist_number}/${String(options.cue_number).trim()}`;
-
     const goOk = await runCommandStep(steps, partialErrors, 'go', goCommand, options);
     if (goOk) {
       return buildWorkflowResult(
@@ -745,10 +824,7 @@ export const eosWorkflowRehearsalGoSafeTool: ToolDefinition<typeof rehearsalGoSa
       );
     }
 
-    if (options.rollback_on_failure && options.rollback_cue_number != null) {
-      const rollbackCommand = options.rollback_cuelist_number == null
-        ? `Go To Cue ${String(options.rollback_cue_number).trim()}`
-        : `Go To Cue ${options.rollback_cuelist_number}/${String(options.rollback_cue_number).trim()}`;
+    if (rollbackCommand != null) {
       const rollbackOk = await runCommandStep(steps, partialErrors, 'rollback', rollbackCommand, options);
       if (!rollbackOk) {
         return buildWorkflowResult(


### PR DESCRIPTION
### Motivation
- Provide a consistent `dry_run` option across all `eos_workflow_*` tools so workflows can preview EOS command sequences without sending them. 
- In dry-run mode produce a full commands preview and avoid calling `sendDeterministicCommand`. 
- For real execution keep a structured, command-by-command audit log to surface what was sent and what failed while preserving low-level safety checks on primitive tools. 

### Description
- Introduces a shared `workflowDryRunSchema` and plugs it into all workflow input schemas (`eos_workflow_*`) so `dry_run` is consistently documented and validated. 
- In `buildWorkflowResult` adds `command_log` (detailed per-step entries) and makes `commandsSent` reflect only non-skipped commands so dry-run skips are excluded. 
- Adds dry-run handling to multiple workflows (`create_look`, `create_effect`, `create_cue_series`, `patch_fixture`, `autopatch_band`, `rehearsal_go_safe`, `build_groups_and_palettes`, `update_cue_look`) so they collect `commands_preview` and avoid executing `sendDeterministicCommand` when `dry_run=true`. 
- Updates docs (`scripts/toolDocs.ts`, `docs/tools.md`) and tests to document the default behavior (absent/false = execute and return `command_log`, true = preview in `commands_preview`) and adds regression tests asserting `dry_run` presence in schemas and preview behavior. 

### Testing
- Ran unit tests for modified areas: `npx jest src/tools/workflows/__tests__/workflows.test.ts src/schemas/__tests__/tool_schemas.test.ts --runInBand` — all tests passed. 
- Ran TypeScript build: `npm run tsc` — succeeded. 
- Ran linter: `npm run lint` — succeeded. 
- Regenerated/checked documentation: `npm run docs:generate` and `npm run docs:check --skip-jsdoc` — succeeded and updated `docs/tools.md`. 
- Note: a broader `npm test` invocation exposed unrelated existing test failures in other suites (channel/presets/patch tests) that are outside the scope of these workflow changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa6a6264a4832a95e8063037605c40)