### PR TITLE
Add tool discovery metadata and expose it in docs, schemas and MCP registry

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -306,10 +306,26 @@ Les payloads ci-dessous utilisent le format MCP `tools/call` complet. Les exempl
 | `eos_preset_fire` | Declenchement de preset | [#eos-preset-fire](#eos-preset-fire) |
 | `eos_preset_get_info` | Informations de preset | [#eos-preset-get-info](#eos-preset-get-info) |
 
+## Métadonnées de découverte
+
+Les champs `category`, `synonyms`, `riskLevel`, `requiresConfirmation` et `preferredWorkflow` sont publiés dans `config.annotations` pour les clients MCP et repris ci-dessous pour guider le routage LLM.
+
+Catégories documentées : `commands`, `cues`, `dmx`, `keys`, `macros`, `palettes`, `patch`, `presets`, `showControl`.
+
 <a id="eos-address-select"></a>
 ## Selection d'adresse DMX (`eos_address_select`)
 
 **Description :** Selectionne une adresse DMX specifique sur la console.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `dmx` |
+| Synonymes | `dmx`, `address`, `adresse`, `level`, `sortie directe` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look` |
 
 **Arguments :**
 
@@ -340,6 +356,16 @@ oscsend 127.0.0.1 8001 /eos/dmx/address/select s:'{"address_number":"exemple"}'
 ## Reglage DMX brut (`eos_address_set_dmx`)
 
 **Description :** Fixe une valeur DMX brute (0-255) pour une adresse DMX.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `dmx` |
+| Synonymes | `dmx`, `address`, `adresse`, `level`, `sortie directe` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look` |
 
 **Arguments :**
 
@@ -372,6 +398,16 @@ oscsend 127.0.0.1 8001 /eos/dmx/address/dmx s:'{"address_number":"exemple","dmx_
 
 **Description :** Ajuste le niveau (0-100) pour une adresse DMX donnee.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `dmx` |
+| Synonymes | `dmx`, `address`, `adresse`, `level`, `sortie directe` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -402,6 +438,16 @@ oscsend 127.0.0.1 8001 /eos/dmx/address/level s:'{"address_number":"exemple","le
 ## Declenchement de palette de beam (`eos_beam_palette_fire`)
 
 **Description :** Declenche une palette de beam sur la console Eos.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `palettes` |
+| Synonymes | `palette`, `ip`, `fp`, `cp`, `bp`, `look building` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_create_cue_series` |
 
 **Arguments :**
 
@@ -615,6 +661,16 @@ oscsend 127.0.0.1 8001 /eos/chan/param s:'{"channels":1,"parameter":"exemple","v
 
 **Description :** Declenche une palette de couleur sur la console Eos.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `palettes` |
+| Synonymes | `palette`, `ip`, `fp`, `cp`, `bp`, `look building` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_create_cue_series` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -647,6 +703,16 @@ oscsend 127.0.0.1 8001 /eos/cp/fire s:'{"palette_number":1}'
 ## Commande EOS (`eos_command`)
 
 **Description :** Envoie du texte sur la ligne de commande existante de la console. A n'utiliser que lorsqu'aucun outil dedie n'existe. Pour programmer des cues, preferer eos_new_command avec clearLine=true et terminateWithEnter=true.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `commands` |
+| Synonymes | `command line`, `cmd`, `newcmd`, `texte eos`, `ligne de commande` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_update_cue_look` |
 
 **Arguments :**
 
@@ -684,6 +750,16 @@ oscsend 127.0.0.1 8001 /eos/cmd s:'{"command":"exemple"}'
 ## Commande avec substitution (`eos_command_with_substitution`)
 
 **Description :** Applique des substitutions %1, %2, ... puis envoie la commande.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `commands` |
+| Synonymes | `command line`, `cmd`, `newcmd`, `texte eos`, `ligne de commande` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_update_cue_look` |
 
 **Arguments :**
 
@@ -782,6 +858,16 @@ _Pas de mapping OSC documenté._
 
 **Description :** Declenche immediatement une cue specifique dans une liste donnee.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `cues` |
+| Synonymes | `cue`, `cuelist`, `playback`, `go`, `record cue` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_cue_series`, `eos_workflow_update_cue_look` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -816,6 +902,16 @@ oscsend 127.0.0.1 8001 /eos/cmd s:'{"cuelist_number":1,"cue_number":"exemple"}'
 ## Informations de cue (`eos_cue_get_info`)
 
 **Description :** Recupere les informations detaillees d'une cue (timings, flags, notes...).
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `cues` |
+| Synonymes | `cue`, `cuelist`, `playback`, `go`, `record cue` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_cue_series`, `eos_workflow_update_cue_look` |
 
 **Arguments :**
 
@@ -852,6 +948,16 @@ oscsend 127.0.0.1 8001 /eos/get/cue s:'{"cuelist_number":1,"cue_number":"exemple
 ## GO sur liste de cues (`eos_cue_go`)
 
 **Description :** Declenche un GO sur la liste de cues cible, optionnellement vers une cue precise.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `cues` |
+| Synonymes | `cue`, `cuelist`, `playback`, `go`, `record cue` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_cue_series`, `eos_workflow_update_cue_look` |
 
 **Arguments :**
 
@@ -921,6 +1027,16 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'Cue 1 Label "exemple"#'
 
 **Description :** Recupere toutes les cues d'une liste avec leurs labels.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `cues` |
+| Synonymes | `cue`, `cuelist`, `playback`, `go`, `record cue` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_cue_series`, `eos_workflow_update_cue_look` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -986,6 +1102,16 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'Record Cue {cuelist_number}/1#'
 
 **Description :** Selectionne une cue dans la liste sans la declencher.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `cues` |
+| Synonymes | `cue`, `cuelist`, `playback`, `go`, `record cue` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_cue_series`, `eos_workflow_update_cue_look` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -1020,6 +1146,16 @@ oscsend 127.0.0.1 8001 /eos/cmd s:'{"cuelist_number":1,"cue_number":"exemple"}'
 ## Stop ou Back sur liste de cues (`eos_cue_stop_back`)
 
 **Description :** Stoppe la lecture de la liste ou effectue un back selon l'option fournie.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `cues` |
+| Synonymes | `cue`, `cuelist`, `playback`, `go`, `record cue` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_cue_series`, `eos_workflow_update_cue_look` |
 
 **Arguments :**
 
@@ -1087,6 +1223,16 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'Update Cue 1#'
 
 **Description :** Configure un bank OSC pour surveiller une liste de cues.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `cues` |
+| Synonymes | `cue`, `cuelist`, `playback`, `go`, `record cue` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_cue_series`, `eos_workflow_update_cue_look` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -1124,6 +1270,16 @@ oscsend 127.0.0.1 8001 /eos/cuelist/1/config/1/1/1
 
 **Description :** Change de page dans un bank de cues en ajoutant le delta specifie.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `cues` |
+| Synonymes | `cue`, `cuelist`, `playback`, `go`, `record cue` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_cue_series`, `eos_workflow_update_cue_look` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -1157,6 +1313,16 @@ oscsend 127.0.0.1 8001 /eos/cuelist/1/page/1
 ## Informations de cuelist (`eos_cuelist_get_info`)
 
 **Description :** Recupere les attributs d'une liste de cues (modes, flags...).
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `cues` |
+| Synonymes | `cue`, `cuelist`, `playback`, `go`, `record cue` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_cue_series`, `eos_workflow_update_cue_look` |
 
 **Arguments :**
 
@@ -1655,6 +1821,16 @@ _Pas de mapping OSC documenté._
 
 **Description :** Declenche une palette de focus sur la console Eos.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `palettes` |
+| Synonymes | `palette`, `ip`, `fp`, `cp`, `bp`, `look building` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_create_cue_series` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -1781,6 +1957,16 @@ oscsend 127.0.0.1 8001 /eos/get/fpe/set s:'{"set_number":1}'
 
 **Description :** Recupere la cue actuellement en lecture sur la liste specifiee (ou principale).
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `cues` |
+| Synonymes | `cue`, `cuelist`, `playback`, `go`, `record cue` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_cue_series`, `eos_workflow_update_cue_look` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -1843,6 +2029,16 @@ oscsend 127.0.0.1 8001 /eos/get/active/wheels s:'{"timeoutMs":1}'
 ## Lecture de la ligne de commande EOS (`eos_get_command_line`)
 
 **Description :** Recupere le contenu courant de la ligne de commande via OSC Get.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `commands` |
+| Synonymes | `command line`, `cmd`, `newcmd`, `texte eos`, `ligne de commande` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_update_cue_look` |
 
 **Arguments :**
 
@@ -1957,6 +2153,16 @@ _Pas de mapping OSC documenté._
 
 **Description :** Indique si la console est en mode Live ou Blind.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `showControl` |
+| Synonymes | `show control`, `show name`, `live blind`, `cue string`, `staging mode` |
+| Niveau de risque | `critical` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_rehearsal_go` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -1986,6 +2192,16 @@ oscsend 127.0.0.1 8001 /eos/get/live/blind s:'{"timeoutMs":1}'
 ## Cue en attente (`eos_get_pending_cue`)
 
 **Description :** Recupere la prochaine cue en attente sur la liste specifiee (ou principale).
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `cues` |
+| Synonymes | `cue`, `cuelist`, `playback`, `go`, `record cue` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_cue_series`, `eos_workflow_update_cue_look` |
 
 **Arguments :**
 
@@ -2047,6 +2263,16 @@ _Pas de mapping OSC documenté._
 
 **Description :** Recupere le nom du show actuellement charge sur la console.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `showControl` |
+| Synonymes | `show control`, `show name`, `live blind`, `cue string`, `staging mode` |
+| Niveau de risque | `critical` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_rehearsal_go` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -2077,6 +2303,16 @@ oscsend 127.0.0.1 8001 /eos/get/show/name s:'{"timeoutMs":1}'
 
 **Description :** Recupere les libelles affiches des softkeys 1-12.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `keys` |
+| Synonymes | `key`, `button`, `softkey`, `touche`, `facepanel` |
+| Niveau de risque | `medium` |
+| Confirmation requise | Non |
+| Workflow préféré | `eos_workflow_rehearsal_go` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -2106,6 +2342,16 @@ oscsend 127.0.0.1 8001 /eos/get/softkey_labels s:'{"timeoutMs":1}'
 ## Lecture de la ligne de commande utilisateur (`eos_get_user_command_line`)
 
 **Description :** Recupere la ligne de commande pour un utilisateur specifique.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `commands` |
+| Synonymes | `command line`, `cmd`, `newcmd`, `texte eos`, `ligne de commande` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_update_cue_look` |
 
 **Arguments :**
 
@@ -2293,6 +2539,16 @@ oscsend 127.0.0.1 8001 /eos/group/{group}/level s:'{"group_number":1,"level":1}'
 
 **Description :** Declenche une palette d'intensite sur la console Eos.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `palettes` |
+| Synonymes | `palette`, `ip`, `fp`, `cp`, `bp`, `look building` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_create_cue_series` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -2326,6 +2582,16 @@ oscsend 127.0.0.1 8001 /eos/ip/fire s:'{"palette_number":1}'
 
 **Description :** Simule l'appui ou le relachement d'une touche du clavier EOS.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `keys` |
+| Synonymes | `key`, `button`, `softkey`, `touche`, `facepanel` |
+| Niveau de risque | `medium` |
+| Confirmation requise | Non |
+| Workflow préféré | `eos_workflow_rehearsal_go` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -2357,6 +2623,16 @@ oscsend 127.0.0.1 8001 /eos/key/{key} s:'{"key_name":"exemple"}'
 
 **Description :** Declenche une macro en envoyant son numero a la console.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `macros` |
+| Synonymes | `macro`, `macro fire`, `automation`, `sequence` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_rehearsal_go` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -2386,6 +2662,16 @@ oscsend 127.0.0.1 8001 /eos/macro/fire s:'{"macro_number":1}'
 ## Informations de macro (`eos_macro_get_info`)
 
 **Description :** Recupere le libelle et le script d'une macro.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `macros` |
+| Synonymes | `macro`, `macro fire`, `automation`, `sequence` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_rehearsal_go` |
 
 **Arguments :**
 
@@ -2417,6 +2703,16 @@ oscsend 127.0.0.1 8001 /eos/get/macro s:'{"macro_number":1}'
 ## Selection de macro (`eos_macro_select`)
 
 **Description :** Selectionne une macro sans l'executer.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `macros` |
+| Synonymes | `macro`, `macro fire`, `automation`, `sequence` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_rehearsal_go` |
 
 **Arguments :**
 
@@ -2540,6 +2836,16 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'{"osc_command":"exemple"}'
 
 **Description :** Efface optionnellement la ligne de commande puis envoie le texte fourni. A n'utiliser que lorsqu'aucun outil dedie n'existe. Outil recommande pour appliquer les bonnes pratiques de programmation de cues du manuel EOS.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `commands` |
+| Synonymes | `command line`, `cmd`, `newcmd`, `texte eos`, `ligne de commande` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_update_cue_look` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -2578,6 +2884,16 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'{"command":"exemple"}'
 ## Informations de palette (`eos_palette_get_info`)
 
 **Description :** Recupere les informations detaillees pour une palette donnee.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `palettes` |
+| Synonymes | `palette`, `ip`, `fp`, `cp`, `bp`, `look building` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_create_cue_series` |
 
 **Arguments :**
 
@@ -2680,6 +2996,16 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'IP 1 Record#'
 
 **Description :** Recupere les informations de faisceau Augment3d pour une partie de canal.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `patch` |
+| Synonymes | `patch`, `fixture`, `channel setup`, `augment3d`, `adressage` |
+| Niveau de risque | `critical` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_autopatch_band` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -2715,6 +3041,16 @@ oscsend 127.0.0.1 8001 /eos/get/patch/chan_beam s:'{"channel_number":1,"part_num
 
 **Description :** Recupere la position Augment3d d'une partie de canal.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `patch` |
+| Synonymes | `patch`, `fixture`, `channel setup`, `augment3d`, `adressage` |
+| Niveau de risque | `critical` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_autopatch_band` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -2749,6 +3085,16 @@ oscsend 127.0.0.1 8001 /eos/get/patch/chan_pos s:'{"channel_number":1,"part_numb
 ## Informations de patch (`eos_patch_get_channel_info`)
 
 **Description :** Recupere les informations de patch pour un canal donne.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `patch` |
+| Synonymes | `patch`, `fixture`, `channel setup`, `augment3d`, `adressage` |
+| Niveau de risque | `critical` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_autopatch_band` |
 
 **Arguments :**
 
@@ -2913,6 +3259,16 @@ oscsend 127.0.0.1 8001 /eos/pixmap s:'{"pixmap_number":1}'
 
 **Description :** Declenche un preset sur la console Eos.
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `presets` |
+| Synonymes | `preset`, `look`, `preset fire`, `preset select` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_create_cue_series` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -2942,6 +3298,16 @@ oscsend 127.0.0.1 8001 /eos/preset/fire s:'{"preset_number":1}'
 ## Informations de preset (`eos_preset_get_info`)
 
 **Description :** Recupere les informations detaillees pour un preset donne.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `presets` |
+| Synonymes | `preset`, `look`, `preset fire`, `preset select` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_create_cue_series` |
 
 **Arguments :**
 
@@ -2974,6 +3340,16 @@ oscsend 127.0.0.1 8001 /eos/get/preset s:'{"preset_number":1}'
 ## Selection de preset (`eos_preset_select`)
 
 **Description :** Selectionne un preset sur la console Eos.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `presets` |
+| Synonymes | `preset`, `look`, `preset fire`, `preset select` |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_create_look`, `eos_workflow_create_cue_series` |
 
 **Arguments :**
 
@@ -3097,6 +3473,16 @@ oscsend 127.0.0.1 8001 /eos/param/color/rgb s:'{"red":1,"green":1,"blue":1}'
 
 **Description :** Configure le format de reception OSC des cues (placeholders %1-%2).
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `showControl` |
+| Synonymes | `show control`, `show name`, `live blind`, `cue string`, `staging mode` |
+| Niveau de risque | `critical` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_rehearsal_go` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -3126,6 +3512,16 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'{"format_string":"exemple"}'
 ## Format d'envoi des cues (`eos_set_cue_send_string`)
 
 **Description :** Configure le format d'envoi OSC des cues (placeholders %1-%5).
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `showControl` |
+| Synonymes | `show control`, `show name`, `live blind`, `cue string`, `staging mode` |
+| Niveau de risque | `critical` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_rehearsal_go` |
 
 **Arguments :**
 
@@ -3340,6 +3736,16 @@ oscsend 127.0.0.1 8001 /eos/snap s:'{"snapshot_number":1}'
 
 **Description :** Simule l'appui ou le relachement d'une softkey (1-12).
 
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `keys` |
+| Synonymes | `key`, `button`, `softkey`, `touche`, `facepanel` |
+| Niveau de risque | `medium` |
+| Confirmation requise | Non |
+| Workflow préféré | `eos_workflow_rehearsal_go` |
+
 **Arguments :**
 
 | Nom | Type | Requis | Description |
@@ -3525,6 +3931,16 @@ oscsend 127.0.0.1 8001 /eos/param/wheel/rate s:'{"parameter_name":"exemple","rat
 ## Toggle Staging Mode (`eos_toggle_staging_mode`)
 
 **Description :** Active ou desactive le mode Staging de la console.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `showControl` |
+| Synonymes | `show control`, `show name`, `live blind`, `cue string`, `staging mode` |
+| Niveau de risque | `critical` |
+| Confirmation requise | Oui |
+| Workflow préféré | `eos_workflow_rehearsal_go` |
 
 **Arguments :**
 

--- a/scripts/toolDocs.ts
+++ b/scripts/toolDocs.ts
@@ -4,7 +4,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import type { ToolDefinition } from '../src/tools/types.js';
+import type { ToolDefinition, ToolMetadata as DefinitionToolMetadata } from '../src/tools/types.js';
 import { z, type ZodTypeAny, type ZodOptional, type ZodNullable, type ZodDefault, type ZodEffects } from 'zod';
 import {
   Project,
@@ -437,6 +437,70 @@ function formatOscExample(mappingValue: unknown, args?: Record<string, unknown>)
   ];
 }
 
+
+function formatMetadataValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((entry) => `\`${String(entry)}\``).join(', ');
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Oui' : 'Non';
+  }
+  if (typeof value === 'string') {
+    return `\`${value}\``;
+  }
+  if (value == null) {
+    return '—';
+  }
+  return `\`${JSON.stringify(value)}\``;
+}
+
+function extractToolMetadata(tool: ToolDefinition): DefinitionToolMetadata | undefined {
+  const annotations = tool.config.annotations ?? {};
+  const metadata = tool.metadata ?? {};
+  const merged: DefinitionToolMetadata = {
+    ...metadata,
+    category: metadata.category ?? (typeof annotations.category === 'string' ? annotations.category : undefined),
+    synonyms: metadata.synonyms ?? (Array.isArray(annotations.synonyms) ? annotations.synonyms.filter((entry): entry is string => typeof entry === 'string') : undefined),
+    riskLevel: metadata.riskLevel ?? (typeof annotations.riskLevel === 'string' ? metadata.riskLevel ?? annotations.riskLevel as DefinitionToolMetadata['riskLevel'] : undefined),
+    requiresConfirmation: metadata.requiresConfirmation ?? (typeof annotations.requiresConfirmation === 'boolean' ? annotations.requiresConfirmation : undefined),
+    preferredWorkflow: metadata.preferredWorkflow ?? (
+      typeof annotations.preferredWorkflow === 'string' || Array.isArray(annotations.preferredWorkflow)
+        ? annotations.preferredWorkflow as string | string[]
+        : undefined
+    )
+  };
+
+  return Object.values(merged).some((value) => value !== undefined) ? merged : undefined;
+}
+
+function pushToolMetadata(lines: string[], tool: ToolDefinition): void {
+  const metadata = extractToolMetadata(tool);
+  if (!metadata) {
+    return;
+  }
+
+  lines.push('**Métadonnées :**');
+  lines.push('');
+  lines.push('| Champ | Valeur |');
+  lines.push('| --- | --- |');
+  if (metadata.category) {
+    lines.push(`| Catégorie | ${formatMetadataValue(metadata.category)} |`);
+  }
+  if (metadata.synonyms && metadata.synonyms.length > 0) {
+    lines.push(`| Synonymes | ${formatMetadataValue(metadata.synonyms)} |`);
+  }
+  if (metadata.riskLevel) {
+    lines.push(`| Niveau de risque | ${formatMetadataValue(metadata.riskLevel)} |`);
+  }
+  if (typeof metadata.requiresConfirmation === 'boolean') {
+    lines.push(`| Confirmation requise | ${formatMetadataValue(metadata.requiresConfirmation)} |`);
+  }
+  if (metadata.preferredWorkflow) {
+    lines.push(`| Workflow préféré | ${formatMetadataValue(metadata.preferredWorkflow)} |`);
+  }
+  lines.push('');
+}
+
 function slugify(value: string): string {
   return value
     .toLowerCase()
@@ -785,6 +849,19 @@ function buildDocumentation(tools: ToolDefinition[]): { markdown: string; metada
     lines.push('');
   }
 
+  const documentedMetadata = sortedTools
+    .map((tool) => extractToolMetadata(tool))
+    .filter((metadata): metadata is DefinitionToolMetadata => Boolean(metadata));
+  const documentedCategories = Array.from(new Set(documentedMetadata.map((metadata) => metadata.category).filter((category): category is string => Boolean(category)))).sort();
+  if (documentedCategories.length > 0) {
+    lines.push('## Métadonnées de découverte');
+    lines.push('');
+    lines.push('Les champs `category`, `synonyms`, `riskLevel`, `requiresConfirmation` et `preferredWorkflow` sont publiés dans `config.annotations` pour les clients MCP et repris ci-dessous pour guider le routage LLM.');
+    lines.push('');
+    lines.push(`Catégories documentées : ${documentedCategories.map((category) => `\`${category}\``).join(', ')}.`);
+    lines.push('');
+  }
+
   for (const tool of sortedTools) {
     const data = metadata.get(tool.name)!;
     const title = tool.config.title ?? tool.name;
@@ -796,6 +873,7 @@ function buildDocumentation(tools: ToolDefinition[]): { markdown: string; metada
     lines.push('');
     lines.push(`**Description :** ${description}`);
     lines.push('');
+    pushToolMetadata(lines, tool);
 
     if (data.properties.length === 0) {
       lines.push('**Arguments :** Aucun argument.');

--- a/src/schemas/__tests__/tool_schemas.test.ts
+++ b/src/schemas/__tests__/tool_schemas.test.ts
@@ -45,6 +45,41 @@ describe('tool JSON schemas', () => {
   });
 
 
+  it('expose les metadonnees de decouverte dans les schemas des familles principales', () => {
+    const expectedFamilies = new Map([
+      ['eos_cue_go', 'cues'],
+      ['eos_command', 'commands'],
+      ['eos_key_press', 'keys'],
+      ['eos_macro_fire', 'macros'],
+      ['eos_address_set_dmx', 'dmx'],
+      ['eos_palette_get_info', 'palettes'],
+      ['eos_preset_fire', 'presets'],
+      ['eos_patch_get_channel_info', 'patch'],
+      ['eos_set_cue_send_string', 'showControl']
+    ]);
+
+    for (const [toolName, category] of expectedFamilies) {
+      const schema = toolJsonSchemas.find((candidate) => candidate.name === toolName);
+      expect(schema?.metadata).toEqual(expect.objectContaining({
+        category,
+        synonyms: expect.any(Array),
+        riskLevel: expect.any(String),
+        requiresConfirmation: expect.any(Boolean)
+      }));
+      expect(schema?.schema).toMatchObject({
+        'x-eos-metadata': expect.objectContaining({ category })
+      });
+    }
+
+    const patchSchema = toolJsonSchemas.find((schema) => schema.name === 'eos_patch_get_channel_info');
+    expect(patchSchema?.metadata).toMatchObject({
+      category: 'patch',
+      riskLevel: 'critical',
+      preferredWorkflow: 'eos_workflow_autopatch_band'
+    });
+  });
+
+
   it('publie dry_run sur tous les workflows', () => {
     const workflowSchemas = toolJsonSchemas.filter((schema) => schema.name.startsWith('eos_workflow_'));
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -8,7 +8,7 @@ import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sd
 import { z, type ZodRawShape, type ZodTypeAny } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import toolDefinitions from '../tools/index';
-import type { ToolDefinition } from '../tools/types';
+import type { ToolDefinition, ToolMetadata } from '../tools/types';
 
 export interface ToolJsonSchemaDefinition {
   name: string;
@@ -16,6 +16,7 @@ export interface ToolJsonSchemaDefinition {
   description?: string;
   uri: string;
   schema: Record<string, unknown>;
+  metadata?: ToolMetadata;
 }
 
 type ZodToJsonSchema = (
@@ -45,6 +46,7 @@ function buildSchema(definition: ToolDefinition): ToolJsonSchemaDefinition {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: definition.config.title ?? definition.name,
     description: definition.config.description,
+    ...(definition.metadata ? { 'x-eos-metadata': definition.metadata } : {}),
     ...jsonSchema
   };
 
@@ -53,7 +55,8 @@ function buildSchema(definition: ToolDefinition): ToolJsonSchemaDefinition {
     title: definition.config.title,
     description: definition.config.description,
     uri: `schema://tools/${definition.name}`,
-    schema: enrichedSchema
+    schema: enrichedSchema,
+    metadata: definition.metadata
   };
 }
 

--- a/src/server/__tests__/toolRegistry.test.ts
+++ b/src/server/__tests__/toolRegistry.test.ts
@@ -138,6 +138,57 @@ describe('ToolRegistry schema-less tools', () => {
 
 
 
+  it('expose les metadonnees de decouverte dans les summaries et annotations MCP', () => {
+    const server = createMockServer();
+    const registry = new ToolRegistry(server);
+
+    const tool: ToolDefinition = {
+      name: 'metadata_tool',
+      config: {
+        description: 'Tool with discovery metadata',
+        annotations: { mapping: { osc: '/eos/cmd' } }
+      },
+      metadata: {
+        category: 'commands',
+        synonyms: ['cmd', 'ligne de commande'],
+        riskLevel: 'high',
+        requiresConfirmation: true,
+        preferredWorkflow: 'eos_workflow_create_look'
+      },
+      handler: async () => ({ content: [{ type: 'text', text: 'metadata' }] })
+    };
+
+    registry.register(tool);
+
+    expect(server.registerTool).toHaveBeenCalledWith(
+      'metadata_tool',
+      expect.objectContaining({
+        annotations: expect.objectContaining({
+          mapping: { osc: '/eos/cmd' },
+          category: 'commands',
+          riskLevel: 'high',
+          requiresConfirmation: true
+        })
+      }),
+      expect.any(Function)
+    );
+
+    expect(registry.getRegisteredSummaries()).toEqual([
+      expect.objectContaining({
+        name: 'metadata_tool',
+        config: expect.objectContaining({
+          metadata: expect.objectContaining({
+            category: 'commands',
+            riskLevel: 'high',
+            requiresConfirmation: true,
+            preferredWorkflow: 'eos_workflow_create_look'
+          })
+        })
+      })
+    ]);
+  });
+
+
   it('executes a tool without prior manual or schema consultation', async () => {
     const server = createMockServer();
     const registry = new ToolRegistry(server);

--- a/src/server/httpGateway.ts
+++ b/src/server/httpGateway.ts
@@ -384,6 +384,7 @@ class HttpGateway {
         title: schema.title ?? schema.name,
         description: schema.description,
         uri: schema.uri,
+        metadata: schema.metadata,
         schemaUrl: `/schemas/tools/${schema.name}.json`
       }));
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -10,7 +10,8 @@ import type {
   ToolDefinition,
   ToolExecutionResult,
   ToolMiddleware,
-  ToolContext
+  ToolContext,
+  ToolMetadata
 } from '../tools/types';
 import { setCapabilitiesToolNamesProvider } from '../tools/capabilities/context';
 import {
@@ -130,6 +131,7 @@ interface RegisteredToolConfigSummary {
   title?: string;
   description?: string;
   annotations?: Record<string, unknown>;
+  metadata?: ToolMetadata;
 }
 
 interface RegisteredToolSummary {
@@ -141,6 +143,23 @@ interface RegisteredToolSummary {
     inputSchemaResourceUri?: string;
     hasMiddlewares: boolean;
     middlewareCount: number;
+  };
+}
+
+
+function buildToolConfigForRegistration(tool: ToolDefinition): ToolDefinition['config'] {
+  if (!tool.metadata) {
+    return tool.config;
+  }
+
+  const { annotations: metadataAnnotations, ...metadataFields } = tool.metadata;
+  return {
+    ...tool.config,
+    annotations: {
+      ...(tool.config.annotations ?? {}),
+      ...(metadataAnnotations ?? {}),
+      ...metadataFields
+    }
   };
 }
 
@@ -167,8 +186,11 @@ class ToolRegistry {
       return callback(undefined, extra);
     }) as never;
 
-    this.server.registerTool(tool.name, tool.config as never, handlerForServer);
-    this.registeredTools.set(tool.name, tool);
+    const config = buildToolConfigForRegistration(tool);
+    const registeredTool = { ...tool, config };
+
+    this.server.registerTool(tool.name, config as never, handlerForServer);
+    this.registeredTools.set(tool.name, registeredTool);
     this.registeredCallbacks.set(tool.name, callback);
   }
 
@@ -203,7 +225,8 @@ class ToolRegistry {
         config: {
           title: tool.config.title,
           description: tool.config.description,
-          annotations: tool.config.annotations
+          annotations: tool.config.annotations,
+          metadata: tool.metadata
         },
         metadata: {
           hasInputSchema,

--- a/src/tools/commands/command_tools.ts
+++ b/src/tools/commands/command_tools.ts
@@ -15,7 +15,7 @@ import {
   safetyOptionsSchema,
   type SafetyOptions
 } from '../common/safety';
-import { buildToolResult, type ToolDefinition, type ToolExecutionResult } from '../types';
+import { buildToolResult, withToolMetadata, type ToolDefinition, type ToolExecutionResult } from '../types';
 import { buildCueCommandPayload, createCueIdentifierFromOptions, formatCueDescription } from '../cues/common';
 import { mapCueList } from '../cues/mappers';
 import type { CueIdentifier } from '../cues/types';
@@ -807,12 +807,18 @@ export const eosGetUserCommandLineTool: ToolDefinition<typeof userCommandLineInp
   }
 };
 
-export const commandTools = [
+export const commandTools = withToolMetadata([
   eosCommandTool,
   eosNewCommandTool,
   eosCommandWithSubstitutionTool,
   eosGetCommandLineTool,
   eosGetUserCommandLineTool
-] as ToolDefinition[];
+], {
+  category: 'commands',
+  synonyms: ['command line', 'cmd', 'newcmd', 'texte eos', 'ligne de commande'],
+  riskLevel: 'high',
+  requiresConfirmation: true,
+  preferredWorkflow: ['eos_workflow_create_look', 'eos_workflow_update_cue_look']
+}) as ToolDefinition[];
 
 export default commandTools;

--- a/src/tools/commands/index.ts
+++ b/src/tools/commands/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export {
+  commandTools,
+  default,
+  eosCommandTool,
+  eosNewCommandTool,
+  eosCommandWithSubstitutionTool,
+  eosGetCommandLineTool,
+  eosGetUserCommandLineTool
+} from './command_tools';

--- a/src/tools/cues/index.ts
+++ b/src/tools/cues/index.ts
@@ -13,8 +13,9 @@ import eosCuelistBankCreateTool from './cuelist_bank_create';
 import eosCuelistBankPageTool from './cuelist_bank_page';
 import eosGetActiveCueTool from './get_active_cue';
 import eosGetPendingCueTool from './get_pending_cue';
+import { withToolMetadata } from '../types';
 
-export const cueTools = [
+export const cueTools = withToolMetadata([
   eosCueFireTool,
   eosCueGoTool,
   eosCueStopBackTool,
@@ -26,7 +27,13 @@ export const cueTools = [
   eosCuelistBankPageTool,
   eosGetActiveCueTool,
   eosGetPendingCueTool
-];
+], {
+  category: 'cues',
+  synonyms: ['cue', 'cuelist', 'playback', 'go', 'record cue'],
+  riskLevel: 'high',
+  requiresConfirmation: true,
+  preferredWorkflow: ['eos_workflow_create_cue_series', 'eos_workflow_update_cue_look']
+});
 
 export default cueTools;
 

--- a/src/tools/dmx/index.ts
+++ b/src/tools/dmx/index.ts
@@ -5,7 +5,7 @@
 import { z, type ZodRawShape } from 'zod';
 import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
 import { oscMappings } from '../../services/osc/mappings';
-import { buildToolResult, type ToolDefinition, type ToolExecutionResult } from '../types';
+import { buildToolResult, withToolMetadata, type ToolDefinition, type ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
@@ -307,6 +307,12 @@ export const eosAddressSetDmxTool: ToolDefinition<typeof addressSetDmxInputSchem
   }
 };
 
-export const dmxTools = [eosAddressSelectTool, eosAddressSetLevelTool, eosAddressSetDmxTool];
+export const dmxTools = withToolMetadata([eosAddressSelectTool, eosAddressSetLevelTool, eosAddressSetDmxTool], {
+  category: 'dmx',
+  synonyms: ['dmx', 'address', 'adresse', 'level', 'sortie directe'],
+  riskLevel: 'high',
+  requiresConfirmation: true,
+  preferredWorkflow: 'eos_workflow_create_look'
+});
 
 export default dmxTools;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,7 +7,7 @@ import eosConfigureTool from './connection/eos_configure';
 import eosPingTool from './connection/eos_ping';
 import eosResetTool from './connection/eos_reset';
 import eosSubscribeTool from './connection/eos_subscribe';
-import commandTools from './commands/command_tools';
+import commandTools from './commands/index';
 import channelTools from './channels/index';
 import groupTools from './groups/index';
 import pingTool from './ping';

--- a/src/tools/keys/index.ts
+++ b/src/tools/keys/index.ts
@@ -6,7 +6,7 @@ import { z, type ZodRawShape } from 'zod';
 import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
 import type { OscMessageArgument } from '../../services/osc/index';
 import { oscMappings } from '../../services/osc/mappings';
-import type { ToolDefinition, ToolExecutionResult } from '../types';
+import { withToolMetadata, type ToolDefinition, type ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
@@ -318,11 +318,17 @@ export const eosGetSoftkeyLabelsTool: ToolDefinition<typeof softkeyLabelsInputSc
   }
 };
 
-export const keyTools = [
+export const keyTools = withToolMetadata([
   eosKeyPressTool,
   eosSoftkeyPressTool,
   eosGetSoftkeyLabelsTool
-];
+], {
+  category: 'keys',
+  synonyms: ['key', 'button', 'softkey', 'touche', 'facepanel'],
+  riskLevel: 'medium',
+  requiresConfirmation: false,
+  preferredWorkflow: 'eos_workflow_rehearsal_go'
+});
 
 export const eosKeyTools = keyTools;
 

--- a/src/tools/macros/index.ts
+++ b/src/tools/macros/index.ts
@@ -12,7 +12,7 @@ import {
 import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
 import type { OscMessageArgument } from '../../services/osc/index';
 import { oscMappings } from '../../services/osc/mappings';
-import { buildToolResult, type ToolDefinition, type ToolExecutionResult } from '../types';
+import { buildToolResult, withToolMetadata, type ToolDefinition, type ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
@@ -500,11 +500,17 @@ export const eosMacroGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
   }
 };
 
-export const macroTools = [
+export const macroTools = withToolMetadata([
   eosMacroFireTool,
   eosMacroSelectTool,
   eosMacroGetInfoTool
-];
+], {
+  category: 'macros',
+  synonyms: ['macro', 'macro fire', 'automation', 'sequence'],
+  riskLevel: 'high',
+  requiresConfirmation: true,
+  preferredWorkflow: 'eos_workflow_rehearsal_go'
+});
 
 export const eosMacroTools = macroTools;
 

--- a/src/tools/palettes/index.ts
+++ b/src/tools/palettes/index.ts
@@ -19,7 +19,7 @@ import {
   resolveSafetyOptions,
   safetyOptionsSchema
 } from '../common/safety';
-import type { ToolDefinition, ToolExecutionResult } from '../types';
+import { withToolMetadata, type ToolDefinition, type ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
@@ -560,12 +560,18 @@ export const eosPaletteGetInfoTool: ToolDefinition<typeof paletteGetInfoInputSch
   }
 };
 
-const paletteTools = [
+const paletteTools = withToolMetadata([
   eosIntensityPaletteFireTool,
   eosFocusPaletteFireTool,
   eosColorPaletteFireTool,
   eosBeamPaletteFireTool,
   eosPaletteGetInfoTool
-];
+], {
+  category: 'palettes',
+  synonyms: ['palette', 'ip', 'fp', 'cp', 'bp', 'look building'],
+  riskLevel: 'high',
+  requiresConfirmation: true,
+  preferredWorkflow: ['eos_workflow_create_look', 'eos_workflow_create_cue_series']
+});
 
 export default paletteTools;

--- a/src/tools/patch/index.ts
+++ b/src/tools/patch/index.ts
@@ -12,7 +12,7 @@ import {
 import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
 import { oscMappings } from '../../services/osc/mappings';
 import { createDryRunResult, resolveSafetyOptions, safetyOptionsSchema } from '../common/safety';
-import { buildToolResult, type ToolDefinition, type ToolExecutionResult } from '../types';
+import { buildToolResult, withToolMetadata, type ToolDefinition, type ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
@@ -918,10 +918,16 @@ export const eosPatchGetAugment3dBeamTool: ToolDefinition<typeof augment3dInputS
   }
 };
 
-const patchTools = [
+const patchTools = withToolMetadata([
   eosPatchGetChannelInfoTool,
   eosPatchGetAugment3dPositionTool,
   eosPatchGetAugment3dBeamTool
-];
+], {
+  category: 'patch',
+  synonyms: ['patch', 'fixture', 'channel setup', 'augment3d', 'adressage'],
+  riskLevel: 'critical',
+  requiresConfirmation: true,
+  preferredWorkflow: 'eos_workflow_autopatch_band'
+});
 
 export default patchTools;

--- a/src/tools/presets/index.ts
+++ b/src/tools/presets/index.ts
@@ -13,7 +13,7 @@ import {
 import { getOscClient } from '../../services/osc/client';
 import type { OscMessageArgument } from '../../services/osc/index';
 import { oscMappings } from '../../services/osc/mappings';
-import type { ToolDefinition, ToolExecutionResult } from '../types';
+import { withToolMetadata, type ToolDefinition, type ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
@@ -654,7 +654,13 @@ export const eosPresetGetInfoTool: ToolDefinition<typeof presetGetInfoInputSchem
   }
 };
 
-export const presetTools = [eosPresetFireTool, eosPresetSelectTool, eosPresetGetInfoTool];
+export const presetTools = withToolMetadata([eosPresetFireTool, eosPresetSelectTool, eosPresetGetInfoTool], {
+  category: 'presets',
+  synonyms: ['preset', 'look', 'preset fire', 'preset select'],
+  riskLevel: 'high',
+  requiresConfirmation: true,
+  preferredWorkflow: ['eos_workflow_create_look', 'eos_workflow_create_cue_series']
+});
 
 export default presetTools;
 

--- a/src/tools/showControl/index.ts
+++ b/src/tools/showControl/index.ts
@@ -5,7 +5,7 @@
 import { z, type ZodRawShape } from 'zod';
 import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
 import { oscMappings } from '../../services/osc/mappings';
-import { buildToolResult, type ToolDefinition, type ToolExecutionResult } from '../types';
+import { buildToolResult, withToolMetadata, type ToolDefinition, type ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
@@ -446,12 +446,18 @@ export const eosSetCueReceiveStringTool: ToolDefinition<typeof setCueReceiveStri
   }
 };
 
-export const showControlTools = [
+export const showControlTools = withToolMetadata([
   eosGetShowNameTool,
   eosGetLiveBlindStateTool,
   eosToggleStagingModeTool,
   eosSetCueSendStringTool,
   eosSetCueReceiveStringTool
-];
+], {
+  category: 'showControl',
+  synonyms: ['show control', 'show name', 'live blind', 'cue string', 'staging mode'],
+  riskLevel: 'critical',
+  requiresConfirmation: true,
+  preferredWorkflow: 'eos_workflow_rehearsal_go'
+});
 
 export default showControlTools;

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -120,6 +120,17 @@ export type ToolMiddleware = (
   next: () => Promise<ToolExecutionResult>
 ) => Promise<ToolExecutionResult>;
 
+export type ToolRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export interface ToolMetadata {
+  annotations?: Record<string, unknown>;
+  category?: string;
+  synonyms?: string[];
+  riskLevel?: ToolRiskLevel;
+  requiresConfirmation?: boolean;
+  preferredWorkflow?: string | string[];
+}
+
 export interface ToolDefinition<Args extends ZodRawShape | undefined = ZodRawShape | undefined> {
   name: string;
   config: {
@@ -129,6 +140,43 @@ export interface ToolDefinition<Args extends ZodRawShape | undefined = ZodRawSha
     outputSchema?: ZodRawShape;
     annotations?: Record<string, unknown>;
   };
+  metadata?: ToolMetadata;
   handler: (args: unknown, extra: unknown) => Promise<ToolExecutionResult>;
   middlewares?: ToolMiddleware[];
+}
+
+function mergeToolMetadata(base: ToolMetadata | undefined, override: ToolMetadata): ToolMetadata {
+  return {
+    ...base,
+    ...override,
+    annotations: {
+      ...(base?.annotations ?? {}),
+      ...(override.annotations ?? {})
+    },
+    synonyms: override.synonyms ?? base?.synonyms,
+    preferredWorkflow: override.preferredWorkflow ?? base?.preferredWorkflow
+  };
+}
+
+export function withToolMetadata<T extends ToolDefinition>(
+  tools: readonly T[],
+  metadata: ToolMetadata
+): T[] {
+  return tools.map((tool) => {
+    const mergedMetadata = mergeToolMetadata(tool.metadata, metadata);
+    const { annotations: metadataAnnotations, ...annotationMetadata } = mergedMetadata;
+
+    return {
+      ...tool,
+      config: {
+        ...tool.config,
+        annotations: {
+          ...(tool.config.annotations ?? {}),
+          ...metadataAnnotations,
+          ...annotationMetadata
+        }
+      },
+      metadata: mergedMetadata
+    };
+  });
 }


### PR DESCRIPTION
### Motivation
- Provide optional discovery metadata for tools (category, synonyms, risk level, confirmation and preferred workflows) so MCP clients and LLM routing can better classify and handle tools. 
- Surface those metadata to documentation, JSON Schema resources and the `/tools` MCP summaries so external clients can consume them programmatically.

### Description
- Add a typed `ToolMetadata` model and optional `metadata` field on `ToolDefinition`, plus a `withToolMetadata` helper to merge family-level metadata into each tool's `config.annotations` and `metadata` (`src/tools/types.ts`).
- Annotate core families (`cues`, `patch`, `commands`, `keys`, `macros`, `dmx`, `palettes`, `presets`, `showControl`) using `withToolMetadata` and add a small `commands/index.ts` re-export to keep imports stable (`src/tools/*/index.ts`, `src/tools/commands/index.ts`, `src/tools/index.ts`).
- Extend the docs generation script to extract and render those metadata into `docs/tools.md` and add a discovery overview section (`scripts/toolDocs.ts`, `docs/tools.md`).
- Include metadata in published JSON Schema resources as `x-eos-metadata` and expose a `metadata` field in the HTTP schema index, and merge metadata into the MCP `registerTool` annotations when registering tools (`src/schemas/index.ts`, `src/server/httpGateway.ts`, `src/server/toolRegistry.ts`).
- Add tests asserting registry and schema exposure of metadata (`src/server/__tests__/toolRegistry.test.ts`, `src/schemas/__tests__/tool_schemas.test.ts`).

### Testing
- Ran `npm run tsc` and the TypeScript build completed successfully (passed). 
- Ran `npm run lint` and `npm run docs:check` and both completed successfully (passed). 
- Ran the focused unit tests for the new coverage with `npm run test:unit -- --runTestsByPath src/server/__tests__/toolRegistry.test.ts src/schemas/__tests__/tool_schemas.test.ts` and they passed. 
- Ran the full unit test suite `npm run test:unit` which exposed unrelated existing failures in OSC payload / snapshot expectations (failures in `showControl`, `effects`, `magicSheets` and `osc_payloads` snapshot tests), these failures are not caused by the metadata plumbing but are kept here for visibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072a552d5c832aa730437ac9f9b964)