### PR TITLE
Per-target OSC request queue with family locks and diagnostics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,6 +120,20 @@ flowchart TB
 7. **Envoi et attente de réponse**  
    `src/services/osc/client.ts` envoie via le gateway OSC. Les opérations passent par `RequestQueue` pour contrôler la concurrence et les timeouts. Pour les appels avec réponse, `createResponseAwaiter()` écoute les messages entrants, matche l'adresse de réponse attendue, puis résout avec le payload ou renvoie un statut `timeout` / `error` normalisé.
 
+### Garanties de concurrence OSC
+
+`src/services/osc/requestQueue.ts` applique la concurrence configurée par cible OSC. Une cible est définie par le triplet `targetAddress` / `targetPort` / `transportPreference`; deux consoles ou deux préférences de transport différentes disposent donc de files indépendantes. Les tâches d'une même cible restent FIFO quand la concurrence effective vaut `1`, et les timeouts ou erreurs d'une tâche libèrent la file sans bloquer les suivantes.
+
+`src/services/osc/client.ts` ajoute des verrous par famille pour les actions qui touchent un état partagé EOS :
+
+- `command-line` : `/eos/cmd`, `/eos/newcmd` et `/eos/get/cmd_line` restent exclusifs par cible, car ils modifient ou lisent la ligne de commande partagée de la console.
+- `session-control` : handshake, sélection de protocole et souscription restent exclusifs par cible pendant la négociation de session ou d'abonnement.
+- `show-control` : reset reste exclusif par cible.
+
+Les requêtes JSON documentées, les pings et les messages OSC génériques sans famille sensible peuvent être parallélisés jusqu'à `requestConcurrency` pour une même cible. Ils restent néanmoins isolés des autres cibles par leur file propre et continuent d'utiliser leurs options de routage (`targetAddress`, `targetPort`, `transportPreference`) lors de l'envoi gateway.
+
+Les diagnostics de queue sont exposés par `OscClient.getQueueDiagnostics()` et inclus dans `OscClient.getDiagnostics().queue` quand le gateway fournit déjà des diagnostics. Ils indiquent `pending`, `activeCount`, la `concurrency` configurée et le détail par cible (`targetKey`, longueur pending, tâches actives et familles verrouillées).
+
 8. **Cache et invalidations**  
    Les lectures de ressources peuvent passer par `getResourceCache().fetch()` avec TTL et tags. Les messages OSC entrants sont aussi transmis au cache pour invalider ou actualiser les entrées concernées.
 

--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -909,6 +909,82 @@ describe('OscClient', () => {
     expect(service.maxActiveSends).toBeLessThanOrEqual(2);
   });
 
+  it('segmente la file par cible et preference de transport', async () => {
+    const service = new FakeOscService();
+    service.delayMs = 20;
+    const client = new OscClient(service, { requestConcurrency: 1, queueTimeoutMs: 100 });
+
+    const first = client.sendMessage('/test/target-a-1', [], {
+      targetAddress: '10.0.0.1',
+      targetPort: 3032,
+      transportPreference: 'reliability'
+    });
+    const second = client.sendMessage('/test/target-a-2', [], {
+      targetAddress: '10.0.0.1',
+      targetPort: 3032,
+      transportPreference: 'reliability'
+    });
+    const third = client.sendMessage('/test/target-b', [], {
+      targetAddress: '10.0.0.2',
+      targetPort: 3033,
+      transportPreference: 'speed'
+    });
+
+    await waitFor(() => service.sentMessages.length >= 2);
+
+    expect(service.sentMessages.map((message) => message.address)).toEqual([
+      '/test/target-a-1',
+      '/test/target-b'
+    ]);
+    expect(service.sendOptions[0]).toMatchObject({
+      targetAddress: '10.0.0.1',
+      targetPort: 3032,
+      transportPreference: 'reliability'
+    });
+    expect(service.sendOptions[1]).toMatchObject({
+      targetAddress: '10.0.0.2',
+      targetPort: 3033,
+      transportPreference: 'speed'
+    });
+    expect(client.getQueueDiagnostics()).toMatchObject({
+      pending: 1,
+      activeCount: 2,
+      concurrency: 1
+    });
+
+    await Promise.all([first, second, third]);
+    expect(service.sentMessages.map((message) => message.address)).toEqual([
+      '/test/target-a-1',
+      '/test/target-b',
+      '/test/target-a-2'
+    ]);
+  });
+
+  it('serialise les commandes sensibles par cible meme avec une concurrence superieure a 1', async () => {
+    const service = new FakeOscService();
+    service.delayMs = 20;
+    const client = new OscClient(service, { requestConcurrency: 2, queueTimeoutMs: 100 });
+
+    const first = client.sendCommand('Chan 1');
+    const second = client.sendNewCommand('Chan 2');
+    const read = client.sendMessage('/eos/get/cue');
+
+    await waitFor(() => service.sentMessages.length >= 2);
+
+    expect(service.sentMessages.map((message) => message.address)).toEqual([
+      '/eos/cmd',
+      '/eos/get/cue'
+    ]);
+    expect(client.getQueueDiagnostics().targets[0]?.activeFamilies).toContain('command-line');
+
+    await Promise.all([first, second, read]);
+    expect(service.sentMessages.map((message) => message.address)).toEqual([
+      '/eos/cmd',
+      '/eos/get/cue',
+      '/eos/newcmd'
+    ]);
+  });
+
   it('declenche un timeout si la console ne repond pas avant la limite', async () => {
     const service = new FakeOscService();
     service.delayMs = 50;

--- a/src/services/osc/__tests__/requestQueue.test.ts
+++ b/src/services/osc/__tests__/requestQueue.test.ts
@@ -5,49 +5,156 @@
 import { ErrorCode } from '../../../server/errors';
 import { RequestQueue } from '../requestQueue';
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 describe('RequestQueue', () => {
-  it('limite le nombre de taches actives', async () => {
-    const queue = new RequestQueue({ concurrency: 2 });
+  it('execute les taches FIFO pour une meme cible serialisee', async () => {
+    const queue = new RequestQueue({ concurrency: 1 });
+    const starts: string[] = [];
+    const completions: string[] = [];
+
+    const tasks = ['a', 'b', 'c'].map((name) =>
+      queue.run(name, async () => {
+        starts.push(name);
+        await delay(2);
+        completions.push(name);
+        return name;
+      })
+    );
+
+    await expect(Promise.all(tasks)).resolves.toEqual(['a', 'b', 'c']);
+    expect(starts).toEqual(['a', 'b', 'c']);
+    expect(completions).toEqual(['a', 'b', 'c']);
+  });
+
+  it('declenche un timeout personnalise et libere la tache suivante', async () => {
+    const queue = new RequestQueue({ concurrency: 1 });
+    const starts: string[] = [];
+
+    const timeout = queue.run(
+      'operation lente',
+      async () => {
+        starts.push('slow');
+        await delay(30);
+      },
+      { timeoutMs: 5 }
+    );
+    const next = queue.run('operation suivante', async () => {
+      starts.push('next');
+      return 'done';
+    });
+
+    await expect(timeout).rejects.toMatchObject({ code: ErrorCode.OSC_TIMEOUT });
+    await expect(next).resolves.toBe('done');
+    expect(starts).toEqual(['slow', 'next']);
+  });
+
+  it('propage l erreur d une tache sans bloquer les suivantes', async () => {
+    const queue = new RequestQueue({ concurrency: 1 });
+    const error = new Error('failure');
+    const starts: string[] = [];
+
+    const failing = queue.run('task-error', async () => {
+      starts.push('failing');
+      throw error;
+    });
+    const next = queue.run('task-next', async () => {
+      starts.push('next');
+      return 'ok';
+    });
+
+    await expect(failing).rejects.toBe(error);
+    await expect(next).resolves.toBe('ok');
+    expect(starts).toEqual(['failing', 'next']);
+  });
+
+  it('autorise une concurrence superieure a 1 tout en respectant la limite configuree', async () => {
+    const queue = new RequestQueue({ concurrency: 3 });
     let active = 0;
     let maxActive = 0;
 
-    const tasks = Array.from({ length: 6 }, (_, index) =>
+    const tasks = Array.from({ length: 8 }, (_, index) =>
       queue.run(`task-${index}`, async () => {
         active += 1;
         maxActive = Math.max(maxActive, active);
-        await new Promise<void>((resolve) => setTimeout(resolve, 5));
+        await delay(5);
         active -= 1;
         return index;
       })
     );
 
     const results = await Promise.all(tasks);
-    expect(results).toEqual([0, 1, 2, 3, 4, 5]);
-    expect(maxActive).toBeLessThanOrEqual(2);
+    expect(results).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    expect(maxActive).toBeGreaterThan(1);
+    expect(maxActive).toBeLessThanOrEqual(3);
   });
 
-  it('propage les erreurs des taches', async () => {
+  it('isole la concurrence par cible et expose des diagnostics', async () => {
     const queue = new RequestQueue({ concurrency: 1 });
-    const error = new Error('failure');
+    const starts: string[] = [];
 
-    await expect(
-      queue.run('task-error', async () => {
-        throw error;
-      })
-    ).rejects.toBe(error);
+    const first = queue.run(
+      'target-a',
+      async () => {
+        starts.push('a');
+        await delay(15);
+      },
+      { targetKey: 'console-a' }
+    );
+    const second = queue.run(
+      'target-b',
+      async () => {
+        starts.push('b');
+      },
+      { targetKey: 'console-b' }
+    );
+
+    await delay(1);
+    expect(starts).toEqual(['a', 'b']);
+    expect(queue.getDiagnostics()).toMatchObject({
+      pending: 0,
+      activeCount: 1,
+      concurrency: 1
+    });
+
+    await Promise.all([first, second]);
+    expect(queue.getDiagnostics()).toEqual({
+      pending: 0,
+      activeCount: 0,
+      concurrency: 1,
+      targets: []
+    });
   });
 
-  it('declenche un timeout personnalise', async () => {
-    const queue = new RequestQueue({ concurrency: 1 });
+  it('verrouille une famille sensible sans bloquer les familles paralleles', async () => {
+    const queue = new RequestQueue({ concurrency: 2 });
+    const starts: string[] = [];
 
-    await expect(
-      queue.run(
-        'operation lente',
-        async () => {
-          await new Promise<void>((resolve) => setTimeout(resolve, 20));
-        },
-        { timeoutMs: 5 }
-      )
-    ).rejects.toMatchObject({ code: ErrorCode.OSC_TIMEOUT });
+    const first = queue.run(
+      'cmd-1',
+      async () => {
+        starts.push('cmd-1');
+        await delay(15);
+      },
+      { familyKey: 'command-line' }
+    );
+    const second = queue.run(
+      'cmd-2',
+      async () => {
+        starts.push('cmd-2');
+      },
+      { familyKey: 'command-line' }
+    );
+    const read = queue.run('read', async () => {
+      starts.push('read');
+    });
+
+    await delay(1);
+    expect(starts).toEqual(['cmd-1', 'read']);
+    await first;
+    await Promise.all([second, read]);
+    expect(starts).toEqual(['cmd-1', 'read', 'cmd-2']);
   });
 });

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -23,7 +23,7 @@ import {
   isAppError
 } from '../../server/errors';
 import { getResourceCache } from '../cache/index';
-import { RequestQueue, type RequestQueueRunOptions } from './requestQueue';
+import { RequestQueue, type RequestQueueDiagnostics, type RequestQueueRunOptions } from './requestQueue';
 import { getRequestContext } from '../../server/requestContext';
 import {
   extractJsonPayloadFromMessage,
@@ -240,6 +240,15 @@ interface InternalOscJsonRequestOptions {
 interface SendQueueOptions extends RequestQueueRunOptions {
   operation?: string;
 }
+
+export type OscQueueFamily = 'command-line' | 'session-control' | 'show-control';
+
+export interface OscQueuePolicy {
+  targetKey: string;
+  familyKey?: OscQueueFamily;
+}
+
+export type OscQueueDiagnostics = RequestQueueDiagnostics;
 
 export class OscClient {
   private readonly requestQueue: RequestQueue;
@@ -717,7 +726,14 @@ export class OscClient {
     if (typeof this.gateway.getDiagnostics !== 'function') {
       throw new Error('Le service OSC ne fournit pas de diagnostics.');
     }
-    return this.gateway.getDiagnostics();
+    return {
+      ...this.gateway.getDiagnostics(),
+      queue: this.getQueueDiagnostics()
+    };
+  }
+
+  public getQueueDiagnostics(): OscQueueDiagnostics {
+    return this.requestQueue.getDiagnostics();
   }
 
   public onTransportStatus(listener: (status: TransportStatus) => void): () => void {
@@ -838,15 +854,50 @@ export class OscClient {
       this.gateway.setToolPreference?.(gatewayOptions.toolId, gatewayOptions.transportPreference);
     }
 
+    const queuePolicy = this.buildQueuePolicy(message.address, gatewayOptions);
+
     await this.requestQueue.run(
       operation,
       () => this.gateway.send(message, gatewayOptions),
       {
         timeoutMs,
         timeoutMessage: queueOptions.timeoutMessage,
-        details
+        details,
+        targetKey: queuePolicy.targetKey,
+        familyKey: queueOptions.familyKey ?? queuePolicy.familyKey
       }
     );
+  }
+
+  private buildQueuePolicy(address: string, options: OscGatewaySendOptions): OscQueuePolicy {
+    return {
+      targetKey: this.buildQueueTargetKey(options),
+      ...(this.getSensitiveFamily(address) ? { familyKey: this.getSensitiveFamily(address) } : {})
+    };
+  }
+
+  private buildQueueTargetKey(options: OscGatewaySendOptions): string {
+    return [
+      options.targetAddress ?? 'default-address',
+      typeof options.targetPort === 'number' ? String(options.targetPort) : 'default-port',
+      options.transportPreference ?? 'auto'
+    ].join('|');
+  }
+
+  private getSensitiveFamily(address: string): OscQueueFamily | undefined {
+    if (address === COMMAND_REQUEST || address === NEW_COMMAND_REQUEST || address === COMMAND_LINE_GET_REQUEST) {
+      return 'command-line';
+    }
+
+    if (address === HANDSHAKE_REQUEST || address === PROTOCOL_SELECT_REQUEST || address === SUBSCRIBE_REQUEST) {
+      return 'session-control';
+    }
+
+    if (address === RESET_REQUEST) {
+      return 'show-control';
+    }
+
+    return undefined;
   }
 
   private async dispatchCommand(

--- a/src/services/osc/requestQueue.ts
+++ b/src/services/osc/requestQueue.ts
@@ -12,6 +12,22 @@ export interface RequestQueueRunOptions {
   timeoutMs?: number;
   timeoutMessage?: string;
   details?: Record<string, unknown>;
+  targetKey?: string;
+  familyKey?: string;
+}
+
+export interface RequestQueueTargetDiagnostics {
+  targetKey: string;
+  pending: number;
+  activeCount: number;
+  activeFamilies: string[];
+}
+
+export interface RequestQueueDiagnostics {
+  pending: number;
+  activeCount: number;
+  concurrency: number;
+  targets: RequestQueueTargetDiagnostics[];
 }
 
 interface QueueTask<T> {
@@ -20,6 +36,15 @@ interface QueueTask<T> {
   readonly resolve: (value: T) => void;
   readonly reject: (reason?: unknown) => void;
   readonly options: RequestQueueRunOptions;
+  readonly targetKey: string;
+  readonly familyKey: string | null;
+}
+
+interface TargetQueueState {
+  readonly targetKey: string;
+  readonly pending: QueueTask<unknown>[];
+  readonly activeFamilies: Set<string>;
+  activeCount: number;
 }
 
 function normaliseConcurrency(value: number | undefined): number {
@@ -29,12 +54,19 @@ function normaliseConcurrency(value: number | undefined): number {
   return Math.max(1, Math.trunc(value));
 }
 
+function normaliseKey(value: string | undefined, fallback: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    return fallback;
+  }
+  return value;
+}
+
 export class RequestQueue {
   private readonly concurrency: number;
 
-  private readonly pending: QueueTask<unknown>[] = [];
+  private readonly targets = new Map<string, TargetQueueState>();
 
-  private activeCount = 0;
+  private readonly targetOrder: string[] = [];
 
   constructor(options: RequestQueueOptions = {}) {
     this.concurrency = normaliseConcurrency(options.concurrency);
@@ -46,30 +78,105 @@ export class RequestQueue {
     options: RequestQueueRunOptions = {}
   ): Promise<T> {
     return new Promise<T>((resolve, reject) => {
+      const targetKey = normaliseKey(options.targetKey, 'default');
       const queueTask: QueueTask<T> = {
         operation,
         execute: task,
         resolve,
         reject,
-        options
+        options,
+        targetKey,
+        familyKey: normaliseKey(options.familyKey, '') || null
       };
-      this.pending.push(queueTask as QueueTask<unknown>);
+      this.getTargetState(targetKey).pending.push(queueTask as QueueTask<unknown>);
       this.process();
     });
   }
 
-  private process(): void {
-    while (this.activeCount < this.concurrency) {
-      const next = this.pending.shift();
-      if (!next) {
-        return;
-      }
+  public getDiagnostics(): RequestQueueDiagnostics {
+    const targets = Array.from(this.targets.values()).map((target) => ({
+      targetKey: target.targetKey,
+      pending: target.pending.length,
+      activeCount: target.activeCount,
+      activeFamilies: Array.from(target.activeFamilies).sort()
+    }));
 
-      this.activeCount += 1;
-      void this.execute(next).finally(() => {
-        this.activeCount -= 1;
-        this.process();
-      });
+    return {
+      pending: targets.reduce((total, target) => total + target.pending, 0),
+      activeCount: targets.reduce((total, target) => total + target.activeCount, 0),
+      concurrency: this.concurrency,
+      targets
+    };
+  }
+
+  private getTargetState(targetKey: string): TargetQueueState {
+    const existing = this.targets.get(targetKey);
+    if (existing) {
+      return existing;
+    }
+
+    const created: TargetQueueState = {
+      targetKey,
+      pending: [],
+      activeFamilies: new Set(),
+      activeCount: 0
+    };
+    this.targets.set(targetKey, created);
+    this.targetOrder.push(targetKey);
+    return created;
+  }
+
+  private process(): void {
+    let started = false;
+
+    do {
+      started = false;
+      for (const targetKey of [...this.targetOrder]) {
+        const target = this.targets.get(targetKey);
+        if (!target || target.activeCount >= this.concurrency) {
+          continue;
+        }
+
+        const nextIndex = this.findRunnableTaskIndex(target);
+        if (nextIndex < 0) {
+          this.cleanupTarget(target);
+          continue;
+        }
+
+        const [next] = target.pending.splice(nextIndex, 1);
+        target.activeCount += 1;
+        if (next.familyKey) {
+          target.activeFamilies.add(next.familyKey);
+        }
+        started = true;
+
+        void this.execute(next).finally(() => {
+          target.activeCount -= 1;
+          if (next.familyKey) {
+            target.activeFamilies.delete(next.familyKey);
+          }
+          this.cleanupTarget(target);
+          this.process();
+        });
+      }
+    } while (started);
+  }
+
+  private findRunnableTaskIndex(target: TargetQueueState): number {
+    return target.pending.findIndex((candidate) => (
+      !candidate.familyKey || !target.activeFamilies.has(candidate.familyKey)
+    ));
+  }
+
+  private cleanupTarget(target: TargetQueueState): void {
+    if (target.pending.length > 0 || target.activeCount > 0) {
+      return;
+    }
+
+    this.targets.delete(target.targetKey);
+    const index = this.targetOrder.indexOf(target.targetKey);
+    if (index >= 0) {
+      this.targetOrder.splice(index, 1);
     }
   }
 


### PR DESCRIPTION
### Motivation

- Improve OSC send reliability by allowing independent queues per target (address/port/transport) and by preventing concurrent sensitive operations that could corrupt console state. 
- Provide observability into queue state so callers can see pending/active counts and locked families per target. 

### Description

- Implemented per-target queueing and family locking in `src/services/osc/requestQueue.ts` with `targetKey` / `familyKey`, per-target state, `getDiagnostics()` and richer `RequestQueueDiagnostics` output. 
- Integrated queue policy into `src/services/osc/client.ts` so `OscClient.send()` computes a `targetKey` from `targetAddress`/`targetPort`/`transportPreference` and assigns families for sensitive addresses (`command-line`, `session-control`, `show-control`), and exposed `getQueueDiagnostics()` included in `OscClient.getDiagnostics()`. 
- Added tests `src/services/osc/__tests__/requestQueue.test.ts` to cover FIFO ordering, timeout release, task error propagation, concurrency > 1, per-target isolation and family locks. 
- Added `OscClient` integration tests in `src/services/osc/__tests__/client.test.ts` for target/preference segmentation and serialization of sensitive commands, and updated documentation in `docs/architecture.md` describing guarantees and diagnostics. 

### Testing

- Ran targeted unit tests with `npx jest --runInBand src/services/osc/__tests__/requestQueue.test.ts src/services/osc/__tests__/client.test.ts` and both suites passed. 
- Ran TypeScript build with `npm run tsc` and ESLint with `npm run lint`, both completed successfully. 
- A broader `npm test` run executed the full suite and surfaced unrelated, pre-existing snapshot/payload failures outside the modified queue/client behavior; those failures are not caused by these changes and the focused tests above pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073e9263c8832aa8b6cb8ca8b1b691)