### PR TITLE
Allow query count/list endpoints for `requestJson` and add comprehensive query tests

### DIFF
--- a/src/services/osc/messageBuilders.ts
+++ b/src/services/osc/messageBuilders.ts
@@ -159,6 +159,11 @@ export function extractJsonPayloadFromMessage(message: OscMessage): Record<strin
   return parsed as Record<string, unknown>;
 }
 
+const QUERY_JSON_ENDPOINTS = Object.values(oscMappings.queries).flatMap((mapping) => [
+  mapping.count,
+  mapping.list
+]);
+
 const DOCUMENTED_JSON_ENDPOINTS = new Set<string>([
   oscMappings.cues.info,
   oscMappings.cues.list,
@@ -171,7 +176,8 @@ const DOCUMENTED_JSON_ENDPOINTS = new Set<string>([
   oscMappings.palettes.intensity.info,
   oscMappings.palettes.focus.info,
   oscMappings.palettes.color.info,
-  oscMappings.palettes.beam.info
+  oscMappings.palettes.beam.info,
+  ...QUERY_JSON_ENDPOINTS
 ]);
 
 export function isDocumentedJsonEndpoint(address: string): boolean {

--- a/src/tools/queries/__tests__/queries.test.ts
+++ b/src/tools/queries/__tests__/queries.test.ts
@@ -2,6 +2,7 @@
  * Copyright 2026 Florian Ribes (NairolfConcept)
  * SPDX-License-Identifier: Apache-2.0
  */
+import { getResourceCache } from '../../../services/cache/index';
 import type { OscMessage } from '../../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
@@ -29,10 +30,41 @@ class FakeOscService implements OscGateway {
   }
 }
 
+const QUERY_TARGET_TYPES = [
+  'cue',
+  'cuelist',
+  'group',
+  'macro',
+  'ms',
+  'ip',
+  'fp',
+  'cp',
+  'bp',
+  'preset',
+  'sub',
+  'fx',
+  'curve',
+  'snap',
+  'pixmap'
+] as const;
+
+function emitJson(service: FakeOscService, address: string, payload: Record<string, unknown>): void {
+  service.emit({
+    address,
+    args: [
+      {
+        type: 's',
+        value: JSON.stringify(payload)
+      }
+    ]
+  });
+}
+
 describe('query tools', () => {
   let service: FakeOscService;
 
   beforeEach(() => {
+    getResourceCache().clearAll();
     service = new FakeOscService();
     const client = new OscClient(service, { defaultTimeoutMs: 50 });
     setOscClient(client);
@@ -40,6 +72,45 @@ describe('query tools', () => {
 
   afterEach(() => {
     setOscClient(null);
+    getResourceCache().clearAll();
+  });
+
+  it('autorise requestJson pour les endpoints count et list de chaque target_type', async () => {
+    for (const targetType of QUERY_TARGET_TYPES) {
+      const mapping = oscMappings.queries[targetType];
+      const countPromise = runTool(eosGetCountTool, { target_type: targetType });
+
+      queueMicrotask(() => {
+        expect(service.sentMessages.at(-1)).toMatchObject({ address: mapping.count });
+        emitJson(service, mapping.count, { status: 'ok', count: 1 });
+      });
+
+      const countContent = getStructuredContent(await countPromise);
+      expect(countContent).toMatchObject({
+        action: 'get_count',
+        status: 'ok',
+        target_type: targetType,
+        count: 1
+      });
+
+      const listPromise = runTool(eosGetListAllTool, { target_type: targetType });
+
+      queueMicrotask(() => {
+        expect(service.sentMessages.at(-1)).toMatchObject({ address: mapping.list });
+        emitJson(service, mapping.list, {
+          status: 'ok',
+          items: [{ number: 1, uid: `${targetType}:1`, label: targetType }]
+        });
+      });
+
+      const listContent = getStructuredContent(await listPromise);
+      expect(listContent).toMatchObject({
+        action: 'list_all',
+        status: 'ok',
+        target_type: targetType,
+        items: [{ number: '1', uid: `${targetType}:1`, label: targetType }]
+      });
+    }
   });
 
   it('envoie la requete de count vers le mapping FX et normalise la reponse', async () => {
@@ -189,5 +260,27 @@ describe('query tools', () => {
         { number: '2', uid: 'ms:2', label: null }
       ]
     });
+  });
+
+  it('retourne un structuredContent timeout quand aucune reponse OSC narrive', async () => {
+    const result = await runTool(eosGetCountTool, { target_type: 'group', timeoutMs: 50 });
+    const structuredContent = getStructuredContent(result);
+    expect(structuredContent).toBeDefined();
+    if (!structuredContent) {
+      throw new Error('Expected structured content');
+    }
+
+    expect(structuredContent).toMatchObject({
+      action: 'get_count',
+      status: 'timeout',
+      target_type: 'group',
+      count: 0,
+      data: null,
+      osc: {
+        address: oscMappings.queries.group.count,
+        args: {}
+      }
+    });
+    expect(typeof structuredContent.error).toBe('string');
   });
 });


### PR DESCRIPTION
### Motivation

- Enable `client.requestJson(...)` to be used for all query endpoints (`oscMappings.queries.*.count` and `*.list`) so query tools no longer throw for those addresses.
- Verify that each supported `target_type` can call `requestJson` for both `count` and `list` and that responses are normalised correctly.
- Ensure timeout or absent OSC responses produce a `structuredContent.status` of `timeout` (or `error`) instead of causing the tool to fail abruptly.

### Description

- Add `QUERY_JSON_ENDPOINTS` (built from `oscMappings.queries`) and spread it into `DOCUMENTED_JSON_ENDPOINTS` in `src/services/osc/messageBuilders.ts` so query `count`/`list` endpoints are allowed by `requestJson`.
- Extend `src/tools/queries/__tests__/queries.test.ts` with a list of all query `target_type`s, a helper `emitJson`, cache clearing in `beforeEach`/`afterEach`, a test iterating every `target_type` to exercise both `count` and `list`, and a timeout test that asserts `structuredContent.status === 'timeout'`.
- Keep existing query handlers unchanged; they already propagate `response.status`, `response.data` and `response.error` into the returned `structuredContent` so timeout/error statuses are preserved.

### Testing

- Ran `npx jest src/tools/queries/__tests__/queries.test.ts --runInBand` and the test suite passed.
- Ran `npm run tsc` and `npm run lint` and both succeeded.
- Running the full `npm test` invoked unrelated pre-existing failing suites (strict command allowlist, undocumented JSON endpoints in other tools, snapshot diffs), so the broader suite failed but the changes are scoped and the queries tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b7dbfc18832a92a4adb59860aaf9)