### PR TITLE
Add `intensity`/`level` to cue-series looks and emit separate `Chan … At …` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Exemple de modification de cue :
 3. **Confirmation explicite** : attendre une réponse non ambiguë, par exemple « Confirme, exécute la mise à jour de la cue 12. »
 4. **Exécution réelle** : relancer le même workflow avec `dry_run=false`, puis contrôler `structuredContent.command_log` et `structuredContent.commandsSent`.
 
-Les **outils bas niveau sensibles** (`eos_cue_record`, `eos_cue_update`, `eos_patch_*`, `eos_command`, `eos_new_command`, déclenchements `fire`, etc.) s’adressent aux intégrations qui savent exactement quelle commande EOS envoyer et s’appuient sur `require_confirmation`, `safety_level` et des schémas stricts. `eos_new_command` refuse aussi les commandes composées de programmation de cues (par exemple `At` + `Record` + `Label`) : envoyez plutôt `Chan 1 Thru 10 At Full`, puis `Record Cue 3`, puis `Cue 3 Label "Reggae"` en appels séparés. Les **workflows haut niveau guidés** (`eos_workflow_*`) orchestrent plusieurs commandes métier, acceptent des métadonnées clientes inconnues sans les exécuter et fournissent une preview complète via `dry_run=true`; ils sont donc à privilégier pour les assistants conversationnels.
+Les **outils bas niveau sensibles** (`eos_cue_record`, `eos_cue_update`, `eos_patch_*`, `eos_command`, `eos_new_command`, déclenchements `fire`, etc.) s’adressent aux intégrations qui savent exactement quelle commande EOS envoyer et s’appuient sur `require_confirmation`, `safety_level` et des schémas stricts. `eos_new_command` refuse aussi les commandes composées de programmation de cues (par exemple `At` + `Record` + `Label`). Pour une série de cues, Claude doit privilégier `eos_workflow_create_cue_series` avec `looks[].intensity` (ou `looks[].level`) afin que le workflow émette `Chan 1 Thru 10 At Full`, puis `Record Cue 3`, puis `Cue 3 Label "Reggae"` comme commandes séparées, sans concaténer `At`, `Record` ou `Label` dans `channels`. Les **workflows haut niveau guidés** (`eos_workflow_*`) orchestrent plusieurs commandes métier, acceptent des métadonnées clientes inconnues sans les exécuter et fournissent une preview complète via `dry_run=true`; ils sont donc à privilégier pour les assistants conversationnels.
 
 ## Prérequis
 
@@ -558,7 +558,7 @@ Pour limiter les ambiguïtés en conduite et garder une trace claire des décisi
 3. **Choix du niveau d’abstraction** : privilégier les workflows haut niveau lorsque l’intention correspond au besoin :
    - `eos_workflow_autopatch_band` pour préparer rapidement un patch groupe/band ;
    - `eos_workflow_create_look` pour construire un look cohérent à partir de canaux, palettes ou groupes ;
-   - `eos_workflow_create_cue_series` pour générer une suite de cues structurée.
+   - `eos_workflow_create_cue_series` pour générer une suite de cues structurée; pour un niveau, renseigner `looks[].intensity` ou `looks[].level` (`Full`, `Out`, `0`-`100`, valeurs EOS sûres) plutôt que d’ajouter `At` dans `channels`.
 4. **Répétitions** : utiliser `eos_workflow_rehearsal_go_safe` pour les tops en répétition, plutôt qu’un `GO` bas niveau direct, afin de conserver les garde-fous de cuelist, cue cible et validation.
 5. **Prévisualisation obligatoire** : demander d’abord `dry_run: true` sur les workflows ou outils qui le supportent, relire le journal/aperçu retourné avec l’utilisateur, puis relancer uniquement après validation explicite avec `dry_run: false` ou sans champ `dry_run`.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -24,7 +24,7 @@ Exemple concret pour modifier une cue :
 3. **Confirmation explicite** : attendre une reponse non ambigue, par exemple "Confirme, execute la mise a jour de la cue 12".
 4. **Execution reelle** : relancer le meme workflow avec `dry_run=false` seulement apres cette confirmation, puis verifier `structuredContent.command_log` et `structuredContent.commandsSent`.
 
-Les **outils bas niveau sensibles** (`eos_cue_record`, `eos_cue_update`, `eos_patch_*`, `eos_command`, `eos_new_command`, declenchements `fire`, etc.) exposent des garde-fous stricts comme `require_confirmation`, `safety_level` et le rejet des arguments inconnus. Ils sont adaptes aux integrations qui savent exactement quelle commande EOS envoyer. `eos_new_command` refuse aussi les commandes composees de programmation de cues (par exemple `At` + `Record` + `Label`) : envoyez plutot `Chan 1 Thru 10 At Full`, puis `Record Cue 3`, puis `Cue 3 Label "Reggae"` en appels separes.
+Les **outils bas niveau sensibles** (`eos_cue_record`, `eos_cue_update`, `eos_patch_*`, `eos_command`, `eos_new_command`, declenchements `fire`, etc.) exposent des garde-fous stricts comme `require_confirmation`, `safety_level` et le rejet des arguments inconnus. Ils sont adaptes aux integrations qui savent exactement quelle commande EOS envoyer. `eos_new_command` refuse aussi les commandes composees de programmation de cues (par exemple `At` + `Record` + `Label`). Pour une serie de cues, Claude doit privilegier `eos_workflow_create_cue_series` avec `looks[].intensity` (ou `looks[].level`) afin que le workflow emette `Chan 1 Thru 10 At Full`, puis `Record Cue 3`, puis `Cue 3 Label "Reggae"` comme commandes separees.
 
 Les **workflows haut niveau guides** (`eos_workflow_*`) orchestrent plusieurs commandes metier, acceptent des metadonnees clientes inconnues sans les executer et fournissent une preview complete via `dry_run=true`. Ils sont a privilegier pour les assistants conversationnels, car ils imposent un parcours operateur plus lisible avant toute action destructive ou visible en live.
 
@@ -124,6 +124,7 @@ Les payloads ci-dessous utilisent le format MCP `tools/call` complet. Les exempl
       "looks": [
         {
           "channels": "1 Thru 10",
+          "intensity": "Full",
           "color_palette": 101,
           "focus_palette": 201,
           "beam_palette": 301,
@@ -150,7 +151,7 @@ Les payloads ci-dessous utilisent le format MCP `tools/call` complet. Les exempl
 }
 ```
 
-**Options et valeurs par defaut :** `looks` est obligatoire et doit contenir au moins un look; chaque look requiert `channels`. `start_cue_number` vaut `1` par defaut et s'auto-incremente si un look ne precise pas `cue_number`. `base_cuelist_number` absent utilise la cuelist master. `color_palette`, `focus_palette`, `beam_palette` et `cue_label` sont optionnels par look. Pour "10 cues", envoyez 10 objets dans `looks` ou ajoutez des `cue_number` explicites pour les positions particulieres.
+**Options et valeurs par defaut :** `looks` est obligatoire et doit contenir au moins un look; chaque look requiert `channels`. Pour regler un niveau, renseignez `intensity` (ou l'alias `level`) avec `Full`, `Out`, une valeur `0` a `100`, ou une valeur EOS textuelle sure (`On`, `Home`, `FL`) : le workflow genere alors une commande separee `Chan <channels> At <intensity>` avant les palettes. Ne concatenez pas `At`, `Record` ou `Label` dans `channels`. `start_cue_number` vaut `1` par defaut et s'auto-incremente si un look ne precise pas `cue_number`. `base_cuelist_number` absent utilise la cuelist master. `color_palette`, `focus_palette`, `beam_palette` et `cue_label` sont optionnels par look. Pour "10 cues", envoyez 10 objets dans `looks` ou ajoutez des `cue_number` explicites pour les positions particulieres.
 
 ### Workflow groups/palettes
 

--- a/scripts/toolDocs.ts
+++ b/scripts/toolDocs.ts
@@ -520,6 +520,7 @@ const workflowNaturalExamplesLines = [
   "      \"looks\": [",
   "        {",
   "          \"channels\": \"1 Thru 10\",",
+  "          \"intensity\": \"Full\",",
   "          \"color_palette\": 101,",
   "          \"focus_palette\": 201,",
   "          \"beam_palette\": 301,",
@@ -546,7 +547,7 @@ const workflowNaturalExamplesLines = [
   "}",
   "```",
   "",
-  "**Options et valeurs par defaut :** `looks` est obligatoire et doit contenir au moins un look; chaque look requiert `channels`. `start_cue_number` vaut `1` par defaut et s'auto-incremente si un look ne precise pas `cue_number`. `base_cuelist_number` absent utilise la cuelist master. `color_palette`, `focus_palette`, `beam_palette` et `cue_label` sont optionnels par look. Pour \"10 cues\", envoyez 10 objets dans `looks` ou ajoutez des `cue_number` explicites pour les positions particulieres.",
+  "**Options et valeurs par defaut :** `looks` est obligatoire et doit contenir au moins un look; chaque look requiert `channels`. Pour regler un niveau, renseignez `intensity` (ou l'alias `level`) avec `Full`, `Out`, une valeur `0` a `100`, ou une valeur EOS textuelle sure (`On`, `Home`, `FL`) : le workflow genere alors une commande separee `Chan <channels> At <intensity>` avant les palettes. Ne concatenez pas `At`, `Record` ou `Label` dans `channels`. `start_cue_number` vaut `1` par defaut et s'auto-incremente si un look ne precise pas `cue_number`. `base_cuelist_number` absent utilise la cuelist master. `color_palette`, `focus_palette`, `beam_palette` et `cue_label` sont optionnels par look. Pour \"10 cues\", envoyez 10 objets dans `looks` ou ajoutez des `cue_number` explicites pour les positions particulieres.",
   "",
   "### Workflow groups/palettes",
   "",
@@ -700,7 +701,7 @@ function buildDocumentation(tools: ToolDefinition[]): { markdown: string; metada
   lines.push('3. **Confirmation explicite** : attendre une reponse non ambigue, par exemple "Confirme, execute la mise a jour de la cue 12".');
   lines.push('4. **Execution reelle** : relancer le meme workflow avec `dry_run=false` seulement apres cette confirmation, puis verifier `structuredContent.command_log` et `structuredContent.commandsSent`.');
   lines.push('');
-  lines.push('Les **outils bas niveau sensibles** (`eos_cue_record`, `eos_cue_update`, `eos_patch_*`, `eos_command`, `eos_new_command`, declenchements `fire`, etc.) exposent des garde-fous stricts comme `require_confirmation`, `safety_level` et le rejet des arguments inconnus. Ils sont adaptes aux integrations qui savent exactement quelle commande EOS envoyer. `eos_new_command` refuse aussi les commandes composees de programmation de cues (par exemple `At` + `Record` + `Label`) : envoyez plutot `Chan 1 Thru 10 At Full`, puis `Record Cue 3`, puis `Cue 3 Label "Reggae"` en appels separes.');
+  lines.push('Les **outils bas niveau sensibles** (`eos_cue_record`, `eos_cue_update`, `eos_patch_*`, `eos_command`, `eos_new_command`, declenchements `fire`, etc.) exposent des garde-fous stricts comme `require_confirmation`, `safety_level` et le rejet des arguments inconnus. Ils sont adaptes aux integrations qui savent exactement quelle commande EOS envoyer. `eos_new_command` refuse aussi les commandes composees de programmation de cues (par exemple `At` + `Record` + `Label`). Pour une serie de cues, Claude doit privilegier `eos_workflow_create_cue_series` avec `looks[].intensity` (ou `looks[].level`) afin que le workflow emette `Chan 1 Thru 10 At Full`, puis `Record Cue 3`, puis `Cue 3 Label "Reggae"` comme commandes separees.');
   lines.push('');
   lines.push('Les **workflows haut niveau guides** (`eos_workflow_*`) orchestrent plusieurs commandes metier, acceptent des metadonnees clientes inconnues sans les executer et fournissent une preview complete via `dry_run=true`. Ils sont a privilegier pour les assistants conversationnels, car ils imposent un parcours operateur plus lisible avant toute action destructive ou visible en live.');
   lines.push('');

--- a/src/tools/workflows/__tests__/workflows.test.ts
+++ b/src/tools/workflows/__tests__/workflows.test.ts
@@ -396,6 +396,32 @@ describe('workflow tools', () => {
     ]);
   });
 
+  it('applique une intensite separee avant palettes, record et label dans create_cue_series', async () => {
+    const result = await runTool(eosWorkflowCreateCueSeriesTool, {
+      start_cue_number: 3,
+      looks: [
+        {
+          channels: '1 Thru 10',
+          intensity: 'Full',
+          cue_label: 'Reggae'
+        }
+      ]
+    });
+
+    const structured = getStructuredContent(result);
+    expect(structured?.status).toBe('ok');
+    expect(structured?.commands_preview).toEqual([
+      'Chan 1 Thru 10 At Full',
+      'Record Cue 3',
+      'Cue 3 Label "Reggae"'
+    ]);
+    expect(structured?.commandsSent).toEqual([
+      'Chan 1 Thru 10 At Full',
+      'Record Cue 3',
+      'Cue 3 Label "Reggae"'
+    ]);
+  });
+
   it('genere commands_preview en dry run pour create_cue_series et fallback master cuelist', async () => {
     const result = await runTool(eosWorkflowCreateCueSeriesTool, {
       looks: [

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -371,12 +371,40 @@ export const eosWorkflowCreateEffectTool: ToolDefinition<typeof createEffectInpu
 };
 
 
+const safeIntensityTextSchema = z.string().trim().min(1).max(32).refine((value) => {
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return numeric >= 0 && numeric <= 100;
+  }
+
+  return /^(?:Full|Out|On|Home|FL)$/i.test(value);
+}, 'intensity doit etre Full, Out, On, Home, FL ou une valeur numerique de 0 a 100.');
+
+const cueSeriesIntensitySchema = z.union([
+  z.number().finite().min(0).max(100),
+  safeIntensityTextSchema
+]);
+
+function formatCueSeriesIntensity(value: string | number | undefined): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return String(value);
+  }
+
+  return value.trim();
+}
+
 const createCueSeriesInputSchema = {
   base_cuelist_number: cuelistNumberSchema.optional(),
   start_cue_number: cueNumberSchema.optional().default(1),
   looks: z.array(workflowObject({
     channels: z.string().trim().min(1).max(256),
     cue_number: cueNumberSchema.optional(),
+    intensity: cueSeriesIntensitySchema.optional(),
+    level: cueSeriesIntensitySchema.optional(),
     color_palette: z.coerce.number().int().min(1).max(99999).optional(),
     focus_palette: z.coerce.number().int().min(1).max(99999).optional(),
     beam_palette: z.coerce.number().int().min(1).max(99999).optional(),
@@ -427,8 +455,12 @@ export const eosWorkflowCreateCueSeriesTool: ToolDefinition<typeof createCueSeri
         pushDefaultLog(steps, `look_${index + 1}_default_cue_number`, `cue_number absent: auto-increment applique avec la valeur ${effectiveCueNumber}.`);
       }
       const cueStepPrefix = `look_${index + 1}_cue_${effectiveCueNumber}`;
+      const intensity = formatCueSeriesIntensity(look.intensity ?? look.level);
       const commands = [
-        { step: `${cueStepPrefix}_select_channels`, command: `Chan ${look.channels}` },
+        {
+          step: `${cueStepPrefix}_select_channels`,
+          command: intensity != null ? `Chan ${look.channels} At ${intensity}` : `Chan ${look.channels}`
+        },
         ...(look.color_palette != null ? [{ step: `${cueStepPrefix}_apply_color_palette`, command: `CP ${look.color_palette}` }] : []),
         ...(look.focus_palette != null ? [{ step: `${cueStepPrefix}_apply_focus_palette`, command: `FP ${look.focus_palette}` }] : []),
         ...(look.beam_palette != null ? [{ step: `${cueStepPrefix}_apply_beam_palette`, command: `BP ${look.beam_palette}` }] : []),


### PR DESCRIPTION
### Motivation
- Allow cue-series `looks[]` to express an explicit intensity/level so the workflow can emit a separate selection+level command instead of requiring assistants to concatenate `At` into `channels`.
- Keep the workflow command sequence clear and safe by producing a distinct selection/level step before applying palettes, recording the cue and setting a label.
- Update documentation so tool authors and assistants (Claude) use the structured `intensity`/`level` field rather than building compound `channels` strings.

### Description
- Added a safe text/number intensity schema (`safeIntensityTextSchema`, `cueSeriesIntensitySchema`) and `formatCueSeriesIntensity` helper to `src/tools/workflows/index.ts` and extended `createCueSeriesInputSchema` with optional `intensity` and `level` per look.
- When a look provides `intensity`/`level`, the workflow now emits `Chan <channels> At <intensity>` as a separate step (selection/level) before palettes, `Record Cue …`, and `Cue … Label …` commands.
- Added a unit test in `src/tools/workflows/__tests__/workflows.test.ts` to assert both `commands_preview` and `commandsSent` contain `Chan 1 Thru 10 At Full`, `Record Cue 3`, and `Cue 3 Label "Reggae"` in the expected order.
- Updated user-facing guidance in `README.md` and the generator `scripts/toolDocs.ts` (and regenerated `docs/tools.md`) to instruct assistants to use `looks[].intensity` / `looks[].level` rather than concatenating `At`/`Record`/`Label` in `channels`.

### Testing
- Ran TypeScript build via `npm run tsc` which succeeded.
- Ran the focused unit tests for the workflows suite via `npm run test:unit -- --runTestsByPath src/tools/workflows/__tests__/workflows.test.ts` and the updated workflow tests passed.
- Ran `scripts/toolDocs.ts` checks via `npm run docs:check` which initially reported the docs needed regeneration and then `npm run docs:generate` was executed successfully to update generated docs.
- Running the full test matrix (`npm test`) surfaced unrelated existing failures in other test suites; the changes in this PR are limited to the cue-series workflow and its tests which passed in isolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04bb270a50832a81df50ad5d5b2f3e)