### PR TITLE
Add keyed session context persistence

### DIFF
--- a/src/services/cache/sessionContextStore.ts
+++ b/src/services/cache/sessionContextStore.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+export type SessionContextPersistenceMode = 'memory' | 'file' | 'external';
+
+interface StoredSessionContextEntry<T> {
+  value: T;
+  expiresAt: number;
+  updatedAt: number;
+}
+
+export interface ExternalSessionContextStore<T = unknown> {
+  get(key: string): Promise<StoredSessionContextEntry<T> | null>;
+  set(key: string, entry: StoredSessionContextEntry<T>): Promise<void>;
+  delete(key: string): Promise<void>;
+  listKeys?: () => Promise<string[]>;
+}
+
+export interface SessionContextPersistenceConfig<T = unknown> {
+  mode: SessionContextPersistenceMode;
+  filePath?: string;
+  externalStore?: ExternalSessionContextStore<T>;
+}
+
+const DEFAULT_SESSION_CONTEXT_FILE = join(tmpdir(), 'eos-mcp-session-contexts.json');
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as { code?: unknown }).code === code
+  );
+}
+
+class MemorySessionContextStore<T> {
+  private readonly entries = new Map<string, StoredSessionContextEntry<T>>();
+
+  public async get(key: string): Promise<StoredSessionContextEntry<T> | null> {
+    return this.entries.get(key) ?? null;
+  }
+
+  public async set(key: string, entry: StoredSessionContextEntry<T>): Promise<void> {
+    this.entries.set(key, entry);
+  }
+
+  public async delete(key: string): Promise<void> {
+    this.entries.delete(key);
+  }
+
+  public async listKeys(): Promise<string[]> {
+    return Array.from(this.entries.keys());
+  }
+
+  public clear(): void {
+    this.entries.clear();
+  }
+}
+
+class FileSessionContextStore<T> implements ExternalSessionContextStore<T> {
+  constructor(private readonly filePath: string = DEFAULT_SESSION_CONTEXT_FILE) {}
+
+  public async get(key: string): Promise<StoredSessionContextEntry<T> | null> {
+    const entries = await this.readEntries();
+    return entries[key] ?? null;
+  }
+
+  public async set(key: string, entry: StoredSessionContextEntry<T>): Promise<void> {
+    const entries = await this.readEntries();
+    entries[key] = entry;
+    await this.writeEntries(entries);
+  }
+
+  public async delete(key: string): Promise<void> {
+    const entries = await this.readEntries();
+    delete entries[key];
+    await this.writeEntries(entries);
+  }
+
+  public async listKeys(): Promise<string[]> {
+    return Object.keys(await this.readEntries());
+  }
+
+  private async readEntries(): Promise<Record<string, StoredSessionContextEntry<T>>> {
+    try {
+      const raw = await readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw) as unknown;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return {};
+      }
+      return parsed as Record<string, StoredSessionContextEntry<T>>;
+    } catch (error) {
+      if (isNodeErrorCode(error, 'ENOENT')) {
+        return {};
+      }
+      throw error;
+    }
+  }
+
+  private async writeEntries(entries: Record<string, StoredSessionContextEntry<T>>): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const tempPath = `${this.filePath}.${process.pid}.tmp`;
+    const payload = JSON.stringify(entries, null, 2);
+    await writeFile(tempPath, payload, 'utf8');
+    await rename(tempPath, this.filePath);
+  }
+
+  public async clear(): Promise<void> {
+    try {
+      await unlink(this.filePath);
+    } catch (error) {
+      if (!isNodeErrorCode(error, 'ENOENT')) {
+        throw error;
+      }
+    }
+  }
+}
+
+class SessionContextStore<T> {
+  private readonly memoryStore = new MemorySessionContextStore<T>();
+
+  private mode: SessionContextPersistenceMode = 'memory';
+
+  private fileStore: FileSessionContextStore<T> = new FileSessionContextStore<T>();
+
+  private externalStore: ExternalSessionContextStore<T> | null = null;
+
+  public configure(config: SessionContextPersistenceConfig<T>): void {
+    this.mode = config.mode;
+    if (config.mode === 'file') {
+      this.fileStore = new FileSessionContextStore<T>(config.filePath);
+    }
+    if (config.mode === 'external') {
+      if (!config.externalStore) {
+        throw new Error('Un stockage externe doit etre fourni pour la persistance session externe.');
+      }
+      this.externalStore = config.externalStore;
+    }
+  }
+
+  public getPersistenceMode(): SessionContextPersistenceMode {
+    return this.mode;
+  }
+
+  public async set(key: string, value: T, ttlMs: number): Promise<StoredSessionContextEntry<T>> {
+    const now = Date.now();
+    const entry = {
+      value,
+      expiresAt: now + Math.max(1, ttlMs),
+      updatedAt: now
+    } satisfies StoredSessionContextEntry<T>;
+    await this.activeStore().set(key, entry);
+    return entry;
+  }
+
+  public async get(key: string): Promise<StoredSessionContextEntry<T> | null> {
+    const entry = await this.activeStore().get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt <= Date.now()) {
+      await this.delete(key);
+      return null;
+    }
+    return entry;
+  }
+
+  public async delete(key: string): Promise<void> {
+    await this.activeStore().delete(key);
+  }
+
+  public async cleanupExpired(): Promise<number> {
+    const store = this.activeStore();
+    if (!store.listKeys) {
+      return 0;
+    }
+
+    const now = Date.now();
+    let deleted = 0;
+    for (const key of await store.listKeys()) {
+      const entry = await store.get(key);
+      if (entry && entry.expiresAt <= now) {
+        await store.delete(key);
+        deleted += 1;
+      }
+    }
+    return deleted;
+  }
+
+  public async clearAll(): Promise<void> {
+    const store = this.activeStore();
+    if (store.listKeys) {
+      await Promise.all((await store.listKeys()).map((key) => store.delete(key)));
+      return;
+    }
+    if (this.mode === 'memory') {
+      this.memoryStore.clear();
+    }
+  }
+
+  private activeStore(): ExternalSessionContextStore<T> {
+    if (this.mode === 'file') {
+      return this.fileStore;
+    }
+    if (this.mode === 'external') {
+      if (!this.externalStore) {
+        throw new Error('Le stockage externe des contextes session nest pas configure.');
+      }
+      return this.externalStore;
+    }
+    return this.memoryStore;
+  }
+}
+
+const sharedSessionContextStore = new SessionContextStore<unknown>();
+
+export function getSessionContextStore(): SessionContextStore<unknown> {
+  return sharedSessionContextStore;
+}
+
+export const SESSION_CONTEXT_CLEANUP_RULES = {
+  defaultTtlMs: 10 * 60 * 1000,
+  maxTtlMs: 24 * 60 * 60 * 1000,
+  cleanup: 'Les contextes expires sont supprimes a la lecture et par cleanupExpiredSessionContexts().'
+} as const;

--- a/src/tools/session/__tests__/session.test.ts
+++ b/src/tools/session/__tests__/session.test.ts
@@ -4,7 +4,8 @@
  */
 import {
   clearCurrentUserId,
-  clearSessionContext,
+  clearAllSessionContexts,
+  configureSessionContextPersistence,
   getCurrentUserId,
   sessionGetCurrentUserTool,
   sessionSetCurrentUserTool
@@ -12,9 +13,10 @@ import {
 import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 describe('session tools', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    configureSessionContextPersistence({ mode: 'memory' });
     clearCurrentUserId();
-    clearSessionContext();
+    await clearAllSessionContexts();
   });
 
   it('stocke le numero utilisateur via le tool de configuration', async () => {

--- a/src/tools/session/__tests__/sessionContext.test.ts
+++ b/src/tools/session/__tests__/sessionContext.test.ts
@@ -3,16 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {
-  clearSessionContext,
+  clearAllSessionContexts,
+  cleanupExpiredSessionContexts,
+  configureSessionContextPersistence,
   sessionClearContextTool,
   sessionGetContextTool,
   sessionSetContextTool
 } from '../index';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
 describe('session context tools', () => {
-  beforeEach(() => {
-    clearSessionContext();
+  beforeEach(async () => {
+    configureSessionContextPersistence({ mode: 'memory' });
+    await clearAllSessionContexts();
   });
 
   it('enregistre puis retourne le contexte courant', async () => {
@@ -40,7 +46,7 @@ describe('session context tools', () => {
     });
     expect(setStructuredContent.suggested_next_actions).toBeDefined();
 
-    const getResult = await runTool(sessionGetContextTool, undefined);
+    const getResult = await runTool(sessionGetContextTool, {});
     const getStructured = getStructuredContent(getResult);
 
     expect(getStructured).toBeDefined();
@@ -66,7 +72,7 @@ describe('session context tools', () => {
       await runTool(sessionSetContextTool, { context, ttl_ms: 10 });
       jest.advanceTimersByTime(11);
 
-      const result = await runTool(sessionGetContextTool, undefined);
+      const result = await runTool(sessionGetContextTool, {});
       const structured = getStructuredContent(result);
 
       expect(structured).toBeDefined();
@@ -91,7 +97,7 @@ describe('session context tools', () => {
       }
     });
 
-    const clearResult = await runTool(sessionClearContextTool, undefined);
+    const clearResult = await runTool(sessionClearContextTool, {});
     const clearStructured = getStructuredContent(clearResult);
 
     expect(clearStructured).toBeDefined();
@@ -101,7 +107,7 @@ describe('session context tools', () => {
     expect(clearStructured.context).toBeNull();
     expect(clearStructured.suggested_next_actions).toBeDefined();
 
-    const getResult = await runTool(sessionGetContextTool, undefined);
+    const getResult = await runTool(sessionGetContextTool, {});
     const getStructured = getStructuredContent(getResult);
 
     expect(getStructured).toBeDefined();
@@ -110,4 +116,77 @@ describe('session context tools', () => {
     }
     expect(getStructured.context).toBeNull();
   });
+
+  it('isole deux agents concurrents avec des contextes differents', async () => {
+    const agentAContext = {
+      show: 'Show Agent A',
+      active_cuelist: 1,
+      selected_channels: [1, 2]
+    };
+    const agentBContext = {
+      show: 'Show Agent B',
+      active_cuelist: 2,
+      selected_channels: [11, 12]
+    };
+
+    await Promise.all([
+      runTool(sessionSetContextTool, { agent_id: 'agent-a', context: agentAContext }),
+      runTool(sessionSetContextTool, { agent_id: 'agent-b', context: agentBContext })
+    ]);
+
+    const [agentAResult, agentBResult] = await Promise.all([
+      runTool(sessionGetContextTool, { agent_id: 'agent-a' }),
+      runTool(sessionGetContextTool, { agent_id: 'agent-b' })
+    ]);
+
+    expect(getStructuredContent(agentAResult)).toMatchObject({
+      context: agentAContext,
+      context_identity: { source: 'agent_id', id: 'agent-a' }
+    });
+    expect(getStructuredContent(agentBResult)).toMatchObject({
+      context: agentBContext,
+      context_identity: { source: 'agent_id', id: 'agent-b' }
+    });
+  });
+
+  it('nettoie explicitement les contextes expires', async () => {
+    jest.useFakeTimers();
+    try {
+      await runTool(sessionSetContextTool, {
+        agent_id: 'agent-expire',
+        context: { show: 'Expired' },
+        ttl_ms: 10
+      });
+      jest.advanceTimersByTime(11);
+
+      await expect(cleanupExpiredSessionContexts()).resolves.toBe(1);
+      const result = await runTool(sessionGetContextTool, { agent_id: 'agent-expire' });
+      expect(getStructuredContent(result)).toMatchObject({ context: null });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+
+  it('persiste les contextes en fichier local lorsque configure', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'eos-mcp-session-context-'));
+    const filePath = join(directory, 'contexts.json');
+    try {
+      const context = { show: 'Persisted file context' };
+      configureSessionContextPersistence({ mode: 'file', filePath });
+
+      await runTool(sessionSetContextTool, { mcp_session_id: 'session-file', context });
+      const result = await runTool(sessionGetContextTool, { mcp_session_id: 'session-file' });
+
+      expect(getStructuredContent(result)).toMatchObject({
+        context,
+        persistence: 'file',
+        context_identity: { source: 'mcp_session_id', id: 'session-file' }
+      });
+    } finally {
+      configureSessionContextPersistence({ mode: 'memory' });
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/tools/session/index.ts
+++ b/src/tools/session/index.ts
@@ -3,15 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { z } from 'zod';
-import { createResourceTag, getResourceCache } from '../../services/cache';
+import { getRequestContext } from '../../server/requestContext';
+import {
+  getSessionContextStore,
+  SESSION_CONTEXT_CLEANUP_RULES,
+  type SessionContextPersistenceConfig
+} from '../../services/cache/sessionContextStore';
 import { getOscClient } from '../../services/osc/client';
 import { oscMappings } from '../../services/osc/mappings';
 import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 let currentUserId: number | null = null;
 
-const SESSION_CONTEXT_CACHE_KEY = 'current_context';
-const DEFAULT_CONTEXT_TTL_MS = 10 * 60 * 1000;
+const SESSION_CONTEXT_KEY_PREFIX = 'session_context';
+const DEFAULT_CONTEXT_TTL_MS = SESSION_CONTEXT_CLEANUP_RULES.defaultTtlMs;
 
 const sessionContextSchema = z
   .object({
@@ -50,30 +55,109 @@ export function clearCurrentUserId(): void {
   currentUserId = null;
 }
 
-async function setSessionContext(context: SessionContext, ttlMs = DEFAULT_CONTEXT_TTL_MS): Promise<void> {
-  const cache = getResourceCache();
-  cache.notifyResourceChange('session', SESSION_CONTEXT_CACHE_KEY);
-  await cache.fetch<SessionContext>({
-    resourceType: 'session',
-    key: SESSION_CONTEXT_CACHE_KEY,
-    ttlMs,
-    tags: [createResourceTag('session'), createResourceTag('session', SESSION_CONTEXT_CACHE_KEY)],
-    fetcher: async () => context
-  });
+type SessionContextIdentity = {
+  key: string;
+  source: 'context_id' | 'mcp_session_id' | 'agent_id' | 'user_id' | 'current_user' | 'default';
+  id: string;
+};
+
+interface ContextIdentityInput {
+  context_id?: string;
+  mcp_session_id?: string;
+  agent_id?: string;
+  user_id?: number;
 }
 
-async function getSessionContext(): Promise<SessionContext | null> {
-  const cache = getResourceCache();
-  return cache.fetch<SessionContext | null>({
-    resourceType: 'session',
-    key: SESSION_CONTEXT_CACHE_KEY,
-    tags: [createResourceTag('session'), createResourceTag('session', SESSION_CONTEXT_CACHE_KEY)],
-    fetcher: async () => null
-  });
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
 }
 
-export function clearSessionContext(): void {
-  getResourceCache().notifyResourceChange('session', SESSION_CONTEXT_CACHE_KEY);
+function normaliseContextId(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(Math.trunc(value));
+  }
+  return null;
+}
+
+function buildSessionContextKey(source: SessionContextIdentity['source'], id: string): string {
+  const safeId = id.replace(/[^a-zA-Z0-9_.:-]/g, '_');
+  return `${SESSION_CONTEXT_KEY_PREFIX}:${source}:${safeId}`;
+}
+
+function resolveSessionContextIdentity(
+  args: ContextIdentityInput = {},
+  extra: unknown = undefined
+): SessionContextIdentity {
+  const extraRecord = asRecord(extra);
+  const requestContext = getRequestContext();
+  const candidates: Array<[SessionContextIdentity['source'], unknown]> = [
+    ['context_id', args.context_id],
+    ['mcp_session_id', args.mcp_session_id],
+    ['agent_id', args.agent_id],
+    ['user_id', args.user_id],
+    ['mcp_session_id', extraRecord.mcpSessionId],
+    ['mcp_session_id', extraRecord.sessionId],
+    ['agent_id', extraRecord.agentId],
+    ['user_id', extraRecord.userId],
+    ['mcp_session_id', requestContext?.sessionId],
+    ['user_id', requestContext?.userId],
+    ['current_user', currentUserId]
+  ];
+
+  for (const [source, candidate] of candidates) {
+    const id = normaliseContextId(candidate);
+    if (id) {
+      return { source, id, key: buildSessionContextKey(source, id) };
+    }
+  }
+
+  return { source: 'default', id: 'local', key: buildSessionContextKey('default', 'local') };
+}
+
+export function configureSessionContextPersistence(config: SessionContextPersistenceConfig<SessionContext>): void {
+  getSessionContextStore().configure(config as SessionContextPersistenceConfig<unknown>);
+}
+
+async function setSessionContext(
+  context: SessionContext,
+  ttlMs = DEFAULT_CONTEXT_TTL_MS,
+  identityInput: ContextIdentityInput = {},
+  extra: unknown = undefined
+): Promise<SessionContextIdentity> {
+  const identity = resolveSessionContextIdentity(identityInput, extra);
+  await getSessionContextStore().set(identity.key, context, ttlMs);
+  return identity;
+}
+
+async function getSessionContext(
+  identityInput: ContextIdentityInput = {},
+  extra: unknown = undefined
+): Promise<{ context: SessionContext | null; identity: SessionContextIdentity }> {
+  const identity = resolveSessionContextIdentity(identityInput, extra);
+  const entry = await getSessionContextStore().get(identity.key);
+  return { context: (entry?.value as SessionContext | undefined) ?? null, identity };
+}
+
+export async function clearSessionContext(
+  identityInput: ContextIdentityInput = {},
+  extra: unknown = undefined
+): Promise<void> {
+  const identity = resolveSessionContextIdentity(identityInput, extra);
+  await getSessionContextStore().delete(identity.key);
+}
+
+export async function clearAllSessionContexts(): Promise<void> {
+  await getSessionContextStore().clearAll();
+}
+
+export async function cleanupExpiredSessionContexts(): Promise<number> {
+  return getSessionContextStore().cleanupExpired();
 }
 
 function buildSuggestedNextActions(hasContext: boolean): Array<Record<string, string>> {
@@ -106,9 +190,21 @@ const setCurrentUserInputSchema = {
   user: z.coerce.number().int().min(0, "L'identifiant utilisateur doit etre positif")
 };
 
+const contextIdentityInputSchema = {
+  context_id: z.string().min(1).optional(),
+  mcp_session_id: z.string().min(1).optional(),
+  agent_id: z.string().min(1).optional(),
+  user_id: z.coerce.number().int().min(0).optional()
+};
+
 const setContextInputSchema = {
   context: sessionContextSchema,
-  ttl_ms: z.coerce.number().int().min(1).max(24 * 60 * 60 * 1000).optional()
+  ttl_ms: z.coerce.number().int().min(1).max(SESSION_CONTEXT_CLEANUP_RULES.maxTtlMs).optional(),
+  ...contextIdentityInputSchema
+};
+
+const contextLookupInputSchema = {
+  ...contextIdentityInputSchema
 };
 
 const targetOptionsSchema = {
@@ -170,7 +266,7 @@ export const sessionSetCurrentUserTool: ToolDefinition<typeof setCurrentUserInpu
       ],
       structuredContent: {
         user: options.user,
-        suggested_next_actions: buildSuggestedNextActions(Boolean(await getSessionContext()))
+        suggested_next_actions: buildSuggestedNextActions(Boolean((await getSessionContext({}, args)).context))
       }
     } as ToolExecutionResult;
   }
@@ -203,7 +299,7 @@ export const sessionGetCurrentUserTool: ToolDefinition = {
       ],
       structuredContent: {
         user: user ?? null,
-        suggested_next_actions: buildSuggestedNextActions(Boolean(await getSessionContext()))
+        suggested_next_actions: buildSuggestedNextActions(Boolean((await getSessionContext()).context))
       }
     } as ToolExecutionResult;
   }
@@ -272,22 +368,25 @@ export const sessionSetContextTool: ToolDefinition<typeof setContextInputSchema>
       'Stocke le contexte courant (show, cuelist active, selections canaux/groupes, palettes recentes) avec un TTL configurable.',
     inputSchema: setContextInputSchema
   },
-  handler: async (args) => {
+  handler: async (args, extra) => {
     const schema = z.object(setContextInputSchema).strict();
     const options = schema.parse(args ?? {});
-
-    await setSessionContext(options.context, options.ttl_ms ?? DEFAULT_CONTEXT_TTL_MS);
+    const identity = await setSessionContext(options.context, options.ttl_ms ?? DEFAULT_CONTEXT_TTL_MS, options, extra);
 
     return {
       content: [
         {
           type: 'text',
-          text: 'Contexte courant enregistre'
+          text: `Contexte enregistre pour ${identity.source}:${identity.id}`
         }
       ],
       structuredContent: {
         context: options.context,
+        context_identity: identity,
+        persistence: getSessionContextStore().getPersistenceMode(),
+        expires_in_ms: options.ttl_ms ?? DEFAULT_CONTEXT_TTL_MS,
         ttl_ms: options.ttl_ms ?? DEFAULT_CONTEXT_TTL_MS,
+        cleanup_rules: SESSION_CONTEXT_CLEANUP_RULES,
         suggested_next_actions: buildSuggestedNextActions(true)
       }
     } as ToolExecutionResult;
@@ -303,14 +402,17 @@ export const sessionSetContextTool: ToolDefinition<typeof setContextInputSchema>
  * @example CLI Consultez docs/tools.md#session-get-context pour un exemple CLI.
  * @example OSC Consultez docs/tools.md#session-get-context pour un exemple OSC.
  */
-export const sessionGetContextTool: ToolDefinition = {
+export const sessionGetContextTool: ToolDefinition<typeof contextLookupInputSchema> = {
   name: 'session_get_context',
   config: {
     title: 'Contexte courant',
-    description: 'Renvoie le contexte courant memorise localement.'
+    description: 'Renvoie le contexte courant memorise localement.',
+    inputSchema: contextLookupInputSchema
   },
-  handler: async () => {
-    const context = await getSessionContext();
+  handler: async (args, extra) => {
+    const schema = z.object(contextLookupInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const { context, identity } = await getSessionContext(options, extra);
 
     return {
       content: [
@@ -321,6 +423,9 @@ export const sessionGetContextTool: ToolDefinition = {
       ],
       structuredContent: {
         context,
+        context_identity: identity,
+        persistence: getSessionContextStore().getPersistenceMode(),
+        cleanup_rules: SESSION_CONTEXT_CLEANUP_RULES,
         suggested_next_actions: buildSuggestedNextActions(Boolean(context))
       }
     } as ToolExecutionResult;
@@ -336,14 +441,18 @@ export const sessionGetContextTool: ToolDefinition = {
  * @example CLI Consultez docs/tools.md#session-clear-context pour un exemple CLI.
  * @example OSC Consultez docs/tools.md#session-clear-context pour un exemple OSC.
  */
-export const sessionClearContextTool: ToolDefinition = {
+export const sessionClearContextTool: ToolDefinition<typeof contextLookupInputSchema> = {
   name: 'session_clear_context',
   config: {
     title: 'Effacer contexte courant',
-    description: 'Supprime le contexte courant memorise localement.'
+    description: 'Supprime le contexte courant memorise localement.',
+    inputSchema: contextLookupInputSchema
   },
-  handler: async () => {
-    clearSessionContext();
+  handler: async (args, extra) => {
+    const schema = z.object(contextLookupInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const { identity } = await getSessionContext(options, extra);
+    await clearSessionContext(options, extra);
 
     return {
       content: [
@@ -354,6 +463,9 @@ export const sessionClearContextTool: ToolDefinition = {
       ],
       structuredContent: {
         context: null,
+        context_identity: identity,
+        persistence: getSessionContextStore().getPersistenceMode(),
+        cleanup_rules: SESSION_CONTEXT_CLEANUP_RULES,
         suggested_next_actions: buildSuggestedNextActions(false)
       }
     } as ToolExecutionResult;


### PR DESCRIPTION
### Motivation
- Replace a single global `current_context` with explicit, namespaced session context identities so multiple agents/sessions/users can have isolated contexts.
- Provide configurable persistence (in-memory, local file, or external store) and make context storage durable and pluggable.
- Enforce TTL, expiry and cleanup rules for contexts to avoid stale state and allow explicit cleanup operations.
- Make session tools accept or deduce a context identifier (context_id / mcp_session_id / agent_id / user_id / request context / current user) so callers can target a specific context.

### Description
- Introduced a new lightweight persistence abstraction `src/services/cache/sessionContextStore.ts` implementing `memory`, `file`, and injectable `external` stores and helpers like `cleanupExpired()` and `clearAll()`.
- Replaced the single cache key with resolved context identities via `resolveSessionContextIdentity()` and namespaced keys (`session_context:<source>:<id>`), and added `setSessionContext`, `getSessionContext`, `clearSessionContext`, `clearAllSessionContexts`, and `cleanupExpiredSessionContexts` in `src/tools/session/index.ts`.
- Added `configureSessionContextPersistence()` to configure persistence mode and updated default TTL and cleanup rules via `SESSION_CONTEXT_CLEANUP_RULES`.
- Updated session tools `session_set_context`, `session_get_context`, and `session_clear_context` to accept lookup inputs, return resolved context identity and persistence metadata, and deduce identity from `extra` / request context when omitted; also updated current-user helpers to consult the new context store.
- Added and adjusted tests in `src/tools/session/__tests__/sessionContext.test.ts` and `src/tools/session/__tests__/session.test.ts` to cover concurrent agents, expiry cleanup, and file-backed persistence; default test harness configures the session store to `memory` during tests.

### Testing
- Typecheck: ran `npm run tsc` and it completed successfully.
- Targeted tests: ran `npx jest src/tools/session/__tests__/sessionContext.test.ts src/tools/session/__tests__/session.test.ts --runInBand` and both suites passed (`9` tests total passed).
- Lint: ran `npm run lint` and it completed without errors.
- Full unit test run: ran `npm run test:unit -- --runInBand`; this produced unrelated failures in pre-existing OSC-related tests (`src/tools/showControl`, `src/tools/effects`, `src/tools/magicSheets`, and `src/tools/__tests__/osc_payloads.test.ts`) and is not caused by the session changes (session suites passed in isolation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07449230d4832abec7dc47d4195708)