### PR TITLE
Highlight primary workflow tools in manifest

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -3315,9 +3315,9 @@ oscsend 127.0.0.1 8001 /eos/param/wheel/tick s:'{"parameter_name":"exemple","tic
 ```
 
 <a id="eos-workflow-autopatch-band"></a>
-## Workflow autopatch band (`eos_workflow_autopatch_band`)
+## Patch complet du groupe sur scene (`eos_workflow_autopatch_band`)
 
-**Description :** Patche sequentiellement plusieurs blocs de fixtures avec option face trad.
+**Description :** Point d entree naturel pour patcher tout un patch band: blocs de fixtures, adresses DMX, labels et option face trad en une seule sequence.
 
 **Arguments :**
 
@@ -3349,9 +3349,9 @@ _OSC_
 _Pas de mapping OSC documenté._
 
 <a id="eos-workflow-build-groups-and-palettes"></a>
-## Workflow build groups and palettes (`eos_workflow_build_groups_and_palettes`)
+## Construire groupes et palettes (`eos_workflow_build_groups_and_palettes`)
 
-**Description :** Construit des groupes, color palettes et focus palettes en sequence.
+**Description :** Point d entree naturel pour preparer un show: enregistrer des groupes de canaux puis creer et nommer les color palettes et focus palettes associees.
 
 **Arguments :**
 
@@ -3380,9 +3380,9 @@ _OSC_
 _Pas de mapping OSC documenté._
 
 <a id="eos-workflow-create-cue-series"></a>
-## Workflow creation serie de cues (`eos_workflow_create_cue_series`)
+## Programmer une suite de cues reggae (`eos_workflow_create_cue_series`)
 
-**Description :** Enchaine plusieurs looks et enregistre une serie de cues auto-incrementees.
+**Description :** Point d entree naturel pour generer plusieurs cues musicales ou reggae: looks successifs, palettes couleur/focus/beam et numerotation automatique.
 
 **Arguments :**
 
@@ -3411,9 +3411,9 @@ _OSC_
 _Pas de mapping OSC documenté._
 
 <a id="eos-workflow-create-effect"></a>
-## Workflow creation d'effet (`eos_workflow_create_effect`)
+## Creer un effet fly-out (`eos_workflow_create_effect`)
 
-**Description :** Enregistre un groupe optionnel, assigne un effet a des canaux, applique speed/size/direction puis enregistre l'effet.
+**Description :** Point d entree naturel pour creer un fly-out ou effet de mouvement: assignation aux canaux, groupe optionnel, direction center-out/left-right, speed et size.
 
 **Arguments :**
 
@@ -3556,9 +3556,9 @@ _OSC_
 _Pas de mapping OSC documenté._
 
 <a id="eos-workflow-update-cue-look"></a>
-## Workflow update cue look (`eos_workflow_update_cue_look`)
+## Mettre a jour le look d une cue (`eos_workflow_update_cue_look`)
 
-**Description :** Va a une cue, applique des modifications explicites, puis met a jour la cue.
+**Description :** Point d entree naturel pour modifier une cue existante ou courante: aller a la cue, selectionner les canaux, ajuster l intensite puis lancer Update.
 
 **Arguments :**
 

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,74 @@
         "schema_catalogs": [
           "/schemas/tools/index.json"
         ],
-        "schema_base_path": "/schemas/tools/{toolName}.json"
+        "schema_base_path": "/schemas/tools/{toolName}.json",
+        "featured_workflows": [
+          {
+            "id": "eos_workflow_autopatch_band",
+            "title": "Patch complet du groupe sur scene",
+            "description": "Point d entree naturel pour patcher tout un patch band: blocs de fixtures, adresses DMX, labels et option face trad en une seule sequence.",
+            "recommended": true,
+            "primary_entry_point": true,
+            "annotations": {
+              "recommended": true,
+              "primaryEntryPoint": true
+            }
+          },
+          {
+            "id": "eos_workflow_create_cue_series",
+            "title": "Programmer une suite de cues reggae",
+            "description": "Point d entree naturel pour generer plusieurs cues musicales ou reggae: looks successifs, palettes couleur/focus/beam et numerotation automatique.",
+            "recommended": true,
+            "primary_entry_point": true,
+            "annotations": {
+              "recommended": true,
+              "primaryEntryPoint": true
+            }
+          },
+          {
+            "id": "eos_workflow_build_groups_and_palettes",
+            "title": "Construire groupes et palettes",
+            "description": "Point d entree naturel pour preparer un show: enregistrer des groupes de canaux puis creer et nommer les color palettes et focus palettes associees.",
+            "recommended": true,
+            "primary_entry_point": true,
+            "annotations": {
+              "recommended": true,
+              "primaryEntryPoint": true
+            }
+          },
+          {
+            "id": "eos_workflow_update_cue_look",
+            "title": "Mettre a jour le look d une cue",
+            "description": "Point d entree naturel pour modifier une cue existante ou courante: aller a la cue, selectionner les canaux, ajuster l intensite puis lancer Update.",
+            "recommended": true,
+            "primary_entry_point": true,
+            "annotations": {
+              "recommended": true,
+              "primaryEntryPoint": true
+            }
+          },
+          {
+            "id": "eos_workflow_create_effect",
+            "title": "Creer un effet fly-out",
+            "description": "Point d entree naturel pour creer un fly-out ou effet de mouvement: assignation aux canaux, groupe optionnel, direction center-out/left-right, speed et size.",
+            "recommended": true,
+            "primary_entry_point": true,
+            "annotations": {
+              "recommended": true,
+              "primaryEntryPoint": true
+            }
+          }
+        ],
+        "presentation_order": [
+          "eos_workflow_autopatch_band",
+          "eos_workflow_create_cue_series",
+          "eos_workflow_build_groups_and_palettes",
+          "eos_workflow_update_cue_look",
+          "eos_workflow_create_effect",
+          "eos_workflow_create_look",
+          "eos_workflow_patch_fixture",
+          "eos_workflow_rehearsal_go_safe"
+        ]
       }
     },
     "schemas": {

--- a/scripts/validateManifest.ts
+++ b/scripts/validateManifest.ts
@@ -6,6 +6,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import Ajv, { type JSONSchemaType } from 'ajv';
+import { workflowTools } from '../src/tools/workflows/index';
 
 const HTTP_PUBLIC_URL_PLACEHOLDER = 'http://{HOST}:{PORT}';
 
@@ -31,6 +32,15 @@ interface Manifest {
         invoke_endpoint?: string;
         schema_catalogs?: string[];
         schema_base_path?: string;
+        featured_workflows?: Array<{
+          id: string;
+          title: string;
+          description: string;
+          recommended?: boolean;
+          primary_entry_point?: boolean;
+          annotations?: Record<string, unknown>;
+        }>;
+        presentation_order?: string[];
       };
     };
     schemas?: {
@@ -105,7 +115,34 @@ const manifestSchema: JSONSchemaType<Manifest> = {
                   nullable: true,
                   items: { type: 'string', minLength: 1 }
                 },
-                schema_base_path: { type: 'string', nullable: true }
+                schema_base_path: { type: 'string', nullable: true },
+                featured_workflows: {
+                  type: 'array',
+                  nullable: true,
+                  items: {
+                    type: 'object',
+                    additionalProperties: true,
+                    required: ['id', 'title', 'description'],
+                    properties: {
+                      id: { type: 'string', minLength: 1 },
+                      title: { type: 'string', minLength: 1 },
+                      description: { type: 'string', minLength: 1 },
+                      recommended: { type: 'boolean', nullable: true },
+                      primary_entry_point: { type: 'boolean', nullable: true },
+                      annotations: {
+                        type: 'object',
+                        nullable: true,
+                        required: [],
+                        additionalProperties: true
+                      }
+                    }
+                  }
+                },
+                presentation_order: {
+                  type: 'array',
+                  nullable: true,
+                  items: { type: 'string', minLength: 1 }
+                }
               }
             }
           }
@@ -151,6 +188,82 @@ function ensureToolSchemaLinks(manifest: Manifest): void {
       "Le manifest doit aligner mcp.schemas.tool_catalog sur '/schemas/tools/index.json'."
     );
   }
+}
+
+function ensureUniqueValues(values: string[], context: string): void {
+  const seen = new Set<string>();
+  const duplicates = values.filter((value) => {
+    if (seen.has(value)) {
+      return true;
+    }
+    seen.add(value);
+    return false;
+  });
+
+  if (duplicates.length > 0) {
+    throw new Error(`${context} contient des doublons: ${[...new Set(duplicates)].join(', ')}.`);
+  }
+}
+
+function ensureWorkflowManifestCoherence(manifest: Manifest): void {
+  const tools = manifest.mcp.capabilities.tools;
+  const featuredWorkflows = tools?.featured_workflows ?? [];
+  const presentationOrder = tools?.presentation_order ?? [];
+  const exportedWorkflowIds = workflowTools.map((tool) => tool.name);
+  const exportedWorkflowSet = new Set(exportedWorkflowIds);
+
+  if (featuredWorkflows.length === 0) {
+    throw new Error('Le manifest doit exposer les workflows recommandes dans mcp.capabilities.tools.featured_workflows.');
+  }
+
+  const featuredIds = featuredWorkflows.map((entry) => entry.id);
+  ensureUniqueValues(featuredIds, 'mcp.capabilities.tools.featured_workflows');
+  ensureUniqueValues(presentationOrder, 'mcp.capabilities.tools.presentation_order');
+
+  const unknownFeaturedIds = featuredIds.filter((id) => !exportedWorkflowSet.has(id));
+  if (unknownFeaturedIds.length > 0) {
+    throw new Error(
+      `Le manifest reference des workflows non exportes par workflowTools: ${unknownFeaturedIds.join(', ')}.`
+    );
+  }
+
+  const unknownPresentationIds = presentationOrder.filter((id) => !exportedWorkflowSet.has(id));
+  if (unknownPresentationIds.length > 0) {
+    throw new Error(
+      `mcp.capabilities.tools.presentation_order reference des workflows non exportes: ${unknownPresentationIds.join(', ')}.`
+    );
+  }
+
+  const missingExportedWorkflowIds = exportedWorkflowIds.filter((id) => !presentationOrder.includes(id));
+  if (missingExportedWorkflowIds.length > 0) {
+    throw new Error(
+      `mcp.capabilities.tools.presentation_order doit inclure tous les workflowTools exportes: ${missingExportedWorkflowIds.join(', ')}.`
+    );
+  }
+
+  const featuredPrefix = presentationOrder.slice(0, featuredIds.length);
+  if (featuredPrefix.join('\n') !== featuredIds.join('\n')) {
+    throw new Error(
+      'mcp.capabilities.tools.presentation_order doit commencer par les workflows recommandes, dans le meme ordre que featured_workflows.'
+    );
+  }
+
+  featuredWorkflows.forEach((entry) => {
+    if (entry.title.trim().length === 0 || entry.description.trim().length === 0) {
+      throw new Error(`Le workflow ${entry.id} doit definir title et description dans le manifest.`);
+    }
+
+    if (entry.recommended !== true || entry.primary_entry_point !== true) {
+      throw new Error(`Le workflow ${entry.id} doit etre marque recommended et primary_entry_point dans le manifest.`);
+    }
+
+    const annotations = entry.annotations ?? {};
+    if (annotations.recommended !== true || annotations.primaryEntryPoint !== true) {
+      throw new Error(
+        `Le workflow ${entry.id} doit exposer les annotations recommended et primaryEntryPoint pour les clients compatibles.`
+      );
+    }
+  });
 }
 
 function ensureHttpTransportUrls(manifest: Manifest): void {
@@ -210,6 +323,7 @@ async function main(): Promise<void> {
   }
 
   ensureToolSchemaLinks(manifest);
+  ensureWorkflowManifestCoherence(manifest);
   ensureHttpTransportUrls(manifest);
   console.log('Manifest valide ✅');
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -46,6 +46,7 @@ const definitions = [
   eosPingTool,
   eosResetTool,
   eosSubscribeTool,
+  ...workflowTools,
   ...commandTools,
   ...channelTools,
   ...groupTools,
@@ -71,8 +72,7 @@ const definitions = [
   ...fpeTools,
   ...dmxTools,
   ...sessionTools,
-  ...programmingTools,
-  ...workflowTools
+  ...programmingTools
 ];
 
 export const toolDefinitions = definitions as ToolDefinition[];

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -21,6 +21,11 @@ import {
   extractPatchSequenceError
 } from './patchSequence';
 
+const primaryWorkflowAnnotations = {
+  recommended: true,
+  primaryEntryPoint: true
+} satisfies Record<string, unknown>;
+
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
   targetPort: z.coerce.number().int().min(1).max(65535).optional(),
@@ -230,8 +235,8 @@ export const eosWorkflowCreateLookTool: ToolDefinition<typeof createLookInputSch
 
 /**
  * @tool eos_workflow_create_effect
- * @summary Workflow creation d'effet
- * @description Enregistre un groupe optionnel, assigne un effet a des canaux, applique speed/size/direction puis enregistre l'effet.
+ * @summary Creer un effet fly-out
+ * @description Point d entree naturel pour creer un fly-out ou effet de mouvement: assignation aux canaux, groupe optionnel, direction center-out/left-right, speed et size.
  * @arguments Voir docs/tools.md#eos-workflow-create-effect pour le schema complet.
  * @returns ToolExecutionResult avec contenu texte et objet.
  * @example CLI Consultez docs/tools.md#eos-workflow-create-effect pour un exemple CLI.
@@ -240,8 +245,9 @@ export const eosWorkflowCreateLookTool: ToolDefinition<typeof createLookInputSch
 export const eosWorkflowCreateEffectTool: ToolDefinition<typeof createEffectInputSchema> = {
   name: 'eos_workflow_create_effect',
   config: {
-    title: "Workflow creation d'effet",
-    description: "Enregistre un groupe optionnel, assigne un effet a des canaux, applique speed/size/direction puis enregistre l'effet.",
+    title: 'Creer un effet fly-out',
+    description: 'Point d entree naturel pour creer un fly-out ou effet de mouvement: assignation aux canaux, groupe optionnel, direction center-out/left-right, speed et size.',
+    annotations: primaryWorkflowAnnotations,
     inputSchema: createEffectInputSchema
   },
   handler: async (args) => {
@@ -336,8 +342,8 @@ const createCueSeriesInputSchema = {
 
 /**
  * @tool eos_workflow_create_cue_series
- * @summary Workflow creation serie de cues
- * @description Enchaine plusieurs looks et enregistre une serie de cues auto-incrementees.
+ * @summary Programmer une suite de cues reggae
+ * @description Point d entree naturel pour generer plusieurs cues musicales ou reggae: looks successifs, palettes couleur/focus/beam et numerotation automatique.
  * @arguments Voir docs/tools.md#eos-workflow-create-cue-series pour le schema complet.
  * @returns ToolExecutionResult avec contenu texte et objet.
  * @example CLI Consultez docs/tools.md#eos-workflow-create-cue-series pour un exemple CLI.
@@ -346,8 +352,9 @@ const createCueSeriesInputSchema = {
 export const eosWorkflowCreateCueSeriesTool: ToolDefinition<typeof createCueSeriesInputSchema> = {
   name: 'eos_workflow_create_cue_series',
   config: {
-    title: 'Workflow creation serie de cues',
-    description: 'Enchaine plusieurs looks et enregistre une serie de cues auto-incrementees.',
+    title: 'Programmer une suite de cues reggae',
+    description: 'Point d entree naturel pour generer plusieurs cues musicales ou reggae: looks successifs, palettes couleur/focus/beam et numerotation automatique.',
+    annotations: primaryWorkflowAnnotations,
     inputSchema: createCueSeriesInputSchema
   },
   handler: async (args) => {
@@ -545,8 +552,8 @@ const autopatchBandInputSchema = {
 
 /**
  * @tool eos_workflow_autopatch_band
- * @summary Workflow autopatch band
- * @description Patche sequentiellement plusieurs blocs de fixtures avec option face trad.
+ * @summary Patch complet du groupe sur scene
+ * @description Point d entree naturel pour patcher tout un patch band: blocs de fixtures, adresses DMX, labels et option face trad en une seule sequence.
  * @arguments Voir docs/tools.md#eos-workflow-autopatch-band pour le schema complet.
  * @returns ToolExecutionResult avec contenu texte et objet.
  * @example CLI Consultez docs/tools.md#eos-workflow-autopatch-band pour un exemple CLI.
@@ -555,8 +562,9 @@ const autopatchBandInputSchema = {
 export const eosWorkflowAutopatchBandTool: ToolDefinition<typeof autopatchBandInputSchema> = {
   name: 'eos_workflow_autopatch_band',
   config: {
-    title: 'Workflow autopatch band',
-    description: 'Patche sequentiellement plusieurs blocs de fixtures avec option face trad.',
+    title: 'Patch complet du groupe sur scene',
+    description: 'Point d entree naturel pour patcher tout un patch band: blocs de fixtures, adresses DMX, labels et option face trad en une seule sequence.',
+    annotations: primaryWorkflowAnnotations,
     inputSchema: autopatchBandInputSchema
   },
   handler: async (args) => {
@@ -851,8 +859,8 @@ export const eosWorkflowRehearsalGoSafeTool: ToolDefinition<typeof rehearsalGoSa
 
 /**
  * @tool eos_workflow_build_groups_and_palettes
- * @summary Workflow build groups and palettes
- * @description Construit des groupes, color palettes et focus palettes en sequence.
+ * @summary Construire groupes et palettes
+ * @description Point d entree naturel pour preparer un show: enregistrer des groupes de canaux puis creer et nommer les color palettes et focus palettes associees.
  * @arguments Voir docs/tools.md#eos-workflow-build-groups-and-palettes pour le schema complet.
  * @returns ToolExecutionResult avec contenu texte et objet.
  * @example CLI Consultez docs/tools.md#eos-workflow-build-groups-and-palettes pour un exemple CLI.
@@ -861,8 +869,9 @@ export const eosWorkflowRehearsalGoSafeTool: ToolDefinition<typeof rehearsalGoSa
 export const eosWorkflowBuildGroupsAndPalettesTool: ToolDefinition<typeof buildGroupsAndPalettesInputSchema> = {
   name: 'eos_workflow_build_groups_and_palettes',
   config: {
-    title: 'Workflow build groups and palettes',
-    description: 'Construit des groupes, color palettes et focus palettes en sequence.',
+    title: 'Construire groupes et palettes',
+    description: 'Point d entree naturel pour preparer un show: enregistrer des groupes de canaux puis creer et nommer les color palettes et focus palettes associees.',
+    annotations: primaryWorkflowAnnotations,
     inputSchema: buildGroupsAndPalettesInputSchema
   },
   handler: async (args) => {
@@ -914,8 +923,8 @@ export const eosWorkflowBuildGroupsAndPalettesTool: ToolDefinition<typeof buildG
 
 /**
  * @tool eos_workflow_update_cue_look
- * @summary Workflow update cue look
- * @description Va a une cue, applique des modifications explicites, puis met a jour la cue.
+ * @summary Mettre a jour le look d une cue
+ * @description Point d entree naturel pour modifier une cue existante ou courante: aller a la cue, selectionner les canaux, ajuster l intensite puis lancer Update.
  * @arguments Voir docs/tools.md#eos-workflow-update-cue-look pour le schema complet.
  * @returns ToolExecutionResult avec contenu texte et objet.
  * @example CLI Consultez docs/tools.md#eos-workflow-update-cue-look pour un exemple CLI.
@@ -924,8 +933,9 @@ export const eosWorkflowBuildGroupsAndPalettesTool: ToolDefinition<typeof buildG
 export const eosWorkflowUpdateCueLookTool: ToolDefinition<typeof updateCueLookInputSchema> = {
   name: 'eos_workflow_update_cue_look',
   config: {
-    title: 'Workflow update cue look',
-    description: 'Va a une cue, applique des modifications explicites, puis met a jour la cue.',
+    title: 'Mettre a jour le look d une cue',
+    description: 'Point d entree naturel pour modifier une cue existante ou courante: aller a la cue, selectionner les canaux, ajuster l intensite puis lancer Update.',
+    annotations: primaryWorkflowAnnotations,
     inputSchema: updateCueLookInputSchema
   },
   handler: async (args) => {


### PR DESCRIPTION
### Motivation
- Surface and promote high-level workflows as primary entry points so LLM-driven clients discover natural usage flows (patch band, cue series, groups/palettes, update cue, fly-out) before low-level command tools.
- Provide natural-language `title`/`description` and client-side annotations to make these workflows clear as recommended/primary entry points.
- Ensure manifest and runtime exports remain coherent by validating featured workflow IDs and the presentation order against the actual exported `workflowTools`.

### Description
- Add `mcp.capabilities.tools.featured_workflows` and `mcp.capabilities.tools.presentation_order` to `manifest.json`, with `title`, `description`, `recommended`, `primary_entry_point` and `annotations` for the five promoted workflows.
- Update `scripts/validateManifest.ts` to include the new schema fields and add `ensureWorkflowManifestCoherence()` checks that validate uniqueness, that featured IDs exist in exported `workflowTools`, that `presentation_order` includes all exported workflows and begins with the featured list in the same order, and that recommended/primary flags and annotations are present.
- Update `src/tools/workflows/index.ts` to give several workflows natural-language `title`/`description` strings and attach `annotations: { recommended: true, primaryEntryPoint: true }` (via `primaryWorkflowAnnotations`) to the promoted workflows.
- Move `...workflowTools` earlier in `src/tools/index.ts` so the MCP tool list presents workflows before lower-level tools, and regenerate `docs/tools.md` to reflect the updated titles/descriptions.

### Testing
- Ran `npm run lint:manifest` which completed and reported the manifest as valid (`Manifest valide ✅`).
- Ran `npm run lint`, `npm run docs:check` (after `npm run docs:generate`) and `npm run tsc`, all of which completed successfully.
- Ran `git diff --check` and fixed formatting issues; no diff warnings remain.
- Ran the full test suite via `npm test`; unit tests show the workflow-related tests passed (including `src/tools/workflows/__tests__/workflows.test.ts`), but the overall `npm test` run failed with existing unrelated failures (multiple suites failing due to command allowlist / `requestJson` endpoint usage and two OSC snapshot differences); these failures appear orthogonal to the manifest/workflow metadata changes and pre-existed the documentation/regeneration step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faab3f7ae4832ab261f218809b761d)