### PR TITLE
Stabilize LLM-friendly workflow outputs

### DIFF
--- a/docs/release-llm-friendly-workflows.md
+++ b/docs/release-llm-friendly-workflows.md
@@ -1,0 +1,44 @@
+# Checklist release interne — LLM-friendly workflows
+
+Cette checklist doit etre appliquee avant chaque release qui ajoute ou modifie un workflow `eos_workflow_*`.
+
+## 1. Passthrough et compatibilite clients MCP
+
+- [ ] Chaque nouveau workflow utilise un schema Zod `passthrough()` au niveau racine.
+- [ ] Les objets imbriques fournis par le client (ex. `looks`, `fixtures`, `groups`, `color_palettes`, `focus_palettes`) acceptent aussi les metadonnees inconnues avec `passthrough()` quand elles ne sont pas sensibles.
+- [ ] Les champs inconnus ne sont jamais recopies dans les commandes OSC/Eos generees.
+- [ ] Les tools bas niveau sensibles restent stricts et continuent de rejeter les arguments inconnus.
+
+## 2. Defaults documentes et observables
+
+- [ ] `dry_run` absent est documente comme `false`.
+- [ ] `start_cue_number` absent est documente comme `1` pour `eos_workflow_create_cue_series`.
+- [ ] `base_cuelist_number` / `cuelist_number` absent documente clairement le fallback vers la cuelist master quand le workflow le supporte.
+- [ ] Les defaults d'effet (`direction=left_to_right`, `speed=1`, `size=100`) sont documentes.
+- [ ] Les defaults `face_trad_*` de `eos_workflow_autopatch_band` sont documentes.
+- [ ] Les defaults de patch fixture (`part=1`, position 3D `X=0 Y=0 Z=0`) sont documentes.
+- [ ] Chaque default applique apparait dans `structuredContent.applied_defaults` quand il influence le plan retourne.
+
+## 3. Structure de retour stable pour LLM
+
+- [ ] `structuredContent.workflow` contient exactement le nom MCP du tool appele.
+- [ ] `structuredContent.status` utilise seulement les statuts stables (`ok`, `partial_failure`, `failed`).
+- [ ] `structuredContent.steps` est toujours present et liste les etapes dans l'ordre d'orchestration.
+- [ ] `structuredContent.commands_preview` est toujours present et liste les commandes connues du workflow.
+- [ ] `structuredContent.applied_defaults` est toujours present, meme vide.
+- [ ] `structuredContent.warnings` est toujours present, meme vide.
+- [ ] Les champs historiques (`executedSteps`, `command_log`, `commandsSent`, `partialErrors`) restent disponibles pour compatibilite.
+
+## 4. Terminologie et publication
+
+- [ ] Le nom du tool est identique dans le code (`ToolDefinition.name`), les annotations JSDoc, `manifest.json` et `docs/tools.md`.
+- [ ] `manifest.json > mcp.capabilities.tools.presentation_order` reference tous les workflows publies.
+- [ ] `manifest.json > featured_workflows` ne reference que des workflows existants.
+- [ ] Les exemples MCP utilisent le meme nom que le tool publie, sans alias marketing.
+
+## 5. Verifications avant tag
+
+- [ ] Executer `npm run docs:check`.
+- [ ] Executer `npm run lint:manifest`.
+- [ ] Executer `npx jest --runInBand src/tools/workflows/__tests__/workflows.test.ts`.
+- [ ] Si une commande globale comme `npm test` echoue pour des raisons hors scope, consigner les suites impactees dans la note de release interne.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,6 +11,8 @@ Tous les workflows `eos_workflow_*` exposent `dry_run` en option. Quand `dry_run
 
 Quand `dry_run=true`, aucune commande EOS n'est envoyee via `sendDeterministicCommand`; la sequence EOS complete est retournee dans `structuredContent.commands_preview`, et `structuredContent.commandsSent` reste vide. Les garde-fous sensibles restent portes par les tools bas niveau et ne sont pas exposes dans les schemas workflow.
 
+Tous les workflows retournent aussi une structure stable et lisible par les LLM : `structuredContent.steps` (alias moderne de `executedSteps`), `structuredContent.commands_preview` (toujours present), `structuredContent.applied_defaults` (defaults explicites comme `start_cue_number=1` ou fallback cuelist master) et `structuredContent.warnings` (avertissements non bloquants et erreurs partielles resumées).
+
 ## Safety pattern
 
 > **Plan -> dry-run -> confirmation -> execution.** Pour toute modification de show (cue, patch, palette, commande texte ou declenchement live), l’assistant doit annoncer le plan d’action, proposer un dry-run avec preview des commandes, puis executer en reel uniquement apres confirmation explicite de l’operateur.
@@ -52,6 +54,14 @@ Workflows tolerants recenses :
 - `eos_workflow_patch_fixture`
 - `eos_workflow_rehearsal_go_safe`
 - `eos_workflow_update_cue_look`
+
+## Checklist release interne — LLM-friendly workflows
+
+- [ ] Verifier que chaque nouveau workflow `eos_workflow_*` utilise un schema `passthrough()` au niveau racine et sur les objets imbriques pertinents afin d accepter les metadonnees clientes sans les executer.
+- [ ] Documenter chaque valeur par defaut observable (`dry_run=false`, `start_cue_number=1`, fallback cuelist master si `cuelist_number` ou `base_cuelist_number` est absent, defaults `direction/speed/size`, defaults `face_trad_*`, position 3D `0/0/0`).
+- [ ] Confirmer que `structuredContent.steps`, `commands_preview`, `applied_defaults` et `warnings` sont toujours presents et restent des tableaux lisibles par un LLM.
+- [ ] Comparer les noms des tools entre `src/tools/workflows/index.ts`, `manifest.json` (`featured_workflows` et `presentation_order`) et `docs/tools.md`; aucun alias divergent ne doit etre publie.
+- [ ] Executer `npm run docs:check`, `npm run lint:manifest` et les tests workflows avant tag/release.
 
 ## Exemples rapides par workflow naturel
 

--- a/scripts/toolDocs.ts
+++ b/scripts/toolDocs.ts
@@ -687,6 +687,8 @@ function buildDocumentation(tools: ToolDefinition[]): { markdown: string; metada
   lines.push('');
   lines.push("Quand `dry_run=true`, aucune commande EOS n'est envoyee via `sendDeterministicCommand`; la sequence EOS complete est retournee dans `structuredContent.commands_preview`, et `structuredContent.commandsSent` reste vide. Les garde-fous sensibles restent portes par les tools bas niveau et ne sont pas exposes dans les schemas workflow.");
   lines.push('');
+  lines.push('Tous les workflows retournent aussi une structure stable et lisible par les LLM : `structuredContent.steps` (alias moderne de `executedSteps`), `structuredContent.commands_preview` (toujours present), `structuredContent.applied_defaults` (defaults explicites comme `start_cue_number=1` ou fallback cuelist master) et `structuredContent.warnings` (avertissements non bloquants et erreurs partielles resumées).');
+  lines.push('');
   lines.push('## Safety pattern');
   lines.push('');
   lines.push('> **Plan -> dry-run -> confirmation -> execution.** Pour toute modification de show (cue, patch, palette, commande texte ou declenchement live), l’assistant doit annoncer le plan d’action, proposer un dry-run avec preview des commandes, puis executer en reel uniquement apres confirmation explicite de l’operateur.');
@@ -723,6 +725,14 @@ function buildDocumentation(tools: ToolDefinition[]): { markdown: string; metada
   for (const tool of sortedTools.filter(isWorkflowTool)) {
     lines.push(`- \`${tool.name}\``);
   }
+  lines.push('');
+  lines.push('## Checklist release interne — LLM-friendly workflows');
+  lines.push('');
+  lines.push('- [ ] Verifier que chaque nouveau workflow `eos_workflow_*` utilise un schema `passthrough()` au niveau racine et sur les objets imbriques pertinents afin d accepter les metadonnees clientes sans les executer.');
+  lines.push('- [ ] Documenter chaque valeur par defaut observable (`dry_run=false`, `start_cue_number=1`, fallback cuelist master si `cuelist_number` ou `base_cuelist_number` est absent, defaults `direction/speed/size`, defaults `face_trad_*`, position 3D `0/0/0`).');
+  lines.push('- [ ] Confirmer que `structuredContent.steps`, `commands_preview`, `applied_defaults` et `warnings` sont toujours presents et restent des tableaux lisibles par un LLM.');
+  lines.push('- [ ] Comparer les noms des tools entre `src/tools/workflows/index.ts`, `manifest.json` (`featured_workflows` et `presentation_order`) et `docs/tools.md`; aucun alias divergent ne doit etre publie.');
+  lines.push('- [ ] Executer `npm run docs:check`, `npm run lint:manifest` et les tests workflows avant tag/release.');
   lines.push('');
   lines.push(...workflowNaturalExamplesLines);
   lines.push('');

--- a/src/tools/workflows/__tests__/workflows.test.ts
+++ b/src/tools/workflows/__tests__/workflows.test.ts
@@ -2,6 +2,8 @@
  * Copyright 2026 Florian Ribes (NairolfConcept)
  * SPDX-License-Identifier: Apache-2.0
  */
+import fs from 'node:fs';
+import path from 'node:path';
 import type { OscMessage } from '../../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { runTool, getStructuredContent } from '../../__tests__/helpers/runTool';
@@ -237,6 +239,136 @@ describe('workflow tools', () => {
         client_request_id: 'abc-123'
       })
     ).rejects.toThrow(/Unrecognized key/);
+  });
+
+  it('accepte le passthrough et retourne une structure LLM stable sur tous les workflows', async () => {
+    const workflowCases = [
+      {
+        tool: eosWorkflowCreateLookTool,
+        args: { channels: '1', cue_number: 1, dry_run: true, client_trace_id: 'trace-create-look' }
+      },
+      {
+        tool: eosWorkflowCreateEffectTool,
+        args: { channels: '1', effect_number: 1, dry_run: true, client_trace_id: 'trace-create-effect' }
+      },
+      {
+        tool: eosWorkflowCreateCueSeriesTool,
+        args: {
+          looks: [{ channels: '1', cue_label: 'A', client_note: 'nested passthrough' }],
+          dry_run: true,
+          client_trace_id: 'trace-cue-series'
+        }
+      },
+      {
+        tool: eosWorkflowPatchFixtureTool,
+        args: {
+          channel_number: 1,
+          dmx_address: '1/1',
+          device_type: 'Dimmer',
+          label: 'Dimmer 1',
+          dry_run: true,
+          client_trace_id: 'trace-patch-fixture'
+        }
+      },
+      {
+        tool: eosWorkflowAutopatchBandTool,
+        args: {
+          fixtures: [{ count: 1, fixture_query: 'Spica', universe: 1, start_address: 1, label_prefix: 'Wash', client_note: 'nested passthrough' }],
+          dry_run: true,
+          client_trace_id: 'trace-autopatch-band'
+        }
+      },
+      {
+        tool: eosWorkflowRehearsalGoSafeTool,
+        args: { cuelist_number: 1, dry_run: true, client_trace_id: 'trace-rehearsal-go-safe' }
+      },
+      {
+        tool: eosWorkflowBuildGroupsAndPalettesTool,
+        args: {
+          groups: [{ number: 1, label: 'Face', channels: '1', client_note: 'nested passthrough' }],
+          dry_run: true,
+          client_trace_id: 'trace-groups-palettes'
+        }
+      },
+      {
+        tool: eosWorkflowUpdateCueLookTool,
+        args: { channels: '1', dry_run: true, client_trace_id: 'trace-update-cue-look' }
+      }
+    ];
+
+    for (const workflowCase of workflowCases) {
+      const result = await runTool(workflowCase.tool, workflowCase.args);
+      const structured = getStructuredContent(result);
+      expect(structured?.workflow).toBe(workflowCase.tool.name);
+      expect(Array.isArray(structured?.steps)).toBe(true);
+      expect(Array.isArray(structured?.commands_preview)).toBe(true);
+      expect(Array.isArray(structured?.applied_defaults)).toBe(true);
+      expect(Array.isArray(structured?.warnings)).toBe(true);
+      expect(structured).not.toHaveProperty('client_trace_id');
+    }
+  });
+
+  it('expose les defaults documentes dans applied_defaults', async () => {
+    const cueSeriesResult = await runTool(eosWorkflowCreateCueSeriesTool, {
+      looks: [{ channels: '7', cue_label: 'Solo' }],
+      dry_run: true
+    });
+    const cueSeriesStructured = getStructuredContent(cueSeriesResult);
+    expect(cueSeriesStructured?.applied_defaults).toEqual(expect.arrayContaining([
+      {
+        step: 'default_base_cuelist_number',
+        detail: 'base_cuelist_number absent: utilisation automatique de la cuelist master.'
+      },
+      {
+        step: 'default_start_cue_number',
+        detail: 'start_cue_number absent: valeur par defaut 1 appliquee automatiquement.'
+      },
+      {
+        step: 'look_1_default_cue_number',
+        detail: 'cue_number absent: auto-increment applique avec la valeur 1.'
+      }
+    ]));
+
+    const updateResult = await runTool(eosWorkflowUpdateCueLookTool, {
+      cue_number: 5,
+      channels: '9',
+      dry_run: true
+    });
+    const updateStructured = getStructuredContent(updateResult);
+    expect(updateStructured?.applied_defaults).toEqual(expect.arrayContaining([
+      {
+        step: 'default_cuelist_number',
+        detail: 'cuelist_number absent: utilisation automatique de la cuelist master pour la cue cible.'
+      }
+    ]));
+  });
+
+  it('garde les noms de workflows homogenes entre code, manifest et docs', () => {
+    const repoRoot = path.resolve(__dirname, '../../../..');
+    const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, 'manifest.json'), 'utf8')) as {
+      mcp: { capabilities: { tools: { presentation_order: string[]; featured_workflows: Array<{ id: string }> } } };
+    };
+    const docs = fs.readFileSync(path.join(repoRoot, 'docs/tools.md'), 'utf8');
+    const codeWorkflowNames = [
+      eosWorkflowCreateLookTool,
+      eosWorkflowCreateEffectTool,
+      eosWorkflowCreateCueSeriesTool,
+      eosWorkflowPatchFixtureTool,
+      eosWorkflowAutopatchBandTool,
+      eosWorkflowRehearsalGoSafeTool,
+      eosWorkflowBuildGroupsAndPalettesTool,
+      eosWorkflowUpdateCueLookTool
+    ].map((tool) => tool.name).sort();
+    const manifestWorkflowNames = manifest.mcp.capabilities.tools.presentation_order.filter((name) => name.startsWith('eos_workflow_')).sort();
+
+    expect(manifestWorkflowNames).toEqual(codeWorkflowNames);
+    for (const workflow of manifest.mcp.capabilities.tools.featured_workflows) {
+      expect(codeWorkflowNames).toContain(workflow.id);
+      expect(docs).toContain(`\`${workflow.id}\``);
+    }
+    for (const name of codeWorkflowNames) {
+      expect(docs).toContain(`\`${name}\``);
+    }
   });
 
   it('orchestre eos_workflow_create_cue_series avec increment automatique des cues', async () => {

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -50,6 +50,44 @@ interface WorkflowStepLog {
   error?: string;
 }
 
+interface WorkflowAppliedDefault {
+  step: string;
+  detail: string;
+}
+
+interface WorkflowWarning {
+  step: string;
+  detail: string;
+}
+
+function isDefaultStep(step: WorkflowStepLog): boolean {
+  return step.step.startsWith('default_') || step.step.includes('_default_');
+}
+
+function buildAppliedDefaults(steps: WorkflowStepLog[]): WorkflowAppliedDefault[] {
+  return steps
+    .filter((step) => isDefaultStep(step) && typeof step.detail === 'string')
+    .map((step) => ({ step: step.step, detail: step.detail! }));
+}
+
+function buildWarnings(steps: WorkflowStepLog[], partialErrors: Array<{ step: string; error: string }>): WorkflowWarning[] {
+  const skippedWarnings = steps
+    .filter((step) =>
+      step.status === 'skipped'
+      && typeof step.detail === 'string'
+      && step.detail !== 'dry_run'
+      && step.detail !== 'dry_run_conditional_on_go_failure'
+      && step.detail !== 'rollback_not_requested'
+      && !isDefaultStep(step)
+    )
+    .map((step) => ({ step: step.step, detail: step.detail! }));
+
+  return [
+    ...skippedWarnings,
+    ...partialErrors.map((entry) => ({ step: entry.step, detail: entry.error }))
+  ];
+}
+
 function buildWorkflowResult(
   workflow: string,
   status: 'ok' | 'partial_failure' | 'failed',
@@ -58,6 +96,7 @@ function buildWorkflowResult(
   partialErrors: Array<{ step: string; error: string }>,
   extraStructuredContent: Record<string, unknown> = {}
 ): ToolExecutionResult {
+  const { commands_preview: explicitCommandsPreview, ...restStructuredContent } = extraStructuredContent;
   const commandLog = steps
     .filter((step) => typeof step.command === 'string')
     .map((step) => ({
@@ -67,19 +106,26 @@ function buildWorkflowResult(
       ...(step.detail != null ? { detail: step.detail } : {}),
       ...(step.error != null ? { error: step.error } : {})
     }));
+  const commandsPreview = Array.isArray(explicitCommandsPreview)
+    ? explicitCommandsPreview.filter((command): command is string => typeof command === 'string')
+    : commandLog.map((step) => step.command);
 
   return {
     content: [{ type: 'text', text: summary }],
     structuredContent: {
       workflow,
       status,
+      steps,
       executedSteps: steps,
+      commands_preview: commandsPreview,
+      applied_defaults: buildAppliedDefaults(steps),
+      warnings: buildWarnings(steps, partialErrors),
       command_log: commandLog,
       commandsSent: commandLog
         .filter((step) => step.status !== 'skipped')
         .map((step) => step.command),
       partialErrors,
-      ...extraStructuredContent
+      ...restStructuredContent
     }
   };
 }


### PR DESCRIPTION
### Motivation
- Rendre les workflows `eos_workflow_*` plus faciles à consommer par des LLM en exposant une sortie structurée et stable (prévisualisation, étapes, defaults documentés, avertissements). 
- Assurer l'homogénéité terminologique entre le code, le manifest et la doc générée pour éviter des divergences de noms d'outils.
- Fournir une checklist interne pour guider les releases qui ajoutent/modifient des workflows afin de conserver la compatibilité LLM-friendly.

### Description
- Ajout des champs stables retournés par les workflows dans `structuredContent`: `steps`, `commands_preview`, `applied_defaults` et `warnings` tout en conservant les champs historiques (`executedSteps`, `command_log`, `commandsSent`, `partialErrors`). (cf. `src/tools/workflows/index.ts`)
- Implémentation d'aides pour extraire les defaults et warnings depuis le journal d'exécution afin de peupler `applied_defaults` et `warnings`. (cf. `buildAppliedDefaults`, `buildWarnings`)
- Adaptation du builder de résultat pour prioriser un `commands_preview` explicite fourni par le workflow ou en dériver depuis le journal de commandes. (cf. `buildWorkflowResult`)
- Tests unitaires étendus pour vérifier : passthrough (acceptation de champs inconnus), présence systématique des nouveaux champs LLM-friendly, exposition des defaults documentés et cohérence des noms entre code/manifest/docs. (cf. `src/tools/workflows/__tests__/workflows.test.ts`)
- Mise à jour de la documentation générée et du script de génération (`scripts/toolDocs.ts` et `docs/tools.md`) pour décrire le contrat de sortie stable et inclusion d'une checklist de release LLM-friendly (`docs/release-llm-friendly-workflows.md`).

### Testing
- `npm run docs:check` — succès. 
- `npm run lint:manifest` — succès.
- `npm run tsc` — succès (TypeScript compile sans erreur).
- `npm run lint` — succès (ESLint passe).
- `npx jest --runInBand src/tools/workflows/__tests__/workflows.test.ts` — succès, la suite des tests workflows ajoutés/étendus passe.
- `npm test` (suite complète) — échoue sur suites non liées aux changements de workflow (problèmes existants d'allowlist `requestJson`, règles de validation de commandes et quelques snapshots OSC), les tests affectant les workflows restent verts et les échecs sont hors-scope de cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022b598420832a88d268d8a137cc73)