### PR TITLE
Support EOS out response addresses for cue queries

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -32,6 +32,18 @@ Les **workflows haut niveau guides** (`eos_workflow_*`) orchestrent plusieurs co
 
 Avant de raisonner sur le contenu du show, Claude doit lire `eos_connect.structuredContent` ou `eos_capabilities_get.structuredContent.context.osc_limitations`. Si `can_read_queries=false`, Claude ne doit pas inventer le patch, la cuelist, les cues ou les objets EOS : il doit les presenter comme inconnus et demander une lecture reussie ou une confirmation utilisateur explicite. En `handshake_mode=degraded`, le serveur indique seulement que l’envoi est possible; la lecture reste non garantie tant qu’une requete de lecture ne retourne pas `status=ok`.
 
+### Adresses de reponse OSC acceptees pour les lectures cues/cuelists
+
+Les requetes JSON EOS attendent par defaut une reponse sur l’adresse de requete, et les outils de lecture transmettent explicitement les variantes `/eos/out/...` observees sur EOS quand elles sont supportees. Les adresses actuellement acceptees sont :
+
+| Famille | Requete envoyee | Reponses acceptees | Outils concernes |
+| --- | --- | --- | --- |
+| `queries.cue.count` | `/eos/get/cue/count` | `/eos/get/cue/count`, `/eos/out/get/cue/count` | `eos_get_count` avec `target_type: "cue"` |
+| `queries.cue.list` | `/eos/get/cue/list` | `/eos/get/cue/list`, `/eos/out/get/cue/list` | `eos_get_list_all` avec `target_type: "cue"` |
+| `queries.cuelist.list` | `/eos/get/cuelist/list` | `/eos/get/cuelist/list`, `/eos/out/get/cuelist/list` | `eos_get_list_all` avec `target_type: "cuelist"` |
+| `cues.list` | `/eos/get/cuelist` | `/eos/get/cuelist`, `/eos/out/get/cuelist` | `eos_cue_list_all` |
+| `cues.info` | `/eos/get/cue` | `/eos/get/cue`, `/eos/out/get/cue` | `eos_cue_get_info` |
+
 ## Options communes de securite (outils critiques)
 
 Les outils critiques des familles **cues**, **patch**, **palettes** et **commandes texte** exposent les options suivantes :

--- a/scripts/toolDocs.ts
+++ b/scripts/toolDocs.ts
@@ -709,6 +709,18 @@ function buildDocumentation(tools: ToolDefinition[]): { markdown: string; metada
   lines.push('');
   lines.push('Avant de raisonner sur le contenu du show, Claude doit lire `eos_connect.structuredContent` ou `eos_capabilities_get.structuredContent.context.osc_limitations`. Si `can_read_queries=false`, Claude ne doit pas inventer le patch, la cuelist, les cues ou les objets EOS : il doit les presenter comme inconnus et demander une lecture reussie ou une confirmation utilisateur explicite. En `handshake_mode=degraded`, le serveur indique seulement que l’envoi est possible; la lecture reste non garantie tant qu’une requete de lecture ne retourne pas `status=ok`.');
   lines.push('');
+  lines.push('### Adresses de reponse OSC acceptees pour les lectures cues/cuelists');
+  lines.push('');
+  lines.push('Les requetes JSON EOS attendent par defaut une reponse sur l’adresse de requete, et les outils de lecture transmettent explicitement les variantes `/eos/out/...` observees sur EOS quand elles sont supportees. Les adresses actuellement acceptees sont :');
+  lines.push('');
+  lines.push('| Famille | Requete envoyee | Reponses acceptees | Outils concernes |');
+  lines.push('| --- | --- | --- | --- |');
+  lines.push('| `queries.cue.count` | `/eos/get/cue/count` | `/eos/get/cue/count`, `/eos/out/get/cue/count` | `eos_get_count` avec `target_type: "cue"` |');
+  lines.push('| `queries.cue.list` | `/eos/get/cue/list` | `/eos/get/cue/list`, `/eos/out/get/cue/list` | `eos_get_list_all` avec `target_type: "cue"` |');
+  lines.push('| `queries.cuelist.list` | `/eos/get/cuelist/list` | `/eos/get/cuelist/list`, `/eos/out/get/cuelist/list` | `eos_get_list_all` avec `target_type: "cuelist"` |');
+  lines.push('| `cues.list` | `/eos/get/cuelist` | `/eos/get/cuelist`, `/eos/out/get/cuelist` | `eos_cue_list_all` |');
+  lines.push('| `cues.info` | `/eos/get/cue` | `/eos/get/cue`, `/eos/out/get/cue` | `eos_cue_get_info` |');
+  lines.push('');
   lines.push('## Options communes de securite (outils critiques)');
   lines.push('');
   lines.push('Les outils critiques des familles **cues**, **patch**, **palettes** et **commandes texte** exposent les options suivantes :');

--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -722,6 +722,44 @@ describe('OscClient', () => {
     });
   });
 
+  it('accepte les variantes /eos/out/get pour les reponses JSON EOS', async () => {
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    const responsePromise = client.requestJson('/eos/get/cue/list', {
+      responseAddresses: ['/eos/get/cue/list', '/eos/out/get/cue/list']
+    });
+
+    await waitFor(() => service.sentMessages.length >= 1);
+
+    expect(service.sentMessages[0]).toEqual({
+      address: '/eos/get/cue/list',
+      args: []
+    });
+
+    service.emit({
+      address: '/eos/out/get/cue/list',
+      args: [
+        {
+          type: 's',
+          value: JSON.stringify({
+            status: 'ok',
+            cues: [{ number: '1', uid: 'cue-1', label: 'Intro' }]
+          })
+        }
+      ]
+    });
+
+    const result = await responsePromise;
+
+    expect(result.status).toBe('ok');
+    expect(result.data).toEqual({
+      status: 'ok',
+      cues: [{ number: '1', uid: 'cue-1', label: 'Intro' }]
+    });
+    expect(result.payload).toMatchObject({ address: '/eos/out/get/cue/list' });
+  });
+
   it('respecte la limite de concurrence configuree', async () => {
     const service = new FakeOscService();
     service.delayMs = 10;

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -201,6 +201,7 @@ export interface CommandLineState extends Record<string, unknown> {
 export interface OscJsonRequestOptions extends TargetOptions {
   payload?: Record<string, unknown>;
   responseAddress?: string;
+  responseAddresses?: readonly string[];
   timeoutMs?: number;
 }
 
@@ -535,7 +536,12 @@ export class OscClient {
       transportPreference: options.transportPreference
     };
     const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS;
-    const responseAddress = options.responseAddress ?? address;
+    const responseAddresses = this.normaliseResponseAddresses(
+      address,
+      options.responseAddress,
+      options.responseAddresses
+    );
+    const responseAddressSet = new Set(responseAddresses);
     const payload = options.payload ?? {};
     const hasPayload = Object.keys(payload).length > 0;
     const operation = `la requete OSC ${address}`;
@@ -553,11 +559,11 @@ export class OscClient {
     }
 
     const awaiter = this.createResponseAwaiter(
-      (incoming) => (incoming.address === responseAddress ? incoming : null),
+      (incoming) => (responseAddressSet.has(incoming.address) ? incoming : null),
       timeoutMs,
-      `Aucune reponse pour ${responseAddress} recue avant expiration`,
+      `Aucune reponse pour ${responseAddresses.join(' ou ')} recue avant expiration`,
       operation,
-      { address: responseAddress, requestAddress: address }
+      { address: responseAddresses, requestAddress: address }
     );
 
     try {
@@ -578,7 +584,8 @@ export class OscClient {
       const status = this.normaliseStatus(data);
       if (status === 'error') {
         this.ensureConnectionActive(operation, data, {
-          address: responseAddress,
+          address: response.address,
+          acceptedResponseAddresses: responseAddresses,
           requestAddress: address
         });
       }
@@ -625,6 +632,23 @@ export class OscClient {
       ...options,
       payload: extractJsonPayloadFromMessage(request.message)
     });
+  }
+
+  private normaliseResponseAddresses(
+    requestAddress: string,
+    responseAddress?: string,
+    responseAddresses?: readonly string[]
+  ): string[] {
+    const candidates = [
+      responseAddress,
+      ...(responseAddresses ?? []),
+      requestAddress
+    ];
+    return candidates.filter((candidate, index, values): candidate is string => (
+      typeof candidate === 'string' &&
+      candidate.length > 0 &&
+      values.indexOf(candidate) === index
+    ));
   }
 
   public setLogging(options: OscLoggingOptions = {}): OscLoggingState {

--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -209,3 +209,27 @@ export const oscMappings = {
 } as const;
 
 export type OscMappings = typeof oscMappings;
+
+export function toEosOutResponseAddress(address: string): string {
+  return address.startsWith('/eos/out/') ? address : address.replace(/^\/eos\//, '/eos/out/');
+}
+
+export function withEosOutResponseVariant(address: string): readonly [string, string] {
+  return [address, toEosOutResponseAddress(address)] as const;
+}
+
+export const oscResponseMappings = {
+  queries: {
+    cue: {
+      count: withEosOutResponseVariant(oscMappings.queries.cue.count),
+      list: withEosOutResponseVariant(oscMappings.queries.cue.list)
+    },
+    cuelist: {
+      list: withEosOutResponseVariant(oscMappings.queries.cuelist.list)
+    }
+  },
+  cues: {
+    info: withEosOutResponseVariant(oscMappings.cues.info),
+    list: withEosOutResponseVariant(oscMappings.cues.list)
+  }
+} as const;

--- a/src/tools/cues/get_info.ts
+++ b/src/tools/cues/get_info.ts
@@ -11,7 +11,7 @@ import {
 } from '../../services/cache/index';
 import { getOscClient } from '../../services/osc/client';
 import { buildCueJsonMessage } from '../../services/osc/messageBuilders';
-import { oscMappings } from '../../services/osc/mappings';
+import { oscMappings, oscResponseMappings } from '../../services/osc/mappings';
 import type { ToolDefinition, ToolExecutionResult } from '../types';
 import {
   buildCueCommandPayload,
@@ -96,7 +96,10 @@ export const eosCueGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
       prefixTags: [createOscPrefixTag('/eos/out/')],
       fetcher: async () => {
         const request = buildCueJsonMessage(oscMappings.cues.info, payload);
-        const response = await client.requestBuiltJson(request, extractTargetOptions(options));
+        const response = await client.requestBuiltJson(request, {
+          ...extractTargetOptions(options),
+          responseAddresses: oscResponseMappings.cues.info
+        });
 
         const details = mapCueDetails(response.data, identifier);
 

--- a/src/tools/cues/list_all.ts
+++ b/src/tools/cues/list_all.ts
@@ -11,7 +11,7 @@ import {
 } from '../../services/cache/index';
 import { getOscClient } from '../../services/osc/client';
 import { buildCueJsonMessage } from '../../services/osc/messageBuilders';
-import { oscMappings } from '../../services/osc/mappings';
+import { oscMappings, oscResponseMappings } from '../../services/osc/mappings';
 import type { ToolDefinition, ToolExecutionResult } from '../types';
 import {
   buildCueCommandPayload,
@@ -78,7 +78,10 @@ export const eosCueListAllTool: ToolDefinition<typeof listAllInputSchema> = {
       prefixTags: [createOscPrefixTag('/eos/out/')],
       fetcher: async () => {
         const request = buildCueJsonMessage(oscMappings.cues.list, payload);
-        const response = await client.requestBuiltJson(request, extractTargetOptions(options));
+        const response = await client.requestBuiltJson(request, {
+          ...extractTargetOptions(options),
+          responseAddresses: oscResponseMappings.cues.list
+        });
 
         const cues = mapCueList(response.data, identifier);
 

--- a/src/tools/queries/index.ts
+++ b/src/tools/queries/index.ts
@@ -10,7 +10,7 @@ import {
   getResourceCache
 } from '../../services/cache/index';
 import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
-import { oscMappings } from '../../services/osc/mappings';
+import { oscMappings, oscResponseMappings, withEosOutResponseVariant } from '../../services/osc/mappings';
 import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 interface QueryListItem {
@@ -23,6 +23,8 @@ interface QueryTargetConfig {
   label: string;
   countAddress: string;
   listAddress: string;
+  countResponseAddresses: readonly string[];
+  listResponseAddresses: readonly string[];
   responseKeys: string[];
 }
 
@@ -33,90 +35,120 @@ const TARGET_TYPE_CONFIGS = {
     label: 'cues',
     countAddress: oscMappings.queries.cue.count,
     listAddress: oscMappings.queries.cue.list,
+    countResponseAddresses: oscResponseMappings.queries.cue.count,
+    listResponseAddresses: oscResponseMappings.queries.cue.list,
     responseKeys: ['cues', 'items']
   },
   cuelist: {
     label: 'cue lists',
     countAddress: oscMappings.queries.cuelist.count,
     listAddress: oscMappings.queries.cuelist.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.cuelist.count),
+    listResponseAddresses: oscResponseMappings.queries.cuelist.list,
     responseKeys: ['cuelists', 'lists', 'items']
   },
   group: {
     label: 'groupes',
     countAddress: oscMappings.queries.group.count,
     listAddress: oscMappings.queries.group.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.group.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.group.list),
     responseKeys: ['groups', 'items']
   },
   macro: {
     label: 'macros',
     countAddress: oscMappings.queries.macro.count,
     listAddress: oscMappings.queries.macro.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.macro.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.macro.list),
     responseKeys: ['macros', 'items']
   },
   ms: {
     label: 'magic sheets',
     countAddress: oscMappings.queries.ms.count,
     listAddress: oscMappings.queries.ms.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.ms.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.ms.list),
     responseKeys: ['magic_sheets', 'magicSheets', 'items']
   },
   ip: {
     label: 'intensity palettes',
     countAddress: oscMappings.queries.ip.count,
     listAddress: oscMappings.queries.ip.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.ip.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.ip.list),
     responseKeys: ['intensity_palettes', 'ip', 'items']
   },
   fp: {
     label: 'focus palettes',
     countAddress: oscMappings.queries.fp.count,
     listAddress: oscMappings.queries.fp.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.fp.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.fp.list),
     responseKeys: ['focus_palettes', 'fp', 'items']
   },
   cp: {
     label: 'color palettes',
     countAddress: oscMappings.queries.cp.count,
     listAddress: oscMappings.queries.cp.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.cp.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.cp.list),
     responseKeys: ['color_palettes', 'cp', 'items']
   },
   bp: {
     label: 'beam palettes',
     countAddress: oscMappings.queries.bp.count,
     listAddress: oscMappings.queries.bp.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.bp.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.bp.list),
     responseKeys: ['beam_palettes', 'bp', 'items']
   },
   preset: {
     label: 'presets',
     countAddress: oscMappings.queries.preset.count,
     listAddress: oscMappings.queries.preset.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.preset.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.preset.list),
     responseKeys: ['presets', 'items']
   },
   sub: {
     label: 'submasters',
     countAddress: oscMappings.queries.sub.count,
     listAddress: oscMappings.queries.sub.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.sub.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.sub.list),
     responseKeys: ['submasters', 'subs', 'items']
   },
   fx: {
     label: 'effects',
     countAddress: oscMappings.queries.fx.count,
     listAddress: oscMappings.queries.fx.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.fx.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.fx.list),
     responseKeys: ['effects', 'fx', 'items']
   },
   curve: {
     label: 'courbes',
     countAddress: oscMappings.queries.curve.count,
     listAddress: oscMappings.queries.curve.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.curve.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.curve.list),
     responseKeys: ['curves', 'items']
   },
   snap: {
     label: 'snapshots',
     countAddress: oscMappings.queries.snap.count,
     listAddress: oscMappings.queries.snap.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.snap.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.snap.list),
     responseKeys: ['snapshots', 'snaps', 'items']
   },
   pixmap: {
     label: 'pixel maps',
     countAddress: oscMappings.queries.pixmap.count,
     listAddress: oscMappings.queries.pixmap.list,
+    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.pixmap.count),
+    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.pixmap.list),
     responseKeys: ['pixmaps', 'pixel_maps', 'items']
   }
 } as const satisfies Record<string, QueryTargetConfig>;
@@ -237,7 +269,8 @@ export const eosGetCountTool: ToolDefinition<typeof countInputSchema> = {
         const response: OscJsonResponse = await client.requestJson(config.countAddress, {
           timeoutMs: options.timeoutMs,
           targetAddress: options.targetAddress,
-          targetPort: options.targetPort
+          targetPort: options.targetPort,
+          responseAddresses: config.countResponseAddresses
         });
 
         const count = Math.max(0, normaliseCount(response.data));
@@ -309,7 +342,8 @@ export const eosGetListAllTool: ToolDefinition<typeof listInputSchema> = {
         const response: OscJsonResponse = await client.requestJson(config.listAddress, {
           timeoutMs: options.timeoutMs,
           targetAddress: options.targetAddress,
-          targetPort: options.targetPort
+          targetPort: options.targetPort,
+          responseAddresses: config.listResponseAddresses
         });
 
         const items = normaliseList(response.data, config);


### PR DESCRIPTION
### Motivation
- EOS devices sometimes reply to JSON read requests on `/eos/out/...` variants instead of the canonical `/eos/...` addresses, causing query tools to miss valid responses.
- Make JSON request handling robust by allowing callers to declare accepted response addresses and document which `/eos/out/...` variants are supported for cue/cuelist reads.

### Description
- Added helpers and a mapping of accepted response-address variants in `src/services/osc/mappings.ts` (`toEosOutResponseAddress`, `withEosOutResponseVariant`, `oscResponseMappings`).
- Extended the OSC client (`src/services/osc/client.ts`) to accept `responseAddresses` in `OscJsonRequestOptions`, normalize them (keeping the request address as fallback), and match incoming messages against the accepted-address set; also forwarded accepted-response info into connection checks when needed.
- Updated query tools (`src/tools/queries/index.ts`) to include explicit `countResponseAddresses` / `listResponseAddresses` and pass them to `client.requestJson`.
- Updated cue tools (`src/tools/cues/list_all.ts`, `src/tools/cues/get_info.ts`) to pass explicit `responseAddresses` when using `requestBuiltJson`.
- Added a unit test in `src/services/osc/__tests__/client.test.ts` verifying a `/eos/get/cue/list` request accepts a `/eos/out/get/cue/list` response.
- Documented the supported request/response pairs in `scripts/toolDocs.ts` and regenerated `docs/tools.md` so tool documentation lists the accepted `/eos/out/...` variants.

### Testing
- Ran `npm run docs:generate` and the docs were updated successfully (no errors). ✅
- Ran targeted unit suites with Jest: `src/services/osc/__tests__/client.test.ts`, `src/tools/queries/__tests__/queries.test.ts`, `src/tools/cues/__tests__/cues.test.ts` and all passed. ✅
- Compiled TypeScript with `npm run tsc` and ran `npm run lint` and `npm run docs:check`, all succeeded. ✅
- Note: an initial run of the full unit suite (`npm test` / many paths) surfaced unrelated pre-existing failures in other areas (undocumented JSON endpoints / snapshot expectations); these are outside the scope of this change and the targeted suites above are green. ❌

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04cf90b66c832a8fb373d8753a8233)