### PR TITLE
Expose degraded OSC connection limitations and handshake capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,13 +554,14 @@ Les trois intégrations ci-dessous s’appuient sur le protocole MCP. Chaque out
 Pour limiter les ambiguïtés en conduite et garder une trace claire des décisions, demandez à Claude de suivre ce flux avant toute action Eos :
 
 1. **Connexion** : appeler `eos_connect` si la session OSC n’est pas encore établie ou si la cible réseau doit être confirmée.
-2. **Audit des capacités** : appeler `eos_capabilities_get` pour vérifier les outils disponibles, le mode de sécurité et l’état de la passerelle avant de proposer un plan.
+2. **Audit des capacités** : appeler `eos_capabilities_get` pour vérifier les outils disponibles, le mode de sécurité et l’état de la passerelle avant de proposer un plan. Lire explicitement `structuredContent.context.osc_limitations` (ou le résultat de `eos_connect`) : si `can_read_queries=false`, Claude doit annoncer que la lecture EOS n’est pas garantie et ne doit pas inventer le patch, la cuelist, les cues ou l’état du show sans réponse de lecture explicite.
 3. **Choix du niveau d’abstraction** : privilégier les workflows haut niveau lorsque l’intention correspond au besoin :
    - `eos_workflow_autopatch_band` pour préparer rapidement un patch groupe/band ;
    - `eos_workflow_create_look` pour construire un look cohérent à partir de canaux, palettes ou groupes ;
    - `eos_workflow_create_cue_series` pour générer une suite de cues structurée; pour un niveau, renseigner `looks[].intensity` ou `looks[].level` (`Full`, `Out`, `0`-`100`, valeurs EOS sûres) plutôt que d’ajouter `At` dans `channels`.
 4. **Répétitions** : utiliser `eos_workflow_rehearsal_go_safe` pour les tops en répétition, plutôt qu’un `GO` bas niveau direct, afin de conserver les garde-fous de cuelist, cue cible et validation.
 5. **Prévisualisation obligatoire** : demander d’abord `dry_run: true` sur les workflows ou outils qui le supportent, relire le journal/aperçu retourné avec l’utilisateur, puis relancer uniquement après validation explicite avec `dry_run: false` ou sans champ `dry_run`.
+6. **Mode dégradé** : si `eos_connect` retourne `handshake_mode=degraded` ou une limitation « mode dégradé : envoi possible, lecture non garantie », Claude peut proposer des envois prudents après confirmation, mais doit traiter toute lecture de patch/cuelist comme inconnue tant qu’un outil de lecture ne répond pas avec succès.
 
 **Règle de confirmation utilisateur** : Claude doit obtenir une confirmation explicite de l’utilisateur avant toute action destructive ou toute modification du show, notamment patch, record, update, delete, live fire, rappel de palette/preset affectant la scène, ou déclenchement de cue. Lorsque l’outil expose `require_confirmation`, l’appel réel doit inclure `require_confirmation: true` après cette confirmation.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -28,6 +28,10 @@ Les **outils bas niveau sensibles** (`eos_cue_record`, `eos_cue_update`, `eos_pa
 
 Les **workflows haut niveau guides** (`eos_workflow_*`) orchestrent plusieurs commandes metier, acceptent des metadonnees clientes inconnues sans les executer et fournissent une preview complete via `dry_run=true`. Ils sont a privilegier pour les assistants conversationnels, car ils imposent un parcours operateur plus lisible avant toute action destructive ou visible en live.
 
+## Capacites de lecture OSC
+
+Avant de raisonner sur le contenu du show, Claude doit lire `eos_connect.structuredContent` ou `eos_capabilities_get.structuredContent.context.osc_limitations`. Si `can_read_queries=false`, Claude ne doit pas inventer le patch, la cuelist, les cues ou les objets EOS : il doit les presenter comme inconnus et demander une lecture reussie ou une confirmation utilisateur explicite. En `handshake_mode=degraded`, le serveur indique seulement que l’envoi est possible; la lecture reste non garantie tant qu’une requete de lecture ne retourne pas `status=ok`.
+
 ## Options communes de securite (outils critiques)
 
 Les outils critiques des familles **cues**, **patch**, **palettes** et **commandes texte** exposent les options suivantes :
@@ -630,6 +634,8 @@ oscsend 127.0.0.1 8001 /eos/cp/fire s:'{"palette_number":1}'
 | `targetPort` | number | Non | — |
 | `terminateWithEnter` | boolean | Non | — |
 | `user` | number | Non | — |
+| `verification_timeout_ms` | number | Non | — |
+| `verify_after_send` | boolean | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -666,6 +672,8 @@ oscsend 127.0.0.1 8001 /eos/cmd s:'{"command":"exemple"}'
 | `terminateWithEnter` | boolean | Non | — |
 | `user` | number | Non | — |
 | `values` | array<string \| number \| boolean> | Non | — |
+| `verification_timeout_ms` | number | Non | — |
+| `verify_after_send` | boolean | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -1821,6 +1829,8 @@ oscsend 127.0.0.1 8001 /eos/get/active/wheels s:'{"timeoutMs":1}'
 | `targetPort` | number | Non | — |
 | `timeoutMs` | number | Non | — |
 | `user` | number | Non | — |
+| `verification_timeout_ms` | number | Non | — |
+| `verify_after_send` | boolean | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -2082,6 +2092,8 @@ oscsend 127.0.0.1 8001 /eos/get/softkey_labels s:'{"timeoutMs":1}'
 | `targetPort` | number | Non | — |
 | `timeoutMs` | number | Non | — |
 | `user` | number | Oui | — |
+| `verification_timeout_ms` | number | Non | — |
+| `verify_after_send` | boolean | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -2516,6 +2528,8 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'{"osc_command":"exemple"}'
 | `targetPort` | number | Non | — |
 | `terminateWithEnter` | boolean | Non | — |
 | `user` | number | Non | — |
+| `verification_timeout_ms` | number | Non | — |
+| `verify_after_send` | boolean | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 

--- a/scripts/toolDocs.ts
+++ b/scripts/toolDocs.ts
@@ -705,6 +705,10 @@ function buildDocumentation(tools: ToolDefinition[]): { markdown: string; metada
   lines.push('');
   lines.push('Les **workflows haut niveau guides** (`eos_workflow_*`) orchestrent plusieurs commandes metier, acceptent des metadonnees clientes inconnues sans les executer et fournissent une preview complete via `dry_run=true`. Ils sont a privilegier pour les assistants conversationnels, car ils imposent un parcours operateur plus lisible avant toute action destructive ou visible en live.');
   lines.push('');
+  lines.push('## Capacites de lecture OSC');
+  lines.push('');
+  lines.push('Avant de raisonner sur le contenu du show, Claude doit lire `eos_connect.structuredContent` ou `eos_capabilities_get.structuredContent.context.osc_limitations`. Si `can_read_queries=false`, Claude ne doit pas inventer le patch, la cuelist, les cues ou les objets EOS : il doit les presenter comme inconnus et demander une lecture reussie ou une confirmation utilisateur explicite. En `handshake_mode=degraded`, le serveur indique seulement que l’envoi est possible; la lecture reste non garantie tant qu’une requete de lecture ne retourne pas `status=ok`.');
+  lines.push('');
   lines.push('## Options communes de securite (outils critiques)');
   lines.push('');
   lines.push('Les outils critiques des familles **cues**, **patch**, **palettes** et **commandes texte** exposent les options suivantes :');

--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -318,7 +318,8 @@ describe('OscClient', () => {
     expect(parseLegacyHandshakeMessage(legacyMessage)).toEqual({
       version: null,
       protocols: [],
-      raw: legacyMessage
+      raw: legacyMessage,
+      mode: 'legacy'
     });
   });
 
@@ -488,6 +489,9 @@ describe('OscClient', () => {
     await Promise.resolve();
     await Promise.resolve();
     await jest.advanceTimersByTimeAsync(11);
+    await Promise.resolve();
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(11);
 
     await expect(promise).resolves.toMatchObject<Partial<ConnectResult>>({
       status: 'timeout',
@@ -495,6 +499,40 @@ describe('OscClient', () => {
       version: null,
       error: expect.stringContaining('expire')
     });
+  });
+
+  it('retourne un mode degrade lorsque le handshake expire mais que le ping repond et la lecture timeout', async () => {
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    const promise = client.connect({ handshakeTimeoutMs: 5 });
+
+    await waitFor(() => service.sentMessages.some((message) => message.address === '/eos/ping'), 200);
+
+    service.emit({
+      address: '/eos/out/ping',
+      args: [
+        {
+          type: 's',
+          value: JSON.stringify({ status: 'ok', echo: 'degraded-connect-probe' })
+        }
+      ]
+    });
+
+    const result = await promise;
+
+    expect(result).toMatchObject<Partial<ConnectResult>>({
+      status: 'ok',
+      handshake_mode: 'degraded',
+      can_send_commands: true,
+      can_read_queries: false,
+      version: null,
+      protocolStatus: 'skipped',
+      selectedProtocol: null
+    });
+    expect(result.limitations.join(' ')).toContain('Mode dégradé : envoi possible, lecture non garantie.');
+    expect(result.limitations.join(' ')).toContain('Lecture des requêtes EOS non garantie');
+    expect(service.sentMessages.map((message) => message.address)).toContain('/eos/get/cmd_line');
   });
 
   it('retente le handshake en mode speed apres un timeout TCP', async () => {

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -99,10 +99,13 @@ export interface ConnectOptions extends TargetOptions {
   clientId?: string;
 }
 
+export type HandshakeMode = 'canonical' | 'legacy' | 'timeout' | 'degraded';
+
 export interface HandshakeData {
   version: string | null;
   protocols: string[];
   raw: unknown;
+  mode: Extract<HandshakeMode, 'canonical' | 'legacy'>;
 }
 
 export function parseLegacyHandshakeMessage(message: OscMessage): HandshakeData | null {
@@ -117,7 +120,8 @@ export function parseLegacyHandshakeMessage(message: OscMessage): HandshakeData 
   return {
     version: null,
     protocols: [],
-    raw: message
+    raw: message,
+    mode: 'legacy'
   };
 }
 
@@ -128,6 +132,10 @@ export interface ConnectResult extends Record<string, unknown> {
   selectedProtocol: string | null;
   protocolStatus: StepStatus;
   handshakePayload: unknown;
+  can_send_commands: boolean;
+  can_read_queries: boolean;
+  handshake_mode: HandshakeMode;
+  limitations: string[];
   protocolResponse?: unknown;
   error?: string;
 }
@@ -235,21 +243,23 @@ export class OscClient {
         selectedProtocol: protocolResult.selectedProtocol,
         protocolStatus: protocolResult.status,
         handshakePayload: handshake.raw,
+        can_send_commands: true,
+        can_read_queries: handshake.mode === 'canonical',
+        handshake_mode: handshake.mode,
+        limitations: this.buildConnectionLimitations(
+          handshake.mode,
+          true,
+          handshake.mode === 'canonical',
+          protocolResult.status,
+          protocolResult.error
+        ),
         protocolResponse: protocolResult.payload,
         ...(protocolResult.error ? { error: protocolResult.error } : {})
       };
     } catch (error) {
       const timeoutError = this.asAppError(error, ErrorCode.OSC_TIMEOUT);
       if (timeoutError) {
-        return {
-          status: 'timeout',
-          version: null,
-          availableProtocols: [],
-          selectedProtocol: null,
-          protocolStatus: 'skipped',
-          handshakePayload: null,
-          error: timeoutError.message
-        };
+        return this.buildTimeoutConnectResult(options, timeoutError.message);
       }
 
       const connectionLostError = this.asAppError(error, ErrorCode.OSC_CONNECTION_LOST);
@@ -261,6 +271,10 @@ export class OscClient {
           selectedProtocol: null,
           protocolStatus: 'skipped',
           handshakePayload: null,
+          can_send_commands: false,
+          can_read_queries: false,
+          handshake_mode: 'timeout',
+          limitations: this.buildConnectionLimitations('timeout', false, false, 'skipped', connectionLostError.message),
           error: connectionLostError.message
         };
       }
@@ -789,6 +803,108 @@ export class OscClient {
     return args;
   }
 
+  private async buildTimeoutConnectResult(options: ConnectOptions, errorMessage: string): Promise<ConnectResult> {
+    const timeoutMs = Math.max(1, Math.min(
+      options.handshakeTimeoutMs ?? this.config.handshakeTimeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS,
+      this.config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS,
+      400
+    ));
+
+    const targetOptions: TargetOptions = {
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort,
+      toolId: options.toolId,
+      transportPreference: options.transportPreference
+    };
+
+    let canSendCommands = false;
+    let canReadQueries = false;
+    const probeErrors: string[] = [];
+
+    const ping = await this.ping({
+      ...targetOptions,
+      message: 'degraded-connect-probe',
+      timeoutMs
+    });
+
+    if (ping.status === 'ok') {
+      canSendCommands = true;
+
+      const queryProbe = await this.getCommandLine({
+        ...targetOptions,
+        timeoutMs
+      });
+      canReadQueries = queryProbe.status === 'ok';
+      if (!canReadQueries && queryProbe.error) {
+        probeErrors.push(`Probe lecture: ${queryProbe.error}`);
+      }
+    } else if (ping.error) {
+      probeErrors.push(`Probe ping: ${ping.error}`);
+    }
+
+    const handshakeMode: HandshakeMode = canSendCommands ? 'degraded' : 'timeout';
+    const limitations = this.buildConnectionLimitations(
+      handshakeMode,
+      canSendCommands,
+      canReadQueries,
+      'skipped',
+      [errorMessage, ...probeErrors].join(' ')
+    );
+
+    return {
+      status: canSendCommands ? 'ok' : 'timeout',
+      version: null,
+      availableProtocols: [],
+      selectedProtocol: null,
+      protocolStatus: 'skipped',
+      handshakePayload: null,
+      can_send_commands: canSendCommands,
+      can_read_queries: canReadQueries,
+      handshake_mode: handshakeMode,
+      limitations,
+      error: errorMessage
+    };
+  }
+
+  private buildConnectionLimitations(
+    handshakeMode: HandshakeMode,
+    canSendCommands: boolean,
+    canReadQueries: boolean,
+    protocolStatus: StepStatus,
+    detail?: string
+  ): string[] {
+    const limitations: string[] = [];
+
+    if (handshakeMode === 'degraded') {
+      limitations.push('Mode dégradé : envoi possible, lecture non garantie.');
+      limitations.push('Handshake EOS canonique indisponible; version et protocoles non confirmés.');
+    } else if (handshakeMode === 'timeout') {
+      limitations.push('Handshake EOS expiré; aucune capacité OSC confirmée.');
+    } else if (handshakeMode === 'legacy') {
+      limitations.push('Handshake legacy détecté; les requêtes de lecture JSON ne sont pas garanties.');
+    }
+
+    if (!canSendCommands) {
+      limitations.push('Envoi de commandes EOS non confirmé.');
+    }
+
+    if (!canReadQueries) {
+      limitations.push('Lecture des requêtes EOS non garantie; ne pas inventer le patch, les cues ou les cuelists sans réponse de lecture explicite.');
+    }
+
+    if (protocolStatus === 'timeout') {
+      limitations.push('Sélection de protocole expirée; transport OSC conservé en mode best-effort.');
+    } else if (protocolStatus === 'error') {
+      limitations.push('Sélection de protocole en erreur; transport OSC conservé en mode best-effort.');
+    }
+
+    if (detail && detail.trim().length > 0) {
+      limitations.push(`Détail: ${detail.trim()}`);
+    }
+
+    return Array.from(new Set(limitations));
+  }
+
   private async performHandshake(options: ConnectOptions, timeout: number): Promise<HandshakeData> {
     const args = [
       { type: 's', value: 'ETCOSC?' },
@@ -1088,7 +1204,8 @@ export class OscClient {
     return {
       version,
       protocols,
-      raw: payload ?? message
+      raw: payload ?? message,
+      mode: 'canonical'
     };
   }
 

--- a/src/tools/capabilities/index.ts
+++ b/src/tools/capabilities/index.ts
@@ -142,6 +142,7 @@ export const eosCapabilitiesGetTool: ToolDefinition<typeof emptySchema> = {
     const client = getOscClient();
     let liveBlindMode: 'live' | 'blind' | 'unknown' = 'unknown';
     let liveBlindRaw: OscJsonResponse | null = null;
+    let versionRaw: OscJsonResponse | null = null;
     let detectedEosVersion: string | null = null;
 
     try {
@@ -152,11 +153,27 @@ export const eosCapabilitiesGetTool: ToolDefinition<typeof emptySchema> = {
     }
 
     try {
-      const versionResponse = await client.requestJson(oscMappings.system.getVersion, { timeoutMs: 400 });
-      detectedEosVersion = parseDetectedEosVersion(versionResponse.data);
+      versionRaw = await client.requestJson(oscMappings.system.getVersion, { timeoutMs: 400 });
+      detectedEosVersion = parseDetectedEosVersion(versionRaw.data);
     } catch (_error) {
       detectedEosVersion = null;
     }
+
+    const canReadQueries = liveBlindRaw?.status === 'ok' || versionRaw?.status === 'ok';
+    const canSendCommands = oscConnection.health !== 'offline';
+    const limitations = [
+      ...(canSendCommands ? [] : ['Envoi de commandes EOS non confirmé par l’état de transport OSC.']),
+      ...(canReadQueries
+        ? []
+        : ['Lecture des requêtes EOS non garantie; Claude ne doit pas inventer le patch, les cues ou les cuelists sans réponse de lecture explicite.'])
+    ];
+
+    const connectionLimitations = {
+      can_send_commands: canSendCommands,
+      can_read_queries: canReadQueries,
+      handshake_mode: oscConnection.health === 'online' ? 'canonical' : oscConnection.health === 'degraded' ? 'degraded' : 'timeout',
+      limitations
+    };
 
     const safety = {
       default_safety_level: 'strict',
@@ -186,10 +203,12 @@ export const eosCapabilitiesGetTool: ToolDefinition<typeof emptySchema> = {
     const summary = [
       `Capacites disponibles: ${tools.length} outils, ${Object.keys(families).length} familles.`,
       `Connexion OSC: ${oscConnection.health}.`,
+      `Capacites OSC: envoi commandes ${canSendCommands ? 'oui' : 'non'}, lecture requetes ${canReadQueries ? 'oui' : 'non'}.`,
       `Utilisateur courant: ${typeof user === 'number' ? user : 'non defini'}.`,
       `Mode console: ${liveBlindMode}.`,
       `Version EOS detectee: ${detectedEosVersion ?? 'inconnue'}.`,
-      `Version serveur: ${version}.`
+      `Version serveur: ${version}.`,
+      `Limitations: ${limitations.length > 0 ? limitations.join(' | ') : 'aucune'}.`
     ].join(' ');
 
     return {
@@ -201,6 +220,7 @@ export const eosCapabilitiesGetTool: ToolDefinition<typeof emptySchema> = {
         },
         context: {
           osc_connection: oscConnection,
+          osc_limitations: connectionLimitations,
           current_user: user,
           mode: {
             live_blind: liveBlindMode,

--- a/src/tools/connection/eos_connect.ts
+++ b/src/tools/connection/eos_connect.ts
@@ -45,9 +45,13 @@ export const eosConnectTool: ToolDefinition<typeof inputSchema> = {
 
     const summaryParts = [
       `Handshake: ${result.status}`,
+      `Mode handshake: ${result.handshake_mode}`,
+      `Envoi commandes: ${result.can_send_commands ? 'oui' : 'non'}`,
+      `Lecture requetes: ${result.can_read_queries ? 'oui' : 'non'}`,
       `Protocoles disponibles: ${result.availableProtocols.length > 0 ? result.availableProtocols.join(', ') : 'aucun'}`,
       `Protocole selectionne: ${result.selectedProtocol ?? 'non defini'} (${result.protocolStatus})`,
-      `Version detectee: ${result.version ?? 'inconnue'}`
+      `Version detectee: ${result.version ?? 'inconnue'}`,
+      `Limitations: ${result.limitations.length > 0 ? result.limitations.join(' | ') : 'aucune'}`
     ];
 
     return {


### PR DESCRIPTION
### Motivation
- Clarifier les capacités réseau renvoyées par la connexion OSC afin que l’orchestrateur et Claude sachent explicitement si l’envoi de commandes et la lecture de requêtes JSON sont possibles ou non. 
- Traiter le cas où le handshake canonical timeoute mais où le ping répond (mode dégradé) en indiquant clairement « envoi possible, lecture non garantie » pour éviter que Claude n’invente des patchs/cuelists/cues.

### Description
- Enrichit `ConnectResult` avec `can_send_commands`, `can_read_queries`, `handshake_mode` (`canonical|legacy|timeout|degraded`) et `limitations` et introduit `HandshakeMode` et la normalisation `mode` pour les handshakes canoniques/legacy (src/services/osc/client.ts).
- Ajoute une logique de fallback après timeout de handshake qui sonde `ping` puis une lecture de ligne de commande pour détecter le mode `degraded` et construire des limitations lisibles (src/services/osc/client.ts).
- Expose ces informations dans le rendu texte et `structuredContent` de l’outil `eos_connect` (src/tools/connection/eos_connect.ts) et dans `eos_capabilities_get` via `structuredContent.context.osc_limitations` (src/tools/capabilities/index.ts).
- Met à jour la documentation et le générateur de docs pour demander explicitement à Claude de ne pas inventer le patch/cuelist/cues quand `can_read_queries=false` (README.md, scripts/toolDocs.ts, docs/tools.md).
- Ajout d’un test unitaire pour couvrir le scénario « handshake timeout + ping OK + query timeout » qui vérifie le mode `degraded`, les flags et la présence des limitations (src/services/osc/__tests__/client.test.ts).

### Testing
- `tsc` exécuté et réussi.
- Tests ciblés: `npx jest src/services/osc/__tests__/client.test.ts --runInBand` exécuté et tous les tests de ce fichier passent (21/21).
- Lint: `npm run lint` exécuté et réussi.
- Documentation: `npm run docs:generate` puis `npm run docs:check` exécutés et la documentation régénérée/validée avec succès.
- Exécution complète des tests unitaires: `npm run test:unit` a été lancée, les modifications du client OSC passent, mais la suite complète révèle échecs dans plusieurs suites préexistantes liées à endpoints `requestJson` non documentés et snapshots OSC (ces échecs sont hors-scope des changements de cette PR et provenaient de contraintes d’intégration/documentation et snapshots attendus).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c9627584832a936b88337713122f)