### PR TITLE
test: add MCP EOS e2e suite

### DIFF
--- a/docs/testing-e2e.md
+++ b/docs/testing-e2e.md
@@ -1,0 +1,90 @@
+# Tests end-to-end MCP/EOS
+
+Ce projet contient une suite e2e HTTP + OSC dédiée dans `src/server/__tests__/mcp-e2e.test.ts`.
+Elle valide le serveur MCP comme un client réel, sans réutiliser directement les handlers d'outils.
+
+## Architecture du test
+
+La suite démarre trois briques isolées :
+
+1. **Simulateur OSC EOS minimal**
+   - écoute en UDP sur `127.0.0.1` avec un port dynamique ;
+   - décode les paquets OSC en mode `metadata: true` ;
+   - répond aux adresses de base :
+     - `/eos/handshake` ;
+     - `/eos/protocol/select` ;
+     - `/eos/ping` ;
+     - `/eos/get/cue/list` ;
+     - `/eos/dmx/address/select` ;
+     - `/eos/get/*` générique pour les lectures JSON ;
+   - journalise les messages reçus pour vérifier les commandes finales envoyées à EOS.
+2. **Passerelle OSC de test**
+   - fournit l'interface `OscGateway` attendue par le client OSC applicatif ;
+   - envoie réellement les datagrammes OSC au simulateur UDP ;
+   - réémet les réponses du simulateur vers les awaiters du client OSC ;
+   - expose un `OscConnectionStateProvider` connecté pour tester `/health` et les capabilities.
+3. **Serveur HTTP MCP**
+   - démarre avec `createHttpGateway` sur un port dynamique ;
+   - enregistre les outils réels du projet ;
+   - reçoit des appels JSON-RPC sur `/mcp` et des appels REST sur `/tools`.
+
+## Scénarios couverts
+
+Le test `runs a full MCP flow over HTTP against the EOS OSC simulator` couvre :
+
+- initialisation MCP via `/mcp` (`initialize`) ;
+- catalogue REST `/tools` ;
+- catalogue MCP `tools/list` ;
+- connexion EOS (`eos_connect`) avec handshake + sélection de protocole ;
+- capabilities (`eos_capabilities_get`) ;
+- record de cue via workflow (`eos_workflow_create_cue_series`) ;
+- update de cue via workflow (`eos_workflow_update_cue_look`) ;
+- GO (`eos_cue_go`) ;
+- patch fixture (`eos_workflow_patch_fixture`) ;
+- lecture/sélection DMX (`eos_address_select`) ;
+- déclenchement de macro (`eos_macro_fire`) ;
+- fermeture propre de session MCP (`DELETE /mcp`).
+
+## Exécuter la suite
+
+```bash
+npx jest src/server/__tests__/mcp-e2e.test.ts --runInBand
+```
+
+La suite utilise des ports dynamiques et ne nécessite pas de console EOS réelle.
+
+## Ajouter un scénario
+
+Pour ajouter un scénario :
+
+1. Ajoutez au simulateur une réponse réaliste dans `MinimalEosOscSimulator.respond`.
+   - Utilisez l'adresse OSC réelle depuis `oscMappings` quand elle existe.
+   - Renvoyez un objet JSON contenant au minimum `status: 'ok'` pour les endpoints de lecture.
+2. Ajoutez un appel via `callTool(sessionId, '<nom_outil>', args)` dans le test e2e.
+3. Vérifiez à deux niveaux :
+   - la réponse MCP finale (`structuredContent`, `content[0].text`, statut) ;
+   - le flux OSC observé par `simulator.received` quand l'outil doit envoyer une commande.
+4. Gardez les timeouts courts (`500 ms` environ) lorsque le scénario attend une réponse du simulateur.
+5. Préférez les ports dynamiques et ne dépendez jamais de l'environnement local du développeur.
+
+## Brancher une vraie console EOS en laboratoire
+
+Le simulateur est volontairement minimal. Pour un test de laboratoire avec une vraie console :
+
+1. Créez un fichier de test séparé, par exemple `src/server/__tests__/mcp-lab.integration.test.ts`, afin de ne pas rendre la CI dépendante du matériel.
+2. Remplacez `MinimalEosOscSimulator` et `UdpOscTestGateway` par `createOscConnectionGateway` configuré avec :
+   - `host` : adresse IP de la console ;
+   - `udpPort` : port OSC entrant de la console ;
+   - `localPort` : port local autorisé par le réseau labo ;
+   - `tcpPort` : port TCP OSC si le labo le valide.
+3. Protégez le test avec une variable explicite, par exemple `EOS_MCP_LAB_CONSOLE=1`, et ignorez-le sinon.
+4. Dédiez un showfile de laboratoire contenant des cues, macros et adresses DMX non critiques.
+5. Ajoutez un nettoyage après test : retour au black-out/état sûr, reset de ligne de commande, et fermeture des sessions MCP.
+6. Ne faites jamais tourner ces tests contre une console en production ou en répétition sans validation humaine.
+
+## Bonnes pratiques de données de test
+
+- Utilisez des canaux, cues, macros et adresses réservés au test (`Chan 101`, `Cue 1/1`, `Macro 7`, `1/101`).
+- Les réponses JSON doivent ressembler à ce qu'une console EOS renvoie réellement, mais rester compactes.
+- Ajoutez seulement les champs dont le mapper ou l'assertion a besoin.
+- Lorsqu'un outil envoie une commande destructive ou sensible, gardez `require_confirmation: true` dans le scénario e2e pour tester le chemin d'exécution réel.

--- a/src/server/__tests__/mcp-e2e.test.ts
+++ b/src/server/__tests__/mcp-e2e.test.ts
@@ -1,0 +1,557 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { createSocket, type RemoteInfo, type Socket } from 'node:dgram';
+import osc from 'osc';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
+import { createHttpGateway, type HttpGateway } from '../httpGateway';
+import { ToolRegistry } from '../toolRegistry';
+import { toolDefinitions } from '../../tools/index';
+import {
+  OscConnectionStateProvider,
+  type OscDiagnostics,
+  type OscMessage
+} from '../../services/osc/index';
+import {
+  getOscGateway,
+  initializeOscClient,
+  setOscClient,
+  type OscGateway,
+  type OscGatewaySendOptions
+} from '../../services/osc/client';
+import { oscMappings } from '../../services/osc/mappings';
+
+declare const fetch: typeof globalThis.fetch;
+
+type JsonRpcPayload = Record<string, unknown>;
+
+interface ToolCallResult {
+  content?: Array<{ type?: string; text?: string }>;
+  structuredContent?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+class MinimalEosOscSimulator {
+  private socket?: Socket;
+
+  public readonly received: OscMessage[] = [];
+
+  public port = 0;
+
+  public async start(): Promise<void> {
+    this.socket = createSocket('udp4');
+    this.socket.on('message', (buffer, remote) => this.handlePacket(buffer, remote));
+
+    await new Promise<void>((resolve, reject) => {
+      this.socket?.once('error', reject);
+      this.socket?.bind(0, '127.0.0.1', () => {
+        this.socket?.off('error', reject);
+        const address = this.socket?.address();
+        if (!address || typeof address === 'string') {
+          reject(new Error('Port UDP du simulateur EOS introuvable.'));
+          return;
+        }
+        this.port = address.port;
+        resolve();
+      });
+    });
+  }
+
+  public async stop(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      if (!this.socket) {
+        resolve();
+        return;
+      }
+      this.socket.close(() => resolve());
+      this.socket = undefined;
+    });
+  }
+
+  public count(address: string): number {
+    return this.received.filter((message) => message.address === address).length;
+  }
+
+  private handlePacket(buffer: Buffer, remote: RemoteInfo): void {
+    const packet = osc.readPacket(buffer, { metadata: true }) as unknown;
+    const messages = this.extractMessages(packet);
+    messages.forEach((message) => {
+      this.received.push(message);
+      this.respond(message, remote);
+    });
+  }
+
+  private extractMessages(packet: unknown): OscMessage[] {
+    if (!packet || typeof packet !== 'object') {
+      return [];
+    }
+
+    const candidate = packet as OscMessage & { packets?: unknown[] };
+    if (typeof candidate.address === 'string') {
+      return [{ address: candidate.address, args: candidate.args ?? [] }];
+    }
+
+    if (Array.isArray(candidate.packets)) {
+      return candidate.packets.flatMap((entry) => this.extractMessages(entry));
+    }
+
+    return [];
+  }
+
+  private respond(message: OscMessage, remote: RemoteInfo): void {
+    switch (message.address) {
+      case '/eos/ping':
+        this.send('/eos/out/ping', { status: 'ok', echo: this.getFirstArg(message) ?? 'pong' }, remote);
+        return;
+      case '/eos/handshake':
+        this.sendRaw(
+          '/eos/handshake/reply',
+          [
+            { type: 's', value: 'ETCOSC!' },
+            {
+              type: 's',
+              value: JSON.stringify({ version: '3.2.10-sim', protocols: ['json-v1'] })
+            }
+          ],
+          remote
+        );
+        return;
+      case '/eos/protocol/select':
+        this.send('/eos/protocol/select/reply', { status: 'ok', selectedProtocol: this.getFirstArg(message) }, remote);
+        return;
+      case oscMappings.patch.channelInfo:
+        this.send(message.address, {
+          status: 'ok',
+          channel: {
+            channel: 101,
+            label: 'Key Wash',
+            parts: [
+              {
+                part: 1,
+                label: 'Key Wash',
+                manufacturer: 'ETC',
+                model: 'Source Four LED Series 3',
+                dmx_address: '1/101'
+              }
+            ]
+          }
+        }, remote);
+        return;
+      case oscMappings.dmx.addressSelect:
+        this.send(message.address, {
+          status: 'ok',
+          address: '1/101',
+          dmx: 128,
+          level: 50,
+          source: 'simulator'
+        }, remote);
+        return;
+      case oscMappings.dmx.addressDmx:
+      case oscMappings.dmx.addressLevel:
+        this.send(message.address, { status: 'ok', applied: this.parseJsonArg(message) }, remote);
+        return;
+      case oscMappings.macros.info:
+        this.send(message.address, {
+          status: 'ok',
+          macro: { number: 7, label: 'House to half', commands: ['Group 1 At 50 Enter'] }
+        }, remote);
+        return;
+      case oscMappings.cues.list:
+        this.send(message.address, {
+          status: 'ok',
+          cues: [{ cue: 1, cue_number: 1, cuelist: 1, cuelist_number: 1, label: 'E2E 1' }]
+        }, remote);
+        return;
+      default:
+        if (message.address.startsWith('/eos/get/')) {
+          this.send(message.address, { status: 'ok', data: [], count: 0 }, remote);
+        }
+    }
+  }
+
+  private parseJsonArg(message: OscMessage): unknown {
+    const raw = this.getFirstArg(message);
+    if (typeof raw !== 'string') {
+      return raw ?? null;
+    }
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch (_error) {
+      return raw;
+    }
+  }
+
+  private getFirstArg(message: OscMessage): unknown {
+    return message.args?.[0]?.value;
+  }
+
+  private send(address: string, payload: Record<string, unknown>, remote: RemoteInfo): void {
+    this.sendRaw(address, [{ type: 's', value: JSON.stringify(payload) }], remote);
+  }
+
+  private sendRaw(address: string, args: Array<{ type: string; value: unknown }>, remote: RemoteInfo): void {
+    const encoded = Buffer.from(
+      osc.writePacket({ address, args }, { metadata: true }) as Uint8Array
+    );
+    this.socket?.send(encoded, remote.port, remote.address);
+  }
+}
+
+
+class UdpOscTestGateway implements OscGateway {
+  private readonly socket: Socket;
+
+  private readonly listeners = new Set<(message: OscMessage) => void>();
+
+  private readonly startedAt = Date.now();
+
+  private incomingCount = 0;
+
+  private outgoingCount = 0;
+
+  public constructor(
+    private readonly options: { localPort: number; remotePort: number; connectionStateProvider: OscConnectionStateProvider }
+  ) {
+    this.socket = createSocket('udp4');
+    this.socket.on('message', (buffer) => {
+      const packet = osc.readPacket(buffer, { metadata: true }) as unknown;
+      this.extractMessages(packet).forEach((message) => {
+        this.incomingCount += 1;
+        this.listeners.forEach((listener) => listener(message));
+      });
+    });
+  }
+
+  public async start(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.socket.once('error', reject);
+      this.socket.bind(this.options.localPort, '127.0.0.1', () => {
+        this.socket.off('error', reject);
+        const now = Date.now();
+        this.options.connectionStateProvider.setStatus({
+          type: 'udp',
+          state: 'connected',
+          lastHeartbeatAckAt: now,
+          lastHeartbeatSentAt: now,
+          consecutiveFailures: 0
+        });
+        this.options.connectionStateProvider.setStatus({
+          type: 'tcp',
+          state: 'connected',
+          lastHeartbeatAckAt: now,
+          lastHeartbeatSentAt: now,
+          consecutiveFailures: 0
+        });
+        resolve();
+      });
+    });
+  }
+
+  public async send(message: OscMessage, _options?: OscGatewaySendOptions): Promise<void> {
+    const encoded = Buffer.from(osc.writePacket(message, { metadata: true }) as Uint8Array);
+    await new Promise<void>((resolve, reject) => {
+      this.socket.send(encoded, this.options.remotePort, '127.0.0.1', (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        this.outgoingCount += 1;
+        resolve();
+      });
+    });
+  }
+
+  public onMessage(listener: (message: OscMessage) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  public getConnectionStateProvider(): OscConnectionStateProvider {
+    return this.options.connectionStateProvider;
+  }
+
+  public getDiagnostics(): OscDiagnostics {
+    const now = Date.now();
+    return {
+      config: {
+        localAddress: '127.0.0.1',
+        localPort: this.options.localPort,
+        remoteAddress: '127.0.0.1',
+        remotePort: this.options.remotePort
+      },
+      logging: { incoming: false, outgoing: false },
+      stats: {
+        incoming: { count: this.incomingCount, bytes: 0, lastTimestamp: null, lastMessage: null, addresses: [] },
+        outgoing: { count: this.outgoingCount, bytes: 0, lastTimestamp: null, lastMessage: null, addresses: [] }
+      },
+      listeners: { active: this.listeners.size },
+      startedAt: this.startedAt,
+      uptimeMs: now - this.startedAt
+    };
+  }
+
+  public close(): void {
+    this.socket.close();
+    this.listeners.clear();
+  }
+
+  public setToolPreference(): void {
+    // Transport preferences are intentionally accepted but ignored by the isolated UDP e2e gateway.
+  }
+
+  private extractMessages(packet: unknown): OscMessage[] {
+    if (!packet || typeof packet !== 'object') {
+      return [];
+    }
+    const candidate = packet as OscMessage & { packets?: unknown[] };
+    if (typeof candidate.address === 'string') {
+      return [{ address: candidate.address, args: candidate.args ?? [] }];
+    }
+    if (Array.isArray(candidate.packets)) {
+      return candidate.packets.flatMap((entry) => this.extractMessages(entry));
+    }
+    return [];
+  }
+}
+
+async function getAvailableUdpPort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const socket = createSocket('udp4');
+    socket.once('error', reject);
+    socket.bind(0, '127.0.0.1', () => {
+      socket.off('error', reject);
+      const address = socket.address();
+      socket.close(() => {
+        if (!address || typeof address === 'string') {
+          reject(new Error('Port UDP dynamique introuvable.'));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+describe('MCP HTTP e2e with a minimal EOS OSC simulator', () => {
+  jest.setTimeout(20_000);
+
+  let simulator: MinimalEosOscSimulator;
+  let gateway: HttpGateway;
+  let baseUrl: string;
+  let rootServer: McpServer;
+
+  const createRegisteredServer = (): { server: McpServer; registry: ToolRegistry } => {
+    const server = new McpServer({ name: 'eos-mcp-e2e', version: '0.0.0-e2e' });
+    const registry = new ToolRegistry(server);
+    registry.registerMany(toolDefinitions);
+    return { server, registry };
+  };
+
+  const createMcpServer = (): McpServer => createRegisteredServer().server;
+
+  const postMcp = async (
+    body: JsonRpcPayload,
+    sessionId?: string
+  ): Promise<{ response: Response; payload: JsonRpcPayload }> => {
+    const response = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...(sessionId
+          ? {
+              'mcp-session-id': sessionId,
+              'mcp-protocol-version': LATEST_PROTOCOL_VERSION
+            }
+          : {})
+      },
+      body: JSON.stringify(body)
+    });
+    const payload = (await response.json()) as JsonRpcPayload;
+    return { response, payload };
+  };
+
+  const initializeSession = async (): Promise<string> => {
+    const { response, payload } = await postMcp({
+      jsonrpc: '2.0',
+      id: 'init',
+      method: 'initialize',
+      params: {
+        protocolVersion: LATEST_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'jest-e2e-client', version: '0.0.1' }
+      }
+    });
+
+    expect(response.status).toBe(200);
+    expect(payload.error).toBeUndefined();
+    expect((payload.result as { serverInfo?: { name?: string } }).serverInfo?.name).toBe('eos-mcp-e2e');
+
+    const sessionId = response.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+    return sessionId!;
+  };
+
+  const callTool = async (
+    sessionId: string,
+    name: string,
+    args: Record<string, unknown> = {}
+  ): Promise<ToolCallResult> => {
+    const { response, payload } = await postMcp(
+      {
+        jsonrpc: '2.0',
+        id: `call-${name}`,
+        method: 'tools/call',
+        params: { name, arguments: args }
+      },
+      sessionId
+    );
+
+    expect(response.status).toBe(200);
+    expect(payload.error).toBeUndefined();
+    return payload.result as ToolCallResult;
+  };
+
+  beforeAll(async () => {
+    simulator = new MinimalEosOscSimulator();
+    await simulator.start();
+
+    const oscConnectionState = new OscConnectionStateProvider();
+    const oscGateway = new UdpOscTestGateway({
+      localPort: await getAvailableUdpPort(),
+      remotePort: simulator.port,
+      connectionStateProvider: oscConnectionState
+    });
+    await oscGateway.start();
+    initializeOscClient(oscGateway);
+
+    const registeredRoot = createRegisteredServer();
+    rootServer = registeredRoot.server;
+    const rootRegistry = registeredRoot.registry;
+
+    gateway = createHttpGateway(rootRegistry, {
+      port: 0,
+      host: '127.0.0.1',
+      serverFactory: async () => createMcpServer(),
+      oscConnectionProvider: oscConnectionState,
+      oscGateway: { getDiagnostics: () => getOscGateway().getDiagnostics() }
+    });
+
+    await gateway.start();
+    const httpAddress = gateway.getAddress();
+    if (!httpAddress) {
+      throw new Error('Adresse HTTP MCP introuvable.');
+    }
+    baseUrl = `http://127.0.0.1:${httpAddress.port}`;
+  });
+
+  afterAll(async () => {
+    await gateway.stop();
+    await rootServer.close();
+    getOscGateway().close?.();
+    setOscClient(null);
+    await simulator.stop();
+  });
+
+  test('runs a full MCP flow over HTTP against the EOS OSC simulator', async () => {
+    const sessionId = await initializeSession();
+
+    const toolsResponse = await fetch(`${baseUrl}/tools`);
+    expect(toolsResponse.status).toBe(200);
+    const toolsPayload = (await toolsResponse.json()) as { tools?: Array<{ name?: string }> };
+    expect(toolsPayload.tools?.some((tool) => tool.name === 'eos_connect')).toBe(true);
+    expect(toolsPayload.tools?.some((tool) => tool.name === 'eos_workflow_patch_fixture')).toBe(true);
+
+    const listedTools = await postMcp(
+      { jsonrpc: '2.0', id: 'tools-list', method: 'tools/list', params: {} },
+      sessionId
+    );
+    expect((listedTools.payload.result as { tools?: unknown[] }).tools?.length).toBeGreaterThan(10);
+
+    const connect = await callTool(sessionId, 'eos_connect', {
+      handshakeTimeoutMs: 500,
+      protocolTimeoutMs: 500,
+      preferredProtocols: ['json-v1'],
+      transportPreference: 'speed'
+    });
+    expect(connect.structuredContent).toMatchObject({
+      status: 'ok',
+      version: '3.2.10-sim',
+      selectedProtocol: 'json-v1',
+      can_read_queries: true
+    });
+
+    const capabilities = await callTool(sessionId, 'eos_capabilities_get', {});
+    expect(capabilities.structuredContent?.server).toBeDefined();
+    expect(capabilities.structuredContent?.context).toBeDefined();
+
+    const recordCue = await callTool(sessionId, 'eos_workflow_create_cue_series', {
+      base_cuelist_number: 1,
+      start_cue_number: 1,
+      looks: [{ channels: '101', intensity: 50, cue_label: 'E2E 1' }],
+      require_confirmation: true
+    });
+    expect(recordCue.structuredContent?.status).toBe('ok');
+    expect(simulator.received.some((message) => thisIsCommand(message, 'Record Cue 1/1'))).toBe(true);
+
+    const updateCue = await callTool(sessionId, 'eos_workflow_update_cue_look', {
+      cuelist_number: 1,
+      cue_number: 1,
+      channels: '101',
+      intensity_factor: 1,
+      require_confirmation: true
+    });
+    expect(updateCue.structuredContent?.status).toBe('ok');
+    expect(simulator.received.some((message) => thisIsCommand(message, 'Update Cue 1/1'))).toBe(true);
+
+    const go = await callTool(sessionId, 'eos_cue_go', {
+      cuelist_number: 1,
+      cue_number: 1
+    });
+    expect(go.structuredContent).toMatchObject({ action: 'cue_go' });
+    expect(simulator.received.some((message) => thisIsCommand(message, 'Cue 1 CueList 1 Go'))).toBe(true);
+
+    const patchFixture = await callTool(sessionId, 'eos_workflow_patch_fixture', {
+      channel_number: 101,
+      dmx_address: '1/101',
+      device_type: 'Source Four LED Series 3 Lustr X8',
+      label: 'Key Wash',
+      require_confirmation: true
+    });
+    expect(patchFixture.structuredContent?.status).toBe('ok');
+    expect(simulator.received.some((message) => thisIsCommand(message, 'Patch Chan 101 Part 1 Address 1/101'))).toBe(true);
+
+    const dmxRead = await callTool(sessionId, 'eos_address_select', {
+      address_number: '1/101'
+    });
+    expect(dmxRead.structuredContent).toMatchObject({
+      status: 'ok',
+      address: '1/101',
+      osc: expect.objectContaining({ address: oscMappings.dmx.addressSelect })
+    });
+
+    const macro = await callTool(sessionId, 'eos_macro_fire', { macro_number: 7 });
+    expect(macro.structuredContent).toMatchObject({ action: 'macro_fire', macro_number: 7 });
+    expect(simulator.count(oscMappings.macros.fire)).toBeGreaterThanOrEqual(1);
+
+    const closeResponse = await fetch(`${baseUrl}/mcp`, {
+      method: 'DELETE',
+      headers: {
+        'mcp-session-id': sessionId,
+        'mcp-protocol-version': LATEST_PROTOCOL_VERSION
+      }
+    });
+    expect(closeResponse.status).toBe(200);
+  });
+});
+
+function thisIsCommand(message: OscMessage, expectedFragment: string): boolean {
+  const firstArg = message.args?.[0]?.value;
+  return (
+    (message.address === '/eos/newcmd' || message.address === '/eos/cmd') &&
+    typeof firstArg === 'string' &&
+    firstArg.includes(expectedFragment)
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a dedicated end-to-end test that exercises the full MCP HTTP + OSC flow without a real console by simulating an EOS OSC endpoint. 

### Description

- Add a comprehensive E2E test at `src/server/__tests__/mcp-e2e.test.ts` that implements a `MinimalEosOscSimulator` (UDP) and an isolated `UdpOscTestGateway`, registers real tool definitions and drives the server via `createHttpGateway` to exercise `initialize`, `tools/list`, `eos_connect`, `eos_capabilities_get`, cue record/update workflows, `eos_cue_go`, patch fixture, DMX read/select and `eos_macro_fire` flows. 
- The simulator decodes OSC packets (`metadata: true`), records received messages for assertions and returns realistic JSON responses for handshake, protocol selection, ping, cue/macro/patch/dmx endpoints. 
- Provide a test gateway implementing the `OscGateway` contract that relays datagrams to the simulator and exposes an `OscConnectionStateProvider` so the HTTP gateway sees transports as `connected`. 
- Add `docs/testing-e2e.md` explaining how to run/extend the scenarios and how to swap the simulator for a real EOS console in laboratory tests. 

### Testing

- Typecheck: ran `npm run tsc` and it succeeded. 
- Lint: ran `npm run lint` and it succeeded. 
- E2E: ran `npx jest src/server/__tests__/mcp-e2e.test.ts --runInBand` and the new E2E test passed. 
- Unit: ran `npm run test:unit`; several pre-existing unit tests unrelated to these additions failed in this environment (`showControl`, `effects`, `magicSheets`, and `osc_payloads`), so the full unit suite did not pass here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072ccfc278832ab9443e1f4ca0769d)