### PR TITLE
test: add OSC tool contract coverage

### DIFF
--- a/docs/osc-coverage.md
+++ b/docs/osc-coverage.md
@@ -1,186 +1,126 @@
 # Couverture OSC ↔ MCP
 
-Ce document recense les familles/commandes OSC EOS prises en charge par les outils MCP. Il est base sur `src/services/osc/mappings.ts` et les outils exposes dans `src/tools`.
+Ce document liste tous les outils exportés par `src/tools/index.ts` et relie chaque outil à sa commande OSC déclarée et au test de contrat associé.
 
-> ✅ **Couvert** : une ou plusieurs commandes MCP permettent d'appeler cette adresse OSC.
-> ⚠️ **Partiel** : l'adresse sert de base a d'autres outils (construction dynamique).
-> ❌ **Non couvert** : aucun outil MCP ne cible directement la commande.
+Les contrats centralisés sont vérifiés dans `src/tools/__tests__/osc_contracts.test.ts` : adresse OSC, arguments OSC (snapshots), propagation `targetAddress` / `targetPort`, transformation d'erreur OSC en résultat MCP stable et rejet des paramètres inconnus pour les schémas stricts. Les tests de famille sous `src/tools/**/__tests__` conservent les scénarios métier détaillés.
 
-## Commandes & connexion
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
+| Famille | Outil MCP exporté | Commande OSC | Test associé |
 | --- | --- | --- | --- |
-| commands | `/eos/cmd` | `eos_command`, `eos_command_with_substitution`, `eos_new_command` (clearLine=false) | ✅ |
-| commands | `/eos/newcmd` | `eos_new_command` | ✅ |
-| commands | `/eos/get/cmd_line` | `eos_get_command_line` | ✅ |
-| connection | `/eos/ping` | `eos_ping` | ✅ |
-
-## Clavier & softkeys
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| keys | `/eos/key/{key}` | `eos_key_press` | ✅ |
-| keys | `/eos/key/softkey{number}` | `eos_softkey_press` | ✅ |
-| keys | `/eos/get/softkey_labels` | `eos_get_softkey_labels` | ✅ |
-| keys | `/eos/key` | — | ⚠️ Base utilisee pour construire les adresses des touches. |
-
-## Channels & DMX
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| channels | `/eos/cmd` | `eos_channel_select`, `eos_channel_set_level` | ✅ |
-| channels | `/eos/chan` | — | ❌ Aucun outil direct. |
-| channels | `/eos/chan/param` | `eos_channel_set_parameter` | ✅ |
-| channels | `/eos/get/channels` | `eos_channel_get_info` | ✅ |
-| dmx | `/eos/cmd` | `eos_set_dmx` | ✅ |
-| dmx | `/eos/dmx/address/select` | `eos_address_select` | ✅ |
-| dmx | `/eos/dmx/address/level` | `eos_address_set_level` | ✅ |
-| dmx | `/eos/dmx/address/dmx` | `eos_address_set_dmx` | ✅ |
-
-## Groups
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| groups | `/eos/group` | `eos_group_select` | ✅ |
-| groups | `/eos/group/{group}/level` | `eos_group_set_level` | ✅ |
-| groups | `/eos/get/group` | `eos_group_get_info` | ✅ |
-| groups | `/eos/get/group/list` | `eos_group_list_all` | ✅ |
-
-## Palettes & presets
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| palettes | `/eos/get/palette` | `eos_palette_get_info` | ✅ |
-| palettes.intensity | `/eos/ip/fire` | `eos_intensity_palette_fire` | ✅ |
-| palettes.intensity | `/eos/get/ip` | `eos_palette_get_info` | ✅ |
-| palettes.focus | `/eos/fp/fire` | `eos_focus_palette_fire` | ✅ |
-| palettes.focus | `/eos/get/fp` | `eos_palette_get_info` | ✅ |
-| palettes.color | `/eos/cp/fire` | `eos_color_palette_fire` | ✅ |
-| palettes.color | `/eos/get/cp` | `eos_palette_get_info` | ✅ |
-| palettes.beam | `/eos/bp/fire` | `eos_beam_palette_fire` | ✅ |
-| palettes.beam | `/eos/get/bp` | `eos_palette_get_info` | ✅ |
-| presets | `/eos/preset/fire` | `eos_preset_fire` | ✅ |
-| presets | `/eos/preset` | `eos_preset_select` | ✅ |
-| presets | `/eos/get/preset` | `eos_preset_get_info` | ✅ |
-
-## Macros & snapshots
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| macros | `/eos/macro/fire` | `eos_macro_fire` | ✅ |
-| macros | `/eos/macro` | `eos_macro_select` | ✅ |
-| macros | `/eos/get/macro` | `eos_macro_get_info` | ✅ |
-| snapshots | `/eos/snap` | `eos_snapshot_recall` | ✅ |
-| snapshots | `/eos/get/snapshot` | `eos_snapshot_get_info` | ✅ |
-
-## Courbes & effets
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| curves | `/eos/curve/select` | `eos_curve_select` | ✅ |
-| curves | `/eos/get/curve` | `eos_curve_get_info` | ✅ |
-| effects | `/eos/cmd` | `eos_effect_select` | ✅ |
-| effects | `/eos/cmd` | `eos_effect_stop` | ✅ |
-| effects | `/eos/get/effect` | `eos_effect_get_info` | ✅ |
-
-## Parametres & FPE
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| parameters | `/eos/param/wheel/tick` | `eos_wheel_tick` | ✅ |
-| parameters | `/eos/param/wheel/rate` | `eos_switch_continuous` | ✅ |
-| parameters | `/eos/param/color/hs` | `eos_set_color_hs` | ✅ |
-| parameters | `/eos/param/color/rgb` | `eos_set_color_rgb` | ✅ |
-| parameters | `/eos/param/position/xy` | `eos_set_pantilt_xy` | ✅ |
-| parameters | `/eos/param/position/xyz` | `eos_set_xyz_position` | ✅ |
-| parameters | `/eos/get/active/wheels` | `eos_get_active_wheels` | ✅ |
-| fpe | `/eos/get/fpe/set/count` | `eos_fpe_get_set_count` | ✅ |
-| fpe | `/eos/get/fpe/set` | `eos_fpe_get_set_info` | ✅ |
-| fpe | `/eos/get/fpe/point` | `eos_fpe_get_point_info` | ✅ |
-
-## Faders & direct selects
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| faders | `/eos/fader` | `eos_fader_set_level`, `eos_fader_load`, `eos_fader_unload` | ⚠️ Base utilisee pour composer les adresses des faders. |
-| faders | `/eos/fader/{index}/config/{faders}/{page}` | `eos_fader_bank_create` | ✅ |
-| faders | `/eos/fader/{index}/page/{delta}` | `eos_fader_page` | ✅ |
-| directSelects | `/eos/ds/{index}/button/{page}/{button}` | `eos_direct_select_press` | ✅ |
-| directSelects | `/eos/ds/{index}/config/{target}/{buttons}/{flexi}/{page}` | `eos_direct_select_bank_create` | ✅ |
-| directSelects | `/eos/ds/{index}/page/{delta}` | `eos_direct_select_page` | ✅ |
-
-## Pixel maps & Magic Sheets
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| pixelMaps | `/eos/pixmap` | `eos_pixmap_select` | ✅ |
-| pixelMaps | `/eos/get/pixmap` | `eos_pixmap_get_info` | ✅ |
-| magicSheets | `/eos/ms` | `eos_magic_sheet_open` | ✅ |
-| magicSheets | `/eos/newcmd` | `eos_magic_sheet_send_string` | ✅ |
-| magicSheets | `/eos/get/magic_sheet` | `eos_magic_sheet_get_info` | ✅ |
-
-## Queries (Get Count / List)
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| queries.cue | `/eos/get/cue/count` | `eos_get_count` | ✅ `object_type: "cue"` |
-| queries.cue | `/eos/get/cue/list` | `eos_get_list_all` | ✅ `object_type: "cue"` |
-| queries.cuelist | `/eos/get/cuelist/count` | `eos_get_count` | ✅ `object_type: "cuelist"` |
-| queries.cuelist | `/eos/get/cuelist/list` | `eos_get_list_all` | ✅ `object_type: "cuelist"` |
-| queries.group | `/eos/get/group/count` | `eos_get_count` | ✅ `object_type: "group"` |
-| queries.group | `/eos/get/group/list` | `eos_get_list_all` | ✅ `object_type: "group"` |
-| queries.macro | `/eos/get/macro/count` | `eos_get_count` | ✅ `object_type: "macro"` |
-| queries.macro | `/eos/get/macro/list` | `eos_get_list_all` | ✅ `object_type: "macro"` |
-| queries.ms | `/eos/get/magic_sheet/count` | `eos_get_count` | ✅ `object_type: "magic_sheet"` |
-| queries.ms | `/eos/get/magic_sheet/list` | `eos_get_list_all` | ✅ `object_type: "magic_sheet"` |
-| queries.ip | `/eos/get/ip/count` | `eos_get_count` | ✅ `object_type: "ip"` |
-| queries.ip | `/eos/get/ip/list` | `eos_get_list_all` | ✅ `object_type: "ip"` |
-| queries.fp | `/eos/get/fp/count` | `eos_get_count` | ✅ `object_type: "fp"` |
-| queries.fp | `/eos/get/fp/list` | `eos_get_list_all` | ✅ `object_type: "fp"` |
-| queries.cp | `/eos/get/cp/count` | `eos_get_count` | ✅ `object_type: "cp"` |
-| queries.cp | `/eos/get/cp/list` | `eos_get_list_all` | ✅ `object_type: "cp"` |
-| queries.bp | `/eos/get/bp/count` | `eos_get_count` | ✅ `object_type: "bp"` |
-| queries.bp | `/eos/get/bp/list` | `eos_get_list_all` | ✅ `object_type: "bp"` |
-| queries.preset | `/eos/get/preset/count` | `eos_get_count` | ✅ `object_type: "preset"` |
-| queries.preset | `/eos/get/preset/list` | `eos_get_list_all` | ✅ `object_type: "preset"` |
-| queries.sub | `/eos/get/submaster/count` | `eos_get_count` | ✅ `object_type: "sub"` |
-| queries.sub | `/eos/get/submaster/list` | `eos_get_list_all` | ✅ `object_type: "sub"` |
-| queries.fx | `/eos/get/effect/count` | `eos_get_count` | ✅ `object_type: "fx"` |
-| queries.fx | `/eos/get/effect/list` | `eos_get_list_all` | ✅ `object_type: "fx"` |
-| queries.curve | `/eos/get/curve/count` | `eos_get_count` | ✅ `object_type: "curve"` |
-| queries.curve | `/eos/get/curve/list` | `eos_get_list_all` | ✅ `object_type: "curve"` |
-| queries.snap | `/eos/get/snapshot/count` | `eos_get_count` | ✅ `object_type: "snap"` |
-| queries.snap | `/eos/get/snapshot/list` | `eos_get_list_all` | ✅ `object_type: "snap"` |
-| queries.pixmap | `/eos/get/pixmap/count` | `eos_get_count` | ✅ `object_type: "pixmap"` |
-| queries.pixmap | `/eos/get/pixmap/list` | `eos_get_list_all` | ✅ `object_type: "pixmap"` |
-
-## Patch & submasters
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| patch | `/eos/get/patch/chan_info` | `eos_patch_get_channel_info` | ✅ |
-| patch | `/eos/get/patch/chan_pos` | `eos_patch_get_augment3d_position` | ✅ |
-| patch | `/eos/get/patch/chan_beam` | `eos_patch_get_augment3d_beam` | ✅ |
-| submasters | `/eos/sub` | `eos_submaster_set_level`, `eos_submaster_bump` | ⚠️ Base utilisee pour composer les adresses de submasters. |
-| submasters | `/eos/get/submaster` | `eos_submaster_get_info` | ✅ |
-
-## Cues & show control
-
-| Famille | Commande OSC | Outil MCP | Statut/Notes |
-| --- | --- | --- | --- |
-| cues | `/eos/cmd` | `eos_cue_fire` | ✅ |
-| cues | `/eos/cmd` | `eos_cue_go` | ✅ |
-| cues | `/eos/cmd` | `eos_cue_stop_back` | ✅ |
-| cues | `/eos/cmd` | `eos_cue_select` | ✅ |
-| cues | `/eos/get/cue` | `eos_cue_get_info` | ✅ |
-| cues | `/eos/get/cuelist` | `eos_cue_list_all` | ✅ |
-| cues | `/eos/get/cuelist/info` | `eos_cuelist_get_info` | ✅ |
-| cues | `/eos/cuelist/{bank_index}/config/{cuelist_number}/{num_prev_cues}/{num_pending_cues}` | `eos_cuelist_bank_create` | ✅ |
-| cues | `/eos/cuelist/{bank_index}/page/{delta}` | `eos_cuelist_bank_page` | ✅ |
-| cues | `/eos/get/active/cue` | `eos_get_active_cue` | ✅ |
-| cues | `/eos/get/pending/cue` | `eos_get_pending_cue` | ✅ |
-| showControl | `/eos/get/show/name` | `eos_get_show_name` | ✅ |
-| showControl | `/eos/get/live/blind` | `eos_get_live_blind_state` | ✅ |
-| showControl | `/eos/newcmd` | `eos_toggle_staging_mode` | ✅ |
-| showControl | `/eos/newcmd` | `eos_set_cue_send_string` | ✅ |
-| showControl | `/eos/newcmd` | `eos_set_cue_receive_string` | ✅ |
+| capabilities | `eos_capabilities_get` | — | — (outil non OSC ou orchestrateur) |
+| connection | `ping` | — | — (outil non OSC ou orchestrateur) |
+| connection | `eos_connect` | — | — (outil non OSC ou orchestrateur) |
+| connection | `eos_configure` | — | — (outil non OSC ou orchestrateur) |
+| connection | `eos_ping` | `/eos/ping` | `src/tools/__tests__/osc_contracts.test.ts` |
+| connection | `eos_reset` | — | — (outil non OSC ou orchestrateur) |
+| connection | `eos_subscribe` | — | — (outil non OSC ou orchestrateur) |
+| workflows | `eos_workflow_create_look` | — | — (outil non OSC ou orchestrateur) |
+| workflows | `eos_workflow_create_effect` | — | — (outil non OSC ou orchestrateur) |
+| workflows | `eos_workflow_create_cue_series` | — | — (outil non OSC ou orchestrateur) |
+| workflows | `eos_workflow_patch_fixture` | — | — (outil non OSC ou orchestrateur) |
+| workflows | `eos_workflow_autopatch_band` | — | — (outil non OSC ou orchestrateur) |
+| workflows | `eos_workflow_rehearsal_go_safe` | — | — (outil non OSC ou orchestrateur) |
+| workflows | `eos_workflow_build_groups_and_palettes` | — | — (outil non OSC ou orchestrateur) |
+| workflows | `eos_workflow_update_cue_look` | — | — (outil non OSC ou orchestrateur) |
+| commands | `eos_command` | `/eos/cmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| commands | `eos_new_command` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| commands | `eos_command_with_substitution` | `/eos/cmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| commands | `eos_get_command_line` | `/eos/get/cmd_line` | `src/tools/__tests__/osc_contracts.test.ts` |
+| commands | `eos_get_user_command_line` | `/eos/get/cmd_line` | `src/tools/__tests__/osc_contracts.test.ts` |
+| channels | `eos_channel_select` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| channels | `eos_channel_set_level` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| channels | `eos_channel_set_dmx` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| programming | `eos_set_dmx` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| channels | `eos_channel_set_parameter` | `/eos/chan/param` | `src/tools/__tests__/osc_contracts.test.ts` |
+| channels | `eos_channel_get_info` | `/eos/get/channels` | `src/tools/__tests__/osc_contracts.test.ts` |
+| groups | `eos_group_select` | `/eos/group` | `src/tools/__tests__/osc_contracts.test.ts` |
+| groups | `eos_group_set_level` | `/eos/group/{group}/level` | `src/tools/__tests__/osc_contracts.test.ts` |
+| groups | `eos_group_get_info` | `/eos/get/group` | `src/tools/__tests__/osc_contracts.test.ts` |
+| groups | `eos_group_list_all` | `/eos/get/group/list` | `src/tools/__tests__/osc_contracts.test.ts` |
+| diagnostics | `eos_enable_logging` | — | — (outil non OSC ou orchestrateur) |
+| diagnostics | `eos_get_diagnostics` | — | — (outil non OSC ou orchestrateur) |
+| diagnostics | `eos_get_version` | — | — (outil non OSC ou orchestrateur) |
+| diagnostics | `eos_get_setup_defaults` | — | — (outil non OSC ou orchestrateur) |
+| cues | `eos_cue_fire` | `/eos/cmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cue_go` | `/eos/cmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cue_stop_back` | `/eos/cmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cue_select` | `/eos/cmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cue_get_info` | `/eos/get/cue` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cue_list_all` | `/eos/get/cuelist` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cuelist_get_info` | `/eos/get/cuelist/info` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cuelist_bank_create` | `/eos/cuelist/{bank_index}/config/{cuelist_number}/{num_prev_cues}/{num_pending_cues}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cuelist_bank_page` | `/eos/cuelist/{bank_index}/page/{delta}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_get_active_cue` | `/eos/get/active/cue` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_get_pending_cue` | `/eos/get/pending/cue` | `src/tools/__tests__/osc_contracts.test.ts` |
+| palettes | `eos_intensity_palette_fire` | `/eos/ip/fire` | `src/tools/__tests__/osc_contracts.test.ts` |
+| palettes | `eos_focus_palette_fire` | `/eos/fp/fire` | `src/tools/__tests__/osc_contracts.test.ts` |
+| palettes | `eos_color_palette_fire` | `/eos/cp/fire` | `src/tools/__tests__/osc_contracts.test.ts` |
+| palettes | `eos_beam_palette_fire` | `/eos/bp/fire` | `src/tools/__tests__/osc_contracts.test.ts` |
+| palettes | `eos_palette_get_info` | `/eos/get/palette` | `src/tools/__tests__/osc_contracts.test.ts` |
+| presets | `eos_preset_fire` | `/eos/preset/fire` | `src/tools/__tests__/osc_contracts.test.ts` |
+| presets | `eos_preset_select` | `/eos/preset` | `src/tools/__tests__/osc_contracts.test.ts` |
+| presets | `eos_preset_get_info` | `/eos/get/preset` | `src/tools/__tests__/osc_contracts.test.ts` |
+| submasters | `eos_submaster_set_level` | `/eos/sub/{submaster_number}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| submasters | `eos_submaster_bump` | `/eos/sub/{submaster_number}/bump` | `src/tools/__tests__/osc_contracts.test.ts` |
+| submasters | `eos_submaster_get_info` | `/eos/get/submaster` | `src/tools/__tests__/osc_contracts.test.ts` |
+| faders | `eos_fader_bank_create` | `/eos/fader/{index}/config/{faders}/{page}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| faders | `eos_fader_set_level` | `/eos/fader/{bank}/{page}/{fader}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| faders | `eos_fader_load` | `/eos/fader/{bank}/{page}/{fader}/load` | `src/tools/__tests__/osc_contracts.test.ts` |
+| faders | `eos_fader_unload` | `/eos/fader/{bank}/{page}/{fader}/unload` | `src/tools/__tests__/osc_contracts.test.ts` |
+| faders | `eos_fader_page` | `/eos/fader/{index}/page/{delta}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| macros | `eos_macro_fire` | `/eos/macro/fire` | `src/tools/__tests__/osc_contracts.test.ts` |
+| macros | `eos_macro_select` | `/eos/macro` | `src/tools/__tests__/osc_contracts.test.ts` |
+| macros | `eos_macro_get_info` | `/eos/get/macro` | `src/tools/__tests__/osc_contracts.test.ts` |
+| effects | `eos_effect_select` | `/eos/cmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| effects | `eos_effect_stop` | `/eos/cmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| effects | `eos_effect_get_info` | `/eos/get/effect` | `src/tools/__tests__/osc_contracts.test.ts` |
+| wheel | `eos_wheel_tick` | `/eos/param/wheel/tick` | `src/tools/__tests__/osc_contracts.test.ts` |
+| switch | `eos_switch_continuous` | `/eos/param/wheel/rate` | `src/tools/__tests__/osc_contracts.test.ts` |
+| programming | `eos_set_color_hs` | `/eos/param/color/hs` | `src/tools/__tests__/osc_contracts.test.ts` |
+| programming | `eos_set_color_rgb` | `/eos/param/color/rgb` | `src/tools/__tests__/osc_contracts.test.ts` |
+| programming | `eos_set_pantilt_xy` | `/eos/param/position/xy` | `src/tools/__tests__/osc_contracts.test.ts` |
+| programming | `eos_set_xyz_position` | `/eos/param/position/xyz` | `src/tools/__tests__/osc_contracts.test.ts` |
+| queries | `eos_get_active_wheels` | `/eos/get/active/wheels` | `src/tools/__tests__/osc_contracts.test.ts` |
+| keys | `eos_key_press` | `/eos/key/{key}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| keys | `eos_softkey_press` | `/eos/key/softkey{number}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| keys | `eos_get_softkey_labels` | `/eos/get/softkey_labels` | `src/tools/__tests__/osc_contracts.test.ts` |
+| directSelects | `eos_direct_select_bank_create` | `/eos/ds/{index}/config/{target}/{buttons}/{flexi}/{page}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| directSelects | `eos_direct_select_press` | `/eos/ds/{index}/button/{page}/{button}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| directSelects | `eos_direct_select_page` | `/eos/ds/{index}/page/{delta}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| magicSheets | `eos_magic_sheet_open` | `/eos/ms` | `src/tools/__tests__/osc_contracts.test.ts` |
+| magicSheets | `eos_magic_sheet_send_string` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| magicSheets | `eos_magic_sheet_get_info` | `/eos/get/magic_sheet` | `src/tools/__tests__/osc_contracts.test.ts` |
+| pixelMaps | `eos_pixmap_select` | `/eos/pixmap` | `src/tools/__tests__/osc_contracts.test.ts` |
+| pixelMaps | `eos_pixmap_get_info` | `/eos/get/pixmap` | `src/tools/__tests__/osc_contracts.test.ts` |
+| curves | `eos_curve_select` | `/eos/curve/select` | `src/tools/__tests__/osc_contracts.test.ts` |
+| curves | `eos_curve_get_info` | `/eos/get/curve` | `src/tools/__tests__/osc_contracts.test.ts` |
+| fixture | `eos_fixture_search` | — | — (outil non OSC ou orchestrateur) |
+| patch | `eos_patch_get_channel_info` | `/eos/get/patch/chan_info` | `src/tools/__tests__/osc_contracts.test.ts` |
+| patch | `eos_patch_get_augment3d_position` | `/eos/get/patch/chan_pos` | `src/tools/__tests__/osc_contracts.test.ts` |
+| patch | `eos_patch_get_augment3d_beam` | `/eos/get/patch/chan_beam` | `src/tools/__tests__/osc_contracts.test.ts` |
+| snapshots | `eos_snapshot_recall` | `/eos/snap` | `src/tools/__tests__/osc_contracts.test.ts` |
+| snapshots | `eos_snapshot_get_info` | `/eos/get/snapshot` | `src/tools/__tests__/osc_contracts.test.ts` |
+| queries | `eos_get_show_name` | `/eos/get/show/name` | `src/tools/__tests__/osc_contracts.test.ts` |
+| queries | `eos_get_live_blind_state` | `/eos/get/live/blind` | `src/tools/__tests__/osc_contracts.test.ts` |
+| toggle | `eos_toggle_staging_mode` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_set_cue_send_string` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_set_cue_receive_string` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| queries | `eos_get_count` | `cue`: `/eos/get/cue/count`<br>`cuelist`: `/eos/get/cuelist/count`<br>`group`: `/eos/get/group/count`<br>`macro`: `/eos/get/macro/count`<br>`ms`: `/eos/get/magic_sheet/count`<br>`ip`: `/eos/get/ip/count`<br>`fp`: `/eos/get/fp/count`<br>`cp`: `/eos/get/cp/count`<br>`bp`: `/eos/get/bp/count`<br>`preset`: `/eos/get/preset/count`<br>`sub`: `/eos/get/submaster/count`<br>`fx`: `/eos/get/effect/count`<br>`curve`: `/eos/get/curve/count`<br>`snap`: `/eos/get/snapshot/count`<br>`pixmap`: `/eos/get/pixmap/count` | `src/tools/__tests__/osc_contracts.test.ts` |
+| queries | `eos_get_list_all` | `cue`: `/eos/get/cue/list`<br>`cuelist`: `/eos/get/cuelist/list`<br>`group`: `/eos/get/group/list`<br>`macro`: `/eos/get/macro/list`<br>`ms`: `/eos/get/magic_sheet/list`<br>`ip`: `/eos/get/ip/list`<br>`fp`: `/eos/get/fp/list`<br>`cp`: `/eos/get/cp/list`<br>`bp`: `/eos/get/bp/list`<br>`preset`: `/eos/get/preset/list`<br>`sub`: `/eos/get/submaster/list`<br>`fx`: `/eos/get/effect/list`<br>`curve`: `/eos/get/curve/list`<br>`snap`: `/eos/get/snapshot/list`<br>`pixmap`: `/eos/get/pixmap/list` | `src/tools/__tests__/osc_contracts.test.ts` |
+| fpe | `eos_fpe_get_set_count` | `/eos/get/fpe/set/count` | `src/tools/__tests__/osc_contracts.test.ts` |
+| fpe | `eos_fpe_get_set_info` | `/eos/get/fpe/set` | `src/tools/__tests__/osc_contracts.test.ts` |
+| fpe | `eos_fpe_get_point_info` | `/eos/get/fpe/point` | `src/tools/__tests__/osc_contracts.test.ts` |
+| dmx | `eos_address_select` | `/eos/dmx/address/select` | `src/tools/__tests__/osc_contracts.test.ts` |
+| dmx | `eos_address_set_level` | `/eos/dmx/address/level` | `src/tools/__tests__/osc_contracts.test.ts` |
+| dmx | `eos_address_set_dmx` | `/eos/dmx/address/dmx` | `src/tools/__tests__/osc_contracts.test.ts` |
+| programming | `eos_set_user_id` | — | — (outil non OSC ou orchestrateur) |
+| session | `session_set_current_user` | — | — (outil non OSC ou orchestrateur) |
+| session | `session_get_current_user` | — | — (outil non OSC ou orchestrateur) |
+| session | `session_set_context` | — | — (outil non OSC ou orchestrateur) |
+| session | `session_get_context` | — | — (outil non OSC ou orchestrateur) |
+| session | `session_clear_context` | — | — (outil non OSC ou orchestrateur) |
+| cues | `eos_cue_record` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cue_update` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cue_label_set` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| palettes | `eos_palette_record` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| palettes | `eos_palette_label_set` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
+| patch | `eos_patch_set_channel` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |

--- a/src/tools/__tests__/__snapshots__/osc_contracts.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/osc_contracts.test.ts.snap
@@ -1,0 +1,991 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_address_select sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"address":"1/001"}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_address_set_dmx sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"address":"1/001","value":128}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_address_set_level sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"address":"1/001","level":50}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_beam_palette_fire sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "i",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_channel_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"channels":[1,2],"fields":["label"]}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_channel_select sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Chan + 1 Thru 2#",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_channel_set_dmx sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Chan 1 Thru 2 At 45 DMX#",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_channel_set_level sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Chan 1 Thru 2 Sneak 50#",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_channel_set_parameter sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"channels":[1,2],"parameter":"pan","value":45}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_color_palette_fire sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "i",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_command sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Go To Cue 1#",
+  },
+  {
+    "type": "i",
+    "value": 7,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_command_with_substitution sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Chan 1 At 50#",
+  },
+  {
+    "type": "i",
+    "value": 7,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cue_fire sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Cue 2 Part 1 CueList 1 Fire",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cue_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"cuelist":1,"list":1,"cuelist_number":1,"cue":"2","cue_number":"2","number":"2","part":1,"cue_part":1,"fields":["label"]}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cue_go sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Cue 2 Part 1 CueList 1 Go",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cue_label_set sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Cue 1/2 Label "Contract label"#",
+  },
+  {
+    "type": "i",
+    "value": 7,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cue_list_all sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"cuelist":1,"list":1,"cuelist_number":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cue_record sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Record Cue 1/2#",
+  },
+  {
+    "type": "i",
+    "value": 7,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cue_select sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Cue 2 Part 1 CueList 1",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cue_stop_back sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Cue 1 Stop#",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cue_update sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Update Cue 1/2#",
+  },
+  {
+    "type": "i",
+    "value": 7,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cuelist_bank_create sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cuelist_bank_page sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_cuelist_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"cuelist":1,"list":1,"cuelist_number":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_curve_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"curve":1,"fields":["label"]}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_curve_select sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"curve":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_direct_select_bank_create sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_direct_select_page sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_direct_select_press sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "f",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_effect_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"effect":1,"fields":["label"]}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_effect_select sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Effect 1",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_effect_stop sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Effect 1 Stop",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_fader_bank_create sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_fader_load sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_fader_page sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_fader_set_level sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "f",
+    "value": 0.5,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_fader_unload sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_focus_palette_fire sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "i",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_fpe_get_point_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"set":1,"point":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_fpe_get_set_count sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_fpe_get_set_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"set":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_get_active_cue sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"cuelist":1,"list":1,"cuelist_number":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_get_active_wheels sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_get_command_line sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"user":7}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_get_count sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_get_list_all sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_get_live_blind_state sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_get_pending_cue sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"cuelist":1,"list":1,"cuelist_number":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_get_show_name sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_get_softkey_labels sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_get_user_command_line sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"user":7}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_group_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"group":1,"group_number":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_group_list_all sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_group_select sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "i",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_group_set_level sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "f",
+    "value": 50,
+  },
+  {
+    "type": "i",
+    "value": 0,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_intensity_palette_fire sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "i",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_key_press sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "f",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_macro_fire sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "i",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_macro_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"macro":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_macro_select sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "i",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_magic_sheet_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"number":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_magic_sheet_open sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "i",
+    "value": 1,
+  },
+  {
+    "type": "i",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_magic_sheet_send_string sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Magic Sheet 1",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_new_command sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Go To Cue 1#",
+  },
+  {
+    "type": "i",
+    "value": 7,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_palette_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"palette":1,"type":"ip","fields":["label"]}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_palette_label_set sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "IP 1 Label "Contract label"#",
+  },
+  {
+    "type": "i",
+    "value": 7,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_palette_record sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "IP 1 Record#",
+  },
+  {
+    "type": "i",
+    "value": 7,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_patch_get_augment3d_beam sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"channel":1,"part":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_patch_get_augment3d_position sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"channel":1,"part":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_patch_get_channel_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"channel":1,"part":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_patch_set_channel sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Patch Chan 1 Part 1 Address 1/001 Type "Source Four LED Series 3 Lustr X8" Label "Contract label"#",
+  },
+  {
+    "type": "i",
+    "value": 7,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_ping sends the documented OSC address, payload, and target endpoint 1`] = `[]`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_pixmap_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"pixmap":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_pixmap_select sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"pixmap":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_preset_fire sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "i",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_preset_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"preset":1,"fields":["label"]}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_preset_select sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "i",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_set_color_hs sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"hue":120,"saturation":75}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_set_color_rgb sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"red":1,"green":1,"blue":0.64}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_set_cue_receive_string sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Show_Control Cue_Receive_String "Cue %1 -> %2"",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_set_cue_send_string sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Show_Control Cue_Send_String "Cue %1 -> %2"",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_set_dmx sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Address 1 At 45#",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_set_pantilt_xy sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"x":0.1,"y":0.2}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_set_xyz_position sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"x":0.1,"y":0.2,"z":0.3}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_snapshot_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"snapshot":1,"fields":["label"]}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_snapshot_recall sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"snapshot":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_softkey_press sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "f",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_submaster_bump sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "f",
+    "value": 1,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_submaster_get_info sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"submaster":1,"submaster_number":1}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_submaster_set_level sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "f",
+    "value": 0.5,
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_switch_continuous sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"parameter":"pan","rate":0.5}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_toggle_staging_mode sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "Staging Mode",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts eos_wheel_tick sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "s",
+    "value": "{"parameter":"pan","ticks":3,"mode":"coarse"}",
+  },
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts lists every exported OSC tool with a stable contract fixture 1`] = `
+[
+  "eos_ping",
+  "eos_command",
+  "eos_new_command",
+  "eos_command_with_substitution",
+  "eos_get_command_line",
+  "eos_get_user_command_line",
+  "eos_channel_select",
+  "eos_channel_set_level",
+  "eos_channel_set_dmx",
+  "eos_set_dmx",
+  "eos_channel_set_parameter",
+  "eos_channel_get_info",
+  "eos_group_select",
+  "eos_group_set_level",
+  "eos_group_get_info",
+  "eos_group_list_all",
+  "eos_cue_fire",
+  "eos_cue_go",
+  "eos_cue_stop_back",
+  "eos_cue_select",
+  "eos_cue_get_info",
+  "eos_cue_list_all",
+  "eos_cuelist_get_info",
+  "eos_cuelist_bank_create",
+  "eos_cuelist_bank_page",
+  "eos_get_active_cue",
+  "eos_get_pending_cue",
+  "eos_intensity_palette_fire",
+  "eos_focus_palette_fire",
+  "eos_color_palette_fire",
+  "eos_beam_palette_fire",
+  "eos_palette_get_info",
+  "eos_preset_fire",
+  "eos_preset_select",
+  "eos_preset_get_info",
+  "eos_submaster_set_level",
+  "eos_submaster_bump",
+  "eos_submaster_get_info",
+  "eos_fader_bank_create",
+  "eos_fader_set_level",
+  "eos_fader_load",
+  "eos_fader_unload",
+  "eos_fader_page",
+  "eos_macro_fire",
+  "eos_macro_select",
+  "eos_macro_get_info",
+  "eos_effect_select",
+  "eos_effect_stop",
+  "eos_effect_get_info",
+  "eos_wheel_tick",
+  "eos_switch_continuous",
+  "eos_set_color_hs",
+  "eos_set_color_rgb",
+  "eos_set_pantilt_xy",
+  "eos_set_xyz_position",
+  "eos_get_active_wheels",
+  "eos_key_press",
+  "eos_softkey_press",
+  "eos_get_softkey_labels",
+  "eos_direct_select_bank_create",
+  "eos_direct_select_press",
+  "eos_direct_select_page",
+  "eos_magic_sheet_open",
+  "eos_magic_sheet_send_string",
+  "eos_magic_sheet_get_info",
+  "eos_pixmap_select",
+  "eos_pixmap_get_info",
+  "eos_curve_select",
+  "eos_curve_get_info",
+  "eos_patch_get_channel_info",
+  "eos_patch_get_augment3d_position",
+  "eos_patch_get_augment3d_beam",
+  "eos_snapshot_recall",
+  "eos_snapshot_get_info",
+  "eos_get_show_name",
+  "eos_get_live_blind_state",
+  "eos_toggle_staging_mode",
+  "eos_set_cue_send_string",
+  "eos_set_cue_receive_string",
+  "eos_get_count",
+  "eos_get_list_all",
+  "eos_fpe_get_set_count",
+  "eos_fpe_get_set_info",
+  "eos_fpe_get_point_info",
+  "eos_address_select",
+  "eos_address_set_level",
+  "eos_address_set_dmx",
+  "eos_cue_record",
+  "eos_cue_update",
+  "eos_cue_label_set",
+  "eos_palette_record",
+  "eos_palette_label_set",
+  "eos_patch_set_channel",
+]
+`;
+
+exports[`OSC tool contracts exported from src/tools/index.ts lists every tool exported from src/tools/index.ts with a stable fixture 1`] = `
+[
+  "eos_capabilities_get",
+  "ping",
+  "eos_connect",
+  "eos_configure",
+  "eos_ping",
+  "eos_reset",
+  "eos_subscribe",
+  "eos_workflow_create_look",
+  "eos_workflow_create_effect",
+  "eos_workflow_create_cue_series",
+  "eos_workflow_patch_fixture",
+  "eos_workflow_autopatch_band",
+  "eos_workflow_rehearsal_go_safe",
+  "eos_workflow_build_groups_and_palettes",
+  "eos_workflow_update_cue_look",
+  "eos_command",
+  "eos_new_command",
+  "eos_command_with_substitution",
+  "eos_get_command_line",
+  "eos_get_user_command_line",
+  "eos_channel_select",
+  "eos_channel_set_level",
+  "eos_channel_set_dmx",
+  "eos_set_dmx",
+  "eos_channel_set_parameter",
+  "eos_channel_get_info",
+  "eos_group_select",
+  "eos_group_set_level",
+  "eos_group_get_info",
+  "eos_group_list_all",
+  "eos_enable_logging",
+  "eos_get_diagnostics",
+  "eos_get_version",
+  "eos_get_setup_defaults",
+  "eos_cue_fire",
+  "eos_cue_go",
+  "eos_cue_stop_back",
+  "eos_cue_select",
+  "eos_cue_get_info",
+  "eos_cue_list_all",
+  "eos_cuelist_get_info",
+  "eos_cuelist_bank_create",
+  "eos_cuelist_bank_page",
+  "eos_get_active_cue",
+  "eos_get_pending_cue",
+  "eos_intensity_palette_fire",
+  "eos_focus_palette_fire",
+  "eos_color_palette_fire",
+  "eos_beam_palette_fire",
+  "eos_palette_get_info",
+  "eos_preset_fire",
+  "eos_preset_select",
+  "eos_preset_get_info",
+  "eos_submaster_set_level",
+  "eos_submaster_bump",
+  "eos_submaster_get_info",
+  "eos_fader_bank_create",
+  "eos_fader_set_level",
+  "eos_fader_load",
+  "eos_fader_unload",
+  "eos_fader_page",
+  "eos_macro_fire",
+  "eos_macro_select",
+  "eos_macro_get_info",
+  "eos_effect_select",
+  "eos_effect_stop",
+  "eos_effect_get_info",
+  "eos_wheel_tick",
+  "eos_switch_continuous",
+  "eos_set_color_hs",
+  "eos_set_color_rgb",
+  "eos_set_pantilt_xy",
+  "eos_set_xyz_position",
+  "eos_get_active_wheels",
+  "eos_key_press",
+  "eos_softkey_press",
+  "eos_get_softkey_labels",
+  "eos_direct_select_bank_create",
+  "eos_direct_select_press",
+  "eos_direct_select_page",
+  "eos_magic_sheet_open",
+  "eos_magic_sheet_send_string",
+  "eos_magic_sheet_get_info",
+  "eos_pixmap_select",
+  "eos_pixmap_get_info",
+  "eos_curve_select",
+  "eos_curve_get_info",
+  "eos_fixture_search",
+  "eos_patch_get_channel_info",
+  "eos_patch_get_augment3d_position",
+  "eos_patch_get_augment3d_beam",
+  "eos_snapshot_recall",
+  "eos_snapshot_get_info",
+  "eos_get_show_name",
+  "eos_get_live_blind_state",
+  "eos_toggle_staging_mode",
+  "eos_set_cue_send_string",
+  "eos_set_cue_receive_string",
+  "eos_get_count",
+  "eos_get_list_all",
+  "eos_fpe_get_set_count",
+  "eos_fpe_get_set_info",
+  "eos_fpe_get_point_info",
+  "eos_address_select",
+  "eos_address_set_level",
+  "eos_address_set_dmx",
+  "eos_set_user_id",
+  "session_set_current_user",
+  "session_get_current_user",
+  "session_set_context",
+  "session_get_context",
+  "session_clear_context",
+  "eos_cue_record",
+  "eos_cue_update",
+  "eos_cue_label_set",
+  "eos_palette_record",
+  "eos_palette_label_set",
+  "eos_patch_set_channel",
+]
+`;

--- a/src/tools/__tests__/osc_contracts.test.ts
+++ b/src/tools/__tests__/osc_contracts.test.ts
@@ -1,0 +1,403 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { z } from 'zod';
+import type { OscMessage, OscMessageArgument } from '../../services/osc/index';
+import { setOscClient, type OscClient, type OscJsonResponse, type TargetOptions } from '../../services/osc/client';
+import type { BuiltOscWireMessage } from '../../services/osc/messageBuilders';
+import toolDefinitions from '../index';
+import type { ToolDefinition } from '../types';
+import { runTool } from './helpers/runTool';
+
+interface CapturedOscCall {
+  address: string;
+  args: OscMessageArgument[];
+  options: TargetOptions;
+  command?: string;
+}
+
+class MockOscClient {
+  public readonly calls: CapturedOscCall[] = [];
+
+  public async ping(options: TargetOptions & { message?: string } = {}): Promise<Record<string, unknown>> {
+    this.calls.push({
+      address: '/eos/ping',
+      args: options.message ? [{ type: 's', value: options.message }] : [],
+      options
+    });
+    return { status: 'ok', roundtripMs: 1, echo: options.message ?? null, payload: { status: 'ok' } };
+  }
+
+  public async sendCommand(command: string, options: TargetOptions & { user?: number } = {}): Promise<void> {
+    this.captureCommand('/eos/cmd', command, options);
+  }
+
+  public async sendNewCommand(command: string, options: TargetOptions & { user?: number } = {}): Promise<void> {
+    this.captureCommand('/eos/newcmd', command, options);
+  }
+
+  public async sendMessage(
+    address: string,
+    args: OscMessageArgument[] = [],
+    options: TargetOptions = {}
+  ): Promise<void> {
+    this.calls.push({ address, args, options });
+  }
+
+  public async requestJson(
+    address: string,
+    options: TargetOptions & { payload?: Record<string, unknown>; timeoutMs?: number } = {}
+  ): Promise<OscJsonResponse> {
+    const args = options.payload
+      ? [{ type: 's', value: JSON.stringify(options.payload) } satisfies OscMessageArgument]
+      : [];
+    this.calls.push({ address, args, options });
+    return {
+      status: 'ok',
+      data: this.responseDataFor(address),
+      payload: { address, args }
+    };
+  }
+
+  public async requestBuiltJson(
+    request: BuiltOscWireMessage,
+    options: TargetOptions & { timeoutMs?: number } = {}
+  ): Promise<OscJsonResponse> {
+    const message = request.message as OscMessage;
+    const args = message.args ?? [];
+    this.calls.push({ address: message.address, args, options });
+    return {
+      status: 'ok',
+      data: this.responseDataFor(message.address),
+      payload: { address: message.address, args }
+    };
+  }
+
+  public async getCommandLine(options: TargetOptions & { user?: number } = {}): Promise<Record<string, unknown>> {
+    const payload: Record<string, unknown> = {};
+    if (typeof options.user === 'number') {
+      payload.user = options.user;
+    }
+    this.calls.push({
+      address: '/eos/get/cmd_line',
+      args: [{ type: 's', value: JSON.stringify(payload) }],
+      options
+    });
+    return { status: 'ok', text: 'Chan 1', user: options.user ?? null, payload };
+  }
+
+  private captureCommand(address: string, command: string, options: TargetOptions & { user?: number }): void {
+    const args: OscMessageArgument[] = [{ type: 's', value: command }];
+    if (typeof options.user === 'number') {
+      args.push({ type: 'i', value: options.user });
+    }
+    this.calls.push({ address, args, options, command });
+  }
+
+  private responseDataFor(address: string): Record<string, unknown> {
+    if (address.includes('/live/blind')) {
+      return { status: 'ok', state: 'live' };
+    }
+    if (address.includes('/show/name')) {
+      return { status: 'ok', show: 'Contract Test Show' };
+    }
+    if (address.includes('/softkey_labels')) {
+      return { status: 'ok', labels: ['Help', 'More SK'] };
+    }
+    if (address.includes('/count')) {
+      return { status: 'ok', count: 1 };
+    }
+    if (address.includes('/list')) {
+      return { status: 'ok', items: [{ number: 1, label: 'One' }] };
+    }
+    return {
+      status: 'ok',
+      number: 1,
+      label: 'Contract fixture',
+      items: [{ number: 1, label: 'One' }],
+      x: 1,
+      y: 2,
+      z: 3
+    };
+  }
+}
+
+const SAMPLE_VALUES: Record<string, unknown> = {
+  address_number: '1/001',
+  addresses: '1/001',
+  back: false,
+  bank_index: 1,
+  blue: 64,
+  button_count: 10,
+  button_index: 2,
+  channel_number: 1,
+  channels: [1, 2],
+  clearLine: true,
+  color: 'red',
+  command: 'Go To Cue 1',
+  cuelist_number: 1,
+  cue_number: 2,
+  cue_part: 1,
+  curve_number: 1,
+  delta: 1,
+  device_type: 'Source Four LED Series 3 Lustr X8',
+  dmx_address: '1/001',
+  dmx_value: 128,
+  effect_number: 1,
+  exclusive: false,
+  fader_count: 10,
+  fader_index: 1,
+  fields: ['label'],
+  flexi_mode: false,
+  format_string: 'Cue %1 -> %2',
+  green: 128,
+  group_number: 1,
+  hue: 120,
+  key_name: 'go',
+  label: 'Contract label',
+  level: 50,
+  macro_number: 1,
+  mode: 'coarse',
+  ms_number: 1,
+  num_pending_cues: 2,
+  num_prev_cues: 2,
+  offset: 0,
+  osc_command: 'Magic Sheet 1',
+  page_number: 1,
+  palette_number: 1,
+  palette_type: 'ip',
+  parameter: 'pan',
+  parameter_name: 'pan',
+  part: 1,
+  part_number: 1,
+  pixmap_number: 1,
+  point_number: 1,
+  preset_number: 1,
+  rate: 0.5,
+  red: 255,
+  require_confirmation: true,
+  safety_level: 'off',
+  saturation: 75,
+  set_number: 1,
+  snap: false,
+  snapshot_number: 1,
+  softkey_number: 1,
+  state: true,
+  submaster_number: 1,
+  substitutions: [1, 50],
+  target_type: 'cue',
+  target_type_direct_select: 'chan',
+  targetAddress: '192.0.2.10',
+  targetPort: 3032,
+  template: 'Chan %1 At %2',
+  terminateWithEnter: true,
+  ticks: 3,
+  timeoutMs: 50,
+  user: 7,
+  value: 45,
+  values: [1, 50],
+  verification_timeout_ms: 50,
+  view_number: 1,
+  x: 0.1,
+  y: 0.2,
+  z: 0.3
+};
+
+const FIELD_ALIASES: Record<string, string> = {
+  target_type: 'target_type',
+  target_type_direct_select: 'target_type'
+};
+
+function sampleArgsFor(tool: ToolDefinition): Record<string, unknown> {
+  const rawShape = tool.config.inputSchema ?? {};
+  const args: Record<string, unknown> = {};
+
+  for (const key of Object.keys(rawShape)) {
+    if (key === 'target_type' && tool.name.startsWith('eos_direct_select')) {
+      args[key] = 'chan';
+      continue;
+    }
+    if (key in SAMPLE_VALUES) {
+      args[key] = SAMPLE_VALUES[key];
+      continue;
+    }
+    const alias = FIELD_ALIASES[key];
+    if (alias && alias in SAMPLE_VALUES) {
+      args[key] = SAMPLE_VALUES[alias];
+    }
+  }
+
+  return args;
+}
+
+function parseWithStrictSchema(tool: ToolDefinition, args: Record<string, unknown>): void {
+  const rawShape = tool.config.inputSchema;
+  if (!rawShape) {
+    return;
+  }
+  z.object(rawShape).strict().parse(args);
+}
+
+function expectedAddress(tool: ToolDefinition, args: Record<string, unknown>): string {
+  if (tool.name === 'eos_palette_get_info') {
+    return `/eos/get/${String(args.palette_type)}`;
+  }
+  if (tool.name === 'eos_cuelist_bank_create') {
+    return `/eos/cuelist/${String(args.bank_index)}/config/${String(args.cuelist_number)}/${String(args.num_prev_cues)}/${String(args.num_pending_cues)}/${String(args.offset)}`;
+  }
+  const mapping = tool.config.annotations?.mapping as { osc?: unknown } | undefined;
+  const osc = mapping?.osc;
+  if (typeof osc === 'string') {
+    return resolveTemplate(osc, args);
+  }
+  if (osc && typeof osc === 'object') {
+    const key = String(args.target_type);
+    const address = (osc as Record<string, string>)[key];
+    if (address) {
+      return address;
+    }
+  }
+  throw new Error(`No OSC mapping for ${tool.name}`);
+}
+
+function resolveTemplate(template: string, args: Record<string, unknown>): string {
+  return template
+    .replace('{bank_index}', String(args.bank_index))
+    .replace('{key}', keyIdentifier(args.key_name))
+    .replace('softkey{number}', `softkey${String(args.softkey_number)}`)
+    .replace('{group}', String(args.group_number))
+    .replace('{submaster_number}', String(args.submaster_number))
+    .replace('{bank}', String(args.bank_index))
+    .replace('{index}', String(args.bank_index))
+    .replace('{page}', String(args.page_number ?? 1))
+    .replace('{fader}', String(args.fader_index))
+    .replace('{faders}', String(args.fader_count))
+    .replace('{target}', toolTargetName(args.target_type))
+    .replace('{buttons}', String(args.button_count))
+    .replace('{button}', String(args.button_index))
+    .replace('{flexi}', args.flexi_mode ? '1' : '0')
+    .replace('{delta}', String(args.delta))
+    .replace('{cuelist_number}', String(args.cuelist_number))
+    .replace('{num_prev_cues}', String(args.num_prev_cues))
+    .replace('{num_pending_cues}', String(args.num_pending_cues))
+    .replace('{offset}', String(args.offset));
+}
+
+
+function keyIdentifier(value: unknown): string {
+  const keyMap: Record<string, string> = {
+    go: 'go_0',
+    stop_back: 'stop/back'
+  };
+  return keyMap[String(value)] ?? String(value);
+}
+
+function toolTargetName(value: unknown): string {
+  if (value === 'chan') {
+    return 'Chan';
+  }
+  return String(value);
+}
+
+const oscTools = toolDefinitions.filter((tool) => {
+  const mapping = tool.config.annotations?.mapping as { osc?: unknown } | undefined;
+  return Boolean(mapping?.osc);
+});
+
+describe('OSC tool contracts exported from src/tools/index.ts', () => {
+  let client: MockOscClient;
+
+  beforeEach(() => {
+    client = new MockOscClient();
+    setOscClient(client as unknown as OscClient);
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it('lists every tool exported from src/tools/index.ts with a stable fixture', () => {
+    expect(toolDefinitions.map((tool) => tool.name)).toMatchSnapshot();
+  });
+
+  it('lists every exported OSC tool with a stable contract fixture', () => {
+    expect(oscTools.map((tool) => tool.name)).toMatchSnapshot();
+  });
+
+  it('documents every exported tool in the OSC coverage table', () => {
+    const coverage = readFileSync(resolve(__dirname, '../../../docs/osc-coverage.md'), 'utf8');
+
+    for (const tool of toolDefinitions) {
+      expect(coverage).toContain(`\`${tool.name}\``);
+    }
+  });
+
+  it.each(oscTools.map((tool) => [tool.name, tool] as const))(
+    '%s rejects unknown parameters when its schema is strict',
+    async (_name, tool) => {
+      const args = sampleArgsFor(tool);
+      parseWithStrictSchema(tool, args);
+      await expect(runTool(tool, { ...args, unexpected_parameter: true })).rejects.toThrow();
+    }
+  );
+
+  it.each(oscTools.map((tool) => [tool.name, tool] as const))(
+    '%s sends the documented OSC address, payload, and target endpoint',
+    async (_name, tool) => {
+      const args = sampleArgsFor(tool);
+      parseWithStrictSchema(tool, args);
+
+      const extra = tool.name === 'eos_magic_sheet_send_string' ? { role: 'Primary' } : {};
+      await runTool(tool, args, extra);
+
+      expect(client.calls).toHaveLength(1);
+      const [call] = client.calls;
+      expect(call).toMatchObject({
+        address: expectedAddress(tool, args),
+        options: {
+          targetAddress: '192.0.2.10',
+          targetPort: 3032
+        }
+      });
+      expect(call?.args ?? []).toMatchSnapshot();
+    }
+  );
+
+  it('returns stable MCP content when OSC reports an error status', async () => {
+    const errorClient = new MockOscClient();
+    jest.spyOn(errorClient, 'requestJson').mockResolvedValue({
+      status: 'error',
+      data: null,
+      payload: { status: 'error', error: 'boom' },
+      error: 'boom'
+    });
+    setOscClient(errorClient as unknown as OscClient);
+
+    const tool = toolDefinitions.find((candidate) => candidate.name === 'eos_address_set_dmx');
+    if (!tool) {
+      throw new Error('eos_address_set_dmx not exported');
+    }
+
+    const result = await runTool(tool, {
+      address_number: '1/001',
+      dmx_value: 64,
+      targetAddress: '192.0.2.10',
+      targetPort: 3032
+    });
+
+    expect(result).toMatchObject({
+      content: [{ type: 'text' }],
+      structuredContent: {
+        action: 'address_set_dmx',
+        status: 'error',
+        osc: {
+          address: '/eos/dmx/address/dmx',
+          response: { status: 'error', error: 'boom' }
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Centraliser la vérification des contrats OSC pour tous les outils exportés afin d'assurer que chaque outil envoie la bonne adresse/charge et respecte le schéma d'entrée strict.
- Documenter automatiquement la couverture OSC ↔ MCP pour faciliter la revue et la traçabilité des outils vers les adresses OSC.

### Description

- Ajout d'une nouvelle suite de tests `src/tools/__tests__/osc_contracts.test.ts` qui moque `OscClient` et vérifie pour chaque outil OSC exporté : adresse OSC, payload (snapshots), `targetAddress`/`targetPort` et rejet des paramètres inconnus via les schémas `z.object(...).strict()`.
- Mise en place d'un client factice `MockOscClient` centralisé qui capture `sendMessage`, `requestJson`, `sendCommand`, `sendNewCommand`, `getCommandLine` et `requestBuiltJson` pour assertions et snapshots.
- Ajout des snapshots générés `src/tools/__tests__/__snapshots__/osc_contracts.test.ts.snap` couvrant les arguments OSC attendus pour chaque outil mappé.
- Remplacement / mise à jour de `docs/osc-coverage.md` pour lister tous les outils exportés, leur mapping OSC (quand disponible) et pointer vers le test centralisé.

### Testing

- `npx jest src/tools/__tests__/osc_contracts.test.ts --runInBand` — OK (tests du contrat OSC verts, snapshots générés/validés).
- `npm run tsc` — OK (compilation TypeScript sans erreurs).
- `npm run lint` — OK (ESLint sans erreurs).
- Remarques : l'exécution via `npm test -- --runTestsByPath ...` a initialement lancé l'ensemble de la suite (script `npm test` exécute d'autres tests) et peut échouer sur des tests non liés dans cet environnement; les validations ciblées ci-dessus ont été réussies et les snapshots mis à jour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06907b7d54832a96ce937a91b90955)