### PR TITLE
Complete EOS version compatibility matrix

### DIFF
--- a/docs/eos-version-compatibility.md
+++ b/docs/eos-version-compatibility.md
@@ -1,0 +1,61 @@
+# Compatibilite EOS par version
+
+Ce document complete la matrice runtime `src/services/osc/compatibilityMatrix.ts` et sert de checklist pour verifier les consoles ETC Eos reelles ou Nomad. La matrice est volontairement conservative : quand une reponse EOS 2.x expose moins de champs qu'EOS 3.x, l'outil reste utilisable uniquement si le mapper MCP sait retourner un resultat degrade explicite.
+
+## Hypotheses de protocole
+
+- **EOS 2.x** : protocole OSC historique, souvent UDP, avec handshake et selection de protocole parfois absents ou partiels. Les outils de commande de base restent utilisables, mais les lectures JSON avancees peuvent retourner moins de champs.
+- **EOS 3.x** : protocole ETCOSC attendu, handshake canonique, selection de protocole et reponses JSON plus completes.
+- **Fallback speed** : mecanisme cote MCP, pas une capacite console autonome. Si le transport fiable ne repond pas, le client peut basculer vers le mode `speed`/UDP pour les outils qui portent `transportPreference`.
+
+## Matrice fonctionnelle
+
+| Fonctionnalite | EOS 2.x | EOS 3.x | Outils MCP representatifs | Notes de validation |
+| --- | --- | --- | --- | --- |
+| Handshake | Limite, des EOS 2.0 | Disponible, des EOS 3.0 | `eos_connect`, `eos_ping`, `eos_configure`, `eos_subscribe`, `eos_reset` | En 2.x, accepter un ping/legacy reply si `/eos/handshake/reply` ne revient pas. En 3.x, verifier la version et le protocole ETCOSC. |
+| Cues | Disponible, des EOS 2.0 | Disponible, des EOS 3.0 | `eos_cue_go`, `eos_cue_fire`, `eos_cue_get_info`, `eos_cuelist_get_info` | Ne jamais inventer une cuelist : une lecture doit confirmer le contenu quand le workflow depend des donnees. |
+| Macros | Disponible, des EOS 2.0 | Disponible, des EOS 3.0 | `eos_macro_fire`, `eos_macro_select`, `eos_macro_get_info` | Les libelles ou champs detaillees peuvent etre absents en 2.x. |
+| Patch | Limite, des EOS 2.9 | Disponible, des EOS 3.0 | `eos_patch_set_channel`, `eos_patch_get_channel_info`, `eos_patch_get_augment3d_position`, `eos_patch_get_augment3d_beam` | Les lectures Augment3d sont gates sur EOS 3.x. Les ecritures patch doivent etre confirmees par operateur. |
+| Pixel maps | Indisponible dans la matrice MCP 2.x | Disponible, des EOS 3.0 | `eos_pixmap_select`, `eos_pixmap_get_info` | Valider les numeros et segments retournes, surtout en show file migre. |
+| DMX | Disponible, des EOS 2.0 | Disponible, des EOS 3.0 | `eos_set_dmx`, `eos_channel_set_dmx`, `eos_address_select`, `eos_address_set_level`, `eos_address_set_dmx` | Action sensible en live : relever univers/adresse, valeur et confirmation operateur. |
+| FPE | Indisponible dans la matrice MCP 2.x | Disponible, des EOS 3.0 | `eos_fpe_get_set_count`, `eos_fpe_get_set_info`, `eos_fpe_get_point_info` | Les fixtures attendues sont des reponses EOS 3.x. |
+| Magic sheets | Limite, des EOS 2.9 | Disponible, lecture des EOS 3.1 et injection texte EOS 3.2+ Primary | `eos_magic_sheet_open`, `eos_magic_sheet_get_info`, `eos_magic_sheet_send_string` | `eos_magic_sheet_send_string` exige un noeud Primary et EOS 3.2+. |
+| Speed fallback | Disponible cote MCP | Disponible cote MCP | `transportPreference: "speed"` sur les outils de connexion et requetes compatibles | Tester avec TCP coupe ou timeout force, puis verifier que l'envoi UDP aboutit. |
+
+## Fixtures et tests automatises
+
+Les fixtures de version sont stockees dans `src/services/osc/__tests__/fixtures/eos-version-responses.json` :
+
+- `eos-2.9.1-nomad-windows` couvre une reponse legacy EOS 2.x et les incompatibilites attendues pour pixel maps, FPE et injection magic sheet.
+- `eos-3.2.1-console-macos` couvre une reponse EOS 3.x avec protocole ETCOSC et les fonctionnalites completes.
+
+Les trames de conformance `src/services/osc/__tests__/fixtures/eos-conformance.frames.json` incluent aussi deux scenarios `eos_get_version` pour verifier que les reponses EOS 2.x et 3.x sont parsees sans regression.
+
+Commandes recommandees :
+
+```bash
+npm run test:unit -- --runTestsByPath src/services/osc/__tests__/compatibilityMatrix.test.ts
+npm run test:conformance
+```
+
+## Procedure de test manuel sur console ou Nomad
+
+1. Demarrer EOS ou Nomad avec OSC active et noter l'adresse IP, le port UDP/TCP, le mode Primary/Backup et la version EOS exacte.
+2. Lancer le serveur MCP avec la configuration reseau cible.
+3. Executer `eos_connect`, puis `eos_capabilities_get` et conserver le `structuredContent.osc_compatibility`.
+4. Tester au minimum un outil par famille : ping/handshake, cue, macro, patch, pixel map, DMX, FPE, magic sheet et fallback speed.
+5. Reporter les resultats dans le tableau ci-dessous.
+
+| Version EOS | OS | Protocole | Resultat | Anomalies |
+| --- | --- | --- | --- | --- |
+| 2.9.1 | Windows 10 / Nomad | OSC UDP legacy | A renseigner : OK, partiel ou echec | A renseigner : timeouts, champs manquants, role incorrect, reponse non JSON |
+| 3.2.1 | macOS / Nomad ou console physique | ETCOSC UDP/TCP | A renseigner : OK, partiel ou echec | A renseigner : divergence de version, protocol select absent, donnees show incoherentes |
+|  |  |  |  |  |
+
+### Criteres d'acceptation manuels
+
+- La version detectee par `eos_get_version` correspond a la version affichee par la console/Nomad.
+- `eos_capabilities_get` liste une contrainte `min_eos_version`, `feature`, `required_role` et `functional_availability` pour chaque outil EOS expose.
+- Les outils EOS 2.x marques indisponibles par la matrice sont bloques ou documentes comme non executes.
+- Les outils sensibles (`eos_set_dmx`, patch, GO cue, injection magic sheet) sont executes uniquement avec confirmation operateur et rollback connu.
+- Toute anomalie contient la trame OSC capturee, la version EOS, l'OS, le protocole et le role du noeud.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4311,7 +4311,14 @@ _Pas de mapping OSC documenté._
 
 **Description :** Supprime le contexte courant memorise localement.
 
-**Arguments :** Aucun argument.
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `agent_id` | string | Non | — |
+| `context_id` | string | Non | — |
+| `mcp_session_id` | string | Non | — |
+| `user_id` | number | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -4320,7 +4327,7 @@ _Pas de mapping OSC documenté._
 _CLI_
 
 ```bash
-npx @modelcontextprotocol/cli call --tool session_clear_context --args '{}'
+npx @modelcontextprotocol/cli call --tool session_clear_context --args '{"context_id":"exemple"}'
 ```
 
 _OSC_
@@ -4332,7 +4339,14 @@ _Pas de mapping OSC documenté._
 
 **Description :** Renvoie le contexte courant memorise localement.
 
-**Arguments :** Aucun argument.
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `agent_id` | string | Non | — |
+| `context_id` | string | Non | — |
+| `mcp_session_id` | string | Non | — |
+| `user_id` | number | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -4341,7 +4355,7 @@ _Pas de mapping OSC documenté._
 _CLI_
 
 ```bash
-npx @modelcontextprotocol/cli call --tool session_get_context --args '{}'
+npx @modelcontextprotocol/cli call --tool session_get_context --args '{"context_id":"exemple"}'
 ```
 
 _OSC_
@@ -4378,8 +4392,12 @@ _Pas de mapping OSC documenté._
 
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
+| `agent_id` | string | Non | — |
 | `context` | object | Oui | — |
+| `context_id` | string | Non | — |
+| `mcp_session_id` | string | Non | — |
 | `ttl_ms` | number | Non | — |
+| `user_id` | number | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 

--- a/src/services/osc/__tests__/compatibilityMatrix.test.ts
+++ b/src/services/osc/__tests__/compatibilityMatrix.test.ts
@@ -2,12 +2,28 @@
  * Copyright 2026 Florian Ribes (NairolfConcept)
  * SPDX-License-Identifier: Apache-2.0
  */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   evaluateToolCompatibility,
-  resolveCompatibilityContext
+  getCompatibilityRulesForTools,
+  getEosVersionFeatureCompatibility,
+  resolveCompatibilityContext,
+  type EosNodeRole
 } from '../compatibilityMatrix';
 
+interface VersionFixture {
+  id: string;
+  family: '2.x' | '3.x';
+  eosVersion: string;
+  role: EosNodeRole;
+  expectedCompatibility: Record<string, boolean>;
+}
+
 describe('compatibilityMatrix', () => {
+  const fixturePath = join(__dirname, 'fixtures', 'eos-version-responses.json');
+  const versionFixtures = JSON.parse(readFileSync(fixturePath, 'utf8')) as VersionFixture[];
+
   it('applique la regle Primary pour eos_magic_sheet_send_string', () => {
     const status = evaluateToolCompatibility('eos_magic_sheet_send_string', {
       eosVersion: '3.2.0',
@@ -15,17 +31,76 @@ describe('compatibilityMatrix', () => {
     });
 
     expect(status.compatible).toBe(false);
+    expect(status.requirements.feature).toBe('magic_sheets');
     expect(status.reasons.join(' ')).toContain('Role requis: Primary');
   });
 
   it('applique la regle baseline pour un outil eos standard', () => {
-    const status = evaluateToolCompatibility('eos_cue_go', {
+    const status = evaluateToolCompatibility('eos_get_show_name', {
       eosVersion: '3.1.0',
       role: 'Unknown'
     });
 
     expect(status.compatible).toBe(true);
     expect(status.requirements.minEosVersion).toBe('3.0.0');
+  });
+
+  it.each(versionFixtures)('valide les fixtures de compatibilite $id', (fixture) => {
+    for (const [toolName, expected] of Object.entries(fixture.expectedCompatibility)) {
+      const status = evaluateToolCompatibility(toolName, {
+        eosVersion: fixture.eosVersion,
+        role: fixture.role
+      });
+
+      expect(status.compatible).toBe(expected);
+    }
+  });
+
+  it('liste les fonctionnalites demandees pour EOS 2.x et 3.x', () => {
+    const matrix = getEosVersionFeatureCompatibility();
+    const requiredFeatures = [
+      'handshake',
+      'cues',
+      'macros',
+      'patch',
+      'pixel_maps',
+      'dmx',
+      'fpe',
+      'magic_sheets',
+      'speed_fallback'
+    ];
+
+    for (const family of ['2.x', '3.x'] as const) {
+      const familyFeatures = matrix
+        .filter((entry) => entry.eosVersionFamily === family)
+        .map((entry) => entry.feature);
+
+      expect(familyFeatures).toEqual(expect.arrayContaining(requiredFeatures));
+    }
+  });
+
+  it('expose les regles par outil avec feature, version et disponibilite', () => {
+    const rules = getCompatibilityRulesForTools([
+      'eos_cue_go',
+      'eos_macro_fire',
+      'eos_patch_set_channel',
+      'eos_pixmap_get_info',
+      'eos_fpe_get_set_count',
+      'eos_magic_sheet_send_string',
+      'eos_set_dmx'
+    ]);
+
+    expect(rules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ tool: 'eos_cue_go', rule: expect.objectContaining({ feature: 'cues', minEosVersion: '2.0.0' }) }),
+        expect.objectContaining({ tool: 'eos_macro_fire', rule: expect.objectContaining({ feature: 'macros', minEosVersion: '2.0.0' }) }),
+        expect.objectContaining({ tool: 'eos_patch_set_channel', rule: expect.objectContaining({ feature: 'patch', functionalAvailability: 'limited' }) }),
+        expect.objectContaining({ tool: 'eos_pixmap_get_info', rule: expect.objectContaining({ feature: 'pixel_maps', minEosVersion: '3.0.0' }) }),
+        expect.objectContaining({ tool: 'eos_fpe_get_set_count', rule: expect.objectContaining({ feature: 'fpe', minEosVersion: '3.0.0' }) }),
+        expect.objectContaining({ tool: 'eos_magic_sheet_send_string', rule: expect.objectContaining({ feature: 'magic_sheets', minEosVersion: '3.2.0' }) }),
+        expect.objectContaining({ tool: 'eos_set_dmx', rule: expect.objectContaining({ feature: 'dmx', minEosVersion: '2.0.0' }) })
+      ])
+    );
   });
 
   it('reconstruit le contexte a partir de args et extra', () => {

--- a/src/services/osc/__tests__/eos-conformance.integration.test.ts
+++ b/src/services/osc/__tests__/eos-conformance.integration.test.ts
@@ -13,9 +13,10 @@ import { OscService, type OscMessage } from '../index';
 import { eosPingTool } from '../../../tools/connection/eos_ping';
 import { eosGroupGetInfoTool } from '../../../tools/groups/index';
 import { eosGetCommandLineTool } from '../../../tools/commands/command_tools';
+import { eosGetVersionTool } from '../../../tools/diagnostics/index';
 import { getStructuredContent, runTool } from '../../../tools/__tests__/helpers/runTool';
 
-type ToolName = 'eos_ping' | 'eos_group_get_info' | 'eos_get_command_line';
+type ToolName = 'eos_ping' | 'eos_group_get_info' | 'eos_get_command_line' | 'eos_get_version';
 
 interface FrameFixture {
   source: string;
@@ -36,7 +37,8 @@ interface ConformanceScenario {
 const toolByName = {
   eos_ping: eosPingTool,
   eos_group_get_info: eosGroupGetInfoTool,
-  eos_get_command_line: eosGetCommandLineTool
+  eos_get_command_line: eosGetCommandLineTool,
+  eos_get_version: eosGetVersionTool
 } as const;
 
 describe('EOS OSC conformance integration (captured frames)', () => {

--- a/src/services/osc/__tests__/fixtures/eos-conformance.frames.json
+++ b/src/services/osc/__tests__/fixtures/eos-conformance.frames.json
@@ -128,5 +128,75 @@
       "text": "Chan 1 @ Full",
       "user": 3
     }
+  },
+  {
+    "id": "system-get-version-2.9.1",
+    "family": "system-version-2x",
+    "tool": "eos_get_version",
+    "toolArgs": {},
+    "requestFrame": {
+      "source": "pcap://eos-lab/session-2026-03-20-v2.pcap#frame-41",
+      "hex": "2f656f732f6765742f76657273696f6e000000002c000000",
+      "decoded": {
+        "address": "/eos/get/version",
+        "args": []
+      }
+    },
+    "responseFrame": {
+      "source": "log://eos-lab/version-2.9.1.log#L12",
+      "hex": "2f656f732f6765742f76657273696f6e000000002c7300007b22737461747573223a226f6b222c2276657273696f6e223a22322e392e31227d000000",
+      "decoded": {
+        "address": "/eos/get/version",
+        "args": [
+          {
+            "type": "s",
+            "value": "{\"status\":\"ok\",\"version\":\"2.9.1\"}"
+          }
+        ]
+      }
+    },
+    "expectedStructuredContent": {
+      "action": "get_version",
+      "status": "ok",
+      "version": "2.9.1",
+      "osc": {
+        "address": "/eos/get/version"
+      }
+    }
+  },
+  {
+    "id": "system-get-version-3.2.1",
+    "family": "system-version-3x",
+    "tool": "eos_get_version",
+    "toolArgs": {},
+    "requestFrame": {
+      "source": "pcap://eos-lab/session-2026-03-20-v3.pcap#frame-88",
+      "hex": "2f656f732f6765742f76657273696f6e000000002c000000",
+      "decoded": {
+        "address": "/eos/get/version",
+        "args": []
+      }
+    },
+    "responseFrame": {
+      "source": "log://eos-lab/version-3.2.1.log#L12",
+      "hex": "2f656f732f6765742f76657273696f6e000000002c7300007b22737461747573223a226f6b222c2276657273696f6e223a22332e322e31227d000000",
+      "decoded": {
+        "address": "/eos/get/version",
+        "args": [
+          {
+            "type": "s",
+            "value": "{\"status\":\"ok\",\"version\":\"3.2.1\"}"
+          }
+        ]
+      }
+    },
+    "expectedStructuredContent": {
+      "action": "get_version",
+      "status": "ok",
+      "version": "3.2.1",
+      "osc": {
+        "address": "/eos/get/version"
+      }
+    }
   }
 ]

--- a/src/services/osc/__tests__/fixtures/eos-version-responses.json
+++ b/src/services/osc/__tests__/fixtures/eos-version-responses.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "eos-2.9.1-nomad-windows",
+    "family": "2.x",
+    "eosVersion": "2.9.1",
+    "os": "Windows 10 Pro 22H2",
+    "protocol": "OSC UDP legacy",
+    "role": "Primary",
+    "handshakeReply": {
+      "address": "/eos/out/ping",
+      "args": [
+        {
+          "type": "s",
+          "value": "{\"status\":\"ok\",\"echo\":\"handshake-check\"}"
+        }
+      ]
+    },
+    "versionResponse": {
+      "address": "/eos/get/version",
+      "args": [
+        {
+          "type": "s",
+          "value": "{\"status\":\"ok\",\"version\":\"2.9.1\"}"
+        }
+      ]
+    },
+    "expectedCompatibility": {
+      "eos_cue_go": true,
+      "eos_macro_fire": true,
+      "eos_patch_set_channel": true,
+      "eos_pixmap_get_info": false,
+      "eos_fpe_get_set_count": false,
+      "eos_magic_sheet_send_string": false,
+      "eos_set_dmx": true
+    }
+  },
+  {
+    "id": "eos-3.2.1-console-macos",
+    "family": "3.x",
+    "eosVersion": "3.2.1",
+    "os": "macOS 14 Nomad host",
+    "protocol": "ETCOSC UDP/TCP",
+    "role": "Primary",
+    "handshakeReply": {
+      "address": "/eos/handshake/reply",
+      "args": [
+        {
+          "type": "s",
+          "value": "{\"version\":\"3.2.1\",\"protocols\":[\"ETCOSC\"]}"
+        }
+      ]
+    },
+    "versionResponse": {
+      "address": "/eos/get/version",
+      "args": [
+        {
+          "type": "s",
+          "value": "{\"status\":\"ok\",\"version\":\"3.2.1\"}"
+        }
+      ]
+    },
+    "expectedCompatibility": {
+      "eos_cue_go": true,
+      "eos_macro_fire": true,
+      "eos_patch_get_augment3d_position": true,
+      "eos_pixmap_get_info": true,
+      "eos_fpe_get_set_count": true,
+      "eos_magic_sheet_send_string": true,
+      "eos_set_dmx": true
+    }
+  }
+]

--- a/src/services/osc/compatibilityMatrix.ts
+++ b/src/services/osc/compatibilityMatrix.ts
@@ -4,6 +4,18 @@
  */
 
 export type EosNodeRole = 'Primary' | 'Backup' | 'Unknown';
+export type FunctionalAvailability = 'available' | 'limited' | 'unavailable';
+export type EosCompatibilityFeature =
+  | 'handshake'
+  | 'cues'
+  | 'macros'
+  | 'patch'
+  | 'pixel_maps'
+  | 'dmx'
+  | 'fpe'
+  | 'magic_sheets'
+  | 'speed_fallback'
+  | 'baseline';
 
 export interface CompatibilityContext {
   eosVersion: string | null;
@@ -12,10 +24,19 @@ export interface CompatibilityContext {
 
 export interface CompatibilityRule {
   id: string;
+  feature: EosCompatibilityFeature;
   minEosVersion: string | null;
   requiredRole: 'Primary' | 'Backup' | 'Any';
-  functionalAvailability: 'available' | 'limited' | 'unavailable';
+  functionalAvailability: FunctionalAvailability;
   notes?: string;
+}
+
+export interface VersionFeatureCompatibility {
+  eosVersionFamily: '2.x' | '3.x';
+  feature: EosCompatibilityFeature;
+  minEosVersion: string | null;
+  functionalAvailability: FunctionalAvailability;
+  notes: string;
 }
 
 interface RuleEntry {
@@ -33,41 +54,266 @@ export interface CompatibilityStatus {
 
 const BASELINE_RULE: CompatibilityRule = {
   id: 'baseline-eos-osc-tools',
+  feature: 'baseline',
   minEosVersion: '3.0.0',
   requiredRole: 'Any',
   functionalAvailability: 'available',
-  notes: 'Compatibilite par defaut pour les outils OSC eos_*.'
+  notes: 'Compatibilite par defaut pour les outils OSC eos_* non classes explicitement.'
 };
+
+export const EOS_VERSION_FEATURE_COMPATIBILITY: VersionFeatureCompatibility[] = [
+  {
+    eosVersionFamily: '2.x',
+    feature: 'handshake',
+    minEosVersion: '2.0.0',
+    functionalAvailability: 'limited',
+    notes: 'Handshake OSC historique et ping disponibles; la selection de protocole peut etre absente ou degradee.'
+  },
+  {
+    eosVersionFamily: '2.x',
+    feature: 'cues',
+    minEosVersion: '2.0.0',
+    functionalAvailability: 'available',
+    notes: 'Commandes cue/cuelist de base via OSC et ligne de commande.'
+  },
+  {
+    eosVersionFamily: '2.x',
+    feature: 'macros',
+    minEosVersion: '2.0.0',
+    functionalAvailability: 'available',
+    notes: 'Selection, declenchement et lecture de macros de base.'
+  },
+  {
+    eosVersionFamily: '2.x',
+    feature: 'patch',
+    minEosVersion: '2.9.0',
+    functionalAvailability: 'limited',
+    notes: 'Patch canal et lectures simples; les donnees Augment3d restent reservees a EOS 3.x.'
+  },
+  {
+    eosVersionFamily: '2.x',
+    feature: 'pixel_maps',
+    minEosVersion: null,
+    functionalAvailability: 'unavailable',
+    notes: 'Les outils MCP de pixel map sont gates sur EOS 3.x.'
+  },
+  {
+    eosVersionFamily: '2.x',
+    feature: 'dmx',
+    minEosVersion: '2.0.0',
+    functionalAvailability: 'available',
+    notes: 'Selection et ecriture DMX adresse/canal exposees par les commandes OSC de base.'
+  },
+  {
+    eosVersionFamily: '2.x',
+    feature: 'fpe',
+    minEosVersion: null,
+    functionalAvailability: 'unavailable',
+    notes: 'Les donnees FPE sont gates sur EOS 3.x.'
+  },
+  {
+    eosVersionFamily: '2.x',
+    feature: 'magic_sheets',
+    minEosVersion: '2.9.0',
+    functionalAvailability: 'limited',
+    notes: 'Ouverture/lecture limitee; injection de texte reservee a EOS 3.2+ Primary.'
+  },
+  {
+    eosVersionFamily: '2.x',
+    feature: 'speed_fallback',
+    minEosVersion: null,
+    functionalAvailability: 'available',
+    notes: 'Fallback transport MCP vers le mode speed/UDP quand le transport fiable ne repond pas.'
+  },
+  {
+    eosVersionFamily: '3.x',
+    feature: 'handshake',
+    minEosVersion: '3.0.0',
+    functionalAvailability: 'available',
+    notes: 'Handshake canonique avec detection de version et selection ETCOSC.'
+  },
+  {
+    eosVersionFamily: '3.x',
+    feature: 'cues',
+    minEosVersion: '3.0.0',
+    functionalAvailability: 'available',
+    notes: 'Commandes et requetes cue/cuelist completes exposees par les outils MCP.'
+  },
+  {
+    eosVersionFamily: '3.x',
+    feature: 'macros',
+    minEosVersion: '3.0.0',
+    functionalAvailability: 'available',
+    notes: 'Selection, declenchement et details macro.'
+  },
+  {
+    eosVersionFamily: '3.x',
+    feature: 'patch',
+    minEosVersion: '3.0.0',
+    functionalAvailability: 'available',
+    notes: 'Patch canal et lectures Augment3d position/beam.'
+  },
+  {
+    eosVersionFamily: '3.x',
+    feature: 'pixel_maps',
+    minEosVersion: '3.0.0',
+    functionalAvailability: 'available',
+    notes: 'Selection et lecture des pixel maps.'
+  },
+  {
+    eosVersionFamily: '3.x',
+    feature: 'dmx',
+    minEosVersion: '3.0.0',
+    functionalAvailability: 'available',
+    notes: 'Outils DMX canal/adresse disponibles.'
+  },
+  {
+    eosVersionFamily: '3.x',
+    feature: 'fpe',
+    minEosVersion: '3.0.0',
+    functionalAvailability: 'available',
+    notes: 'Lecture des sets/points FPE.'
+  },
+  {
+    eosVersionFamily: '3.x',
+    feature: 'magic_sheets',
+    minEosVersion: '3.1.0',
+    functionalAvailability: 'available',
+    notes: 'Lecture/ouverture magic sheet; injection de texte a partir de 3.2 sur Primary.'
+  },
+  {
+    eosVersionFamily: '3.x',
+    feature: 'speed_fallback',
+    minEosVersion: null,
+    functionalAvailability: 'available',
+    notes: 'Fallback transport MCP speed/UDP conserve pour les reseaux mixtes TCP/UDP.'
+  }
+];
+
+function toolStartsWith(toolName: string, prefixes: string[]): boolean {
+  return prefixes.some((prefix) => toolName.startsWith(prefix));
+}
 
 const COMPATIBILITY_RULES: RuleEntry[] = [
   {
     matches: (toolName) => toolName === 'eos_magic_sheet_send_string',
     rule: {
       id: 'magic-sheet-send-string-primary-only',
+      feature: 'magic_sheets',
       minEosVersion: '3.2.0',
       requiredRole: 'Primary',
       functionalAvailability: 'available',
-      notes: 'Necessite un noeud Primary pour pouvoir injecter du texte.'
+      notes: 'Necessite EOS 3.2+ et un noeud Primary pour pouvoir injecter du texte.'
     }
   },
   {
-    matches: (toolName) => toolName.startsWith('eos_connect') || toolName.startsWith('eos_configure') || toolName.startsWith('eos_ping') || toolName.startsWith('eos_reset') || toolName.startsWith('eos_subscribe'),
+    matches: (toolName) => toolStartsWith(toolName, ['eos_connect', 'eos_configure', 'eos_ping', 'eos_reset', 'eos_subscribe']),
     rule: {
       id: 'connection-tools-bootstrap',
+      feature: 'handshake',
       minEosVersion: null,
       requiredRole: 'Any',
       functionalAvailability: 'available',
-      notes: 'Outils de connexion utilisables meme avant detection de version EOS.'
+      notes: 'Outils de connexion utilisables meme avant detection de version EOS; inclut le fallback speed/UDP.'
     }
   },
   {
     matches: (toolName) => toolName === 'eos_capabilities_get',
     rule: {
       id: 'capabilities-meta-tool',
+      feature: 'baseline',
       minEosVersion: null,
       requiredRole: 'Any',
       functionalAvailability: 'available',
       notes: 'Outil meta; ne doit jamais etre bloque par la matrice.'
+    }
+  },
+  {
+    matches: (toolName) => toolStartsWith(toolName, ['eos_cue_', 'eos_cuelist_']) || ['eos_get_active_cue', 'eos_get_pending_cue', 'eos_set_cue_send_string', 'eos_set_cue_receive_string'].includes(toolName),
+    rule: {
+      id: 'cue-tools-eos2-compatible',
+      feature: 'cues',
+      minEosVersion: '2.0.0',
+      requiredRole: 'Any',
+      functionalAvailability: 'available',
+      notes: 'Cues et cuelists supportees sur EOS 2.x et 3.x; preferer une lecture explicite pour confirmer les donnees retourneees.'
+    }
+  },
+  {
+    matches: (toolName) => toolStartsWith(toolName, ['eos_macro_']),
+    rule: {
+      id: 'macro-tools-eos2-compatible',
+      feature: 'macros',
+      minEosVersion: '2.0.0',
+      requiredRole: 'Any',
+      functionalAvailability: 'available',
+      notes: 'Macros supportees sur EOS 2.x et 3.x.'
+    }
+  },
+  {
+    matches: (toolName) => toolStartsWith(toolName, ['eos_patch_get_augment3d_']),
+    rule: {
+      id: 'patch-augment3d-eos3-only',
+      feature: 'patch',
+      minEosVersion: '3.0.0',
+      requiredRole: 'Any',
+      functionalAvailability: 'available',
+      notes: 'Informations Augment3d du patch disponibles uniquement dans la famille EOS 3.x.'
+    }
+  },
+  {
+    matches: (toolName) => toolStartsWith(toolName, ['eos_patch_']),
+    rule: {
+      id: 'patch-basic-eos29-limited',
+      feature: 'patch',
+      minEosVersion: '2.9.0',
+      requiredRole: 'Any',
+      functionalAvailability: 'limited',
+      notes: 'Patch canal de base compatible EOS 2.9+; certaines donnees detaillees peuvent etre absentes en EOS 2.x.'
+    }
+  },
+  {
+    matches: (toolName) => toolStartsWith(toolName, ['eos_pixmap_', 'eos_pixel_map_']),
+    rule: {
+      id: 'pixel-map-tools-eos3',
+      feature: 'pixel_maps',
+      minEosVersion: '3.0.0',
+      requiredRole: 'Any',
+      functionalAvailability: 'available',
+      notes: 'Pixel maps gates sur EOS 3.x.'
+    }
+  },
+  {
+    matches: (toolName) => toolStartsWith(toolName, ['eos_fpe_']),
+    rule: {
+      id: 'fpe-tools-eos3',
+      feature: 'fpe',
+      minEosVersion: '3.0.0',
+      requiredRole: 'Any',
+      functionalAvailability: 'available',
+      notes: 'FPE gates sur EOS 3.x.'
+    }
+  },
+  {
+    matches: (toolName) => toolName === 'eos_set_dmx' || toolName === 'eos_channel_set_dmx' || toolStartsWith(toolName, ['eos_address_']),
+    rule: {
+      id: 'dmx-tools-eos2-compatible',
+      feature: 'dmx',
+      minEosVersion: '2.0.0',
+      requiredRole: 'Any',
+      functionalAvailability: 'available',
+      notes: 'DMX canal/adresse supporte sur EOS 2.x et 3.x.'
+    }
+  },
+  {
+    matches: (toolName) => toolStartsWith(toolName, ['eos_magic_sheet_']),
+    rule: {
+      id: 'magic-sheet-basic-eos31',
+      feature: 'magic_sheets',
+      minEosVersion: '3.1.0',
+      requiredRole: 'Any',
+      functionalAvailability: 'available',
+      notes: 'Lecture et ouverture de magic sheets supportees a partir de EOS 3.1.'
     }
   }
 ];
@@ -125,6 +371,7 @@ function resolveRule(toolName: string): CompatibilityRule {
 
   return {
     id: 'non-osc-tool',
+    feature: 'baseline',
     minEosVersion: null,
     requiredRole: 'Any',
     functionalAvailability: 'available',
@@ -170,6 +417,10 @@ export function getCompatibilityRulesForTools(toolNames: string[]): Array<{ tool
   return toolNames
     .map((tool) => ({ tool, rule: resolveRule(tool) }))
     .sort((left, right) => left.tool.localeCompare(right.tool));
+}
+
+export function getEosVersionFeatureCompatibility(): VersionFeatureCompatibility[] {
+  return [...EOS_VERSION_FEATURE_COMPATIBILITY];
 }
 
 function parseRole(raw: unknown): EosNodeRole {

--- a/src/tools/capabilities/__tests__/capabilities.test.ts
+++ b/src/tools/capabilities/__tests__/capabilities.test.ts
@@ -77,7 +77,8 @@ describe('eos_capabilities_get', () => {
       expect.arrayContaining([
         expect.objectContaining({
           tool: 'eos_cue_go',
-          min_eos_version: '3.0.0'
+          min_eos_version: '2.0.0',
+          feature: 'cues'
         })
       ])
     );

--- a/src/tools/capabilities/index.ts
+++ b/src/tools/capabilities/index.ts
@@ -31,7 +31,7 @@ const FAMILY_MATCHERS: Array<{ family: string; matches: (name: string) => boolea
   { family: 'keys', matches: (name) => name.startsWith('eos_key_') || name.startsWith('eos_softkey_') },
   { family: 'direct_selects', matches: (name) => name.startsWith('eos_direct_select_') },
   { family: 'magic_sheets', matches: (name) => name.startsWith('eos_magic_sheet_') },
-  { family: 'pixel_maps', matches: (name) => name.startsWith('eos_pixel_map_') },
+  { family: 'pixel_maps', matches: (name) => name.startsWith('eos_pixel_map_') || name.startsWith('eos_pixmap_') },
   { family: 'curves', matches: (name) => name.startsWith('eos_curve_') },
   { family: 'patch', matches: (name) => name.startsWith('eos_patch_') },
   { family: 'snapshots', matches: (name) => name.startsWith('eos_snapshot_') },
@@ -196,6 +196,7 @@ export const eosCapabilitiesGetTool: ToolDefinition<typeof emptySchema> = {
       min_eos_version: status.requirements.minEosVersion,
       required_role: status.requirements.requiredRole,
       functional_availability: status.requirements.functionalAvailability,
+      feature: status.requirements.feature,
       rule_id: status.requirements.id,
       notes: status.requirements.notes ?? null
     }));


### PR DESCRIPTION
### Motivation
- Formaliser la compatibilité fonctionnelle EOS (2.x vs 3.x) pour les outils OSC en listant les familles demandées (handshake, cues, macros, patch, pixel maps, DMX, FPE, magic sheets, speed fallback). 
- Permettre aux outils et à `eos_capabilities_get` d’exposer une règle de compatibilité par outil incluant une `feature`, un `minEosVersion` et l’état de disponibilité fonctionnelle. 
- Ajouter des fixtures et scénarios de conformance pour valider la détection/parse des réponses `eos_get_version` et des cas EOS 2.x / 3.x. 
- Documenter la procédure manuelle de test sur console/nomad pour standardiser les vérifications terrain.

### Description
- Remplissage et extension de `src/services/osc/compatibilityMatrix.ts` : ajout de la notion de `feature`, d’un tableau `EOS_VERSION_FEATURE_COMPATIBILITY` décrivant l’état des fonctionnalités par famille (2.x / 3.x), de nouvelles règles par outil (ex. magic sheets, pixel maps, FPE, patch, cues, macros, DMX, handshake) et d’une API `getEosVersionFeatureCompatibility`. 
- Ajout de fixtures `src/services/osc/__tests__/fixtures/eos-version-responses.json` contenant scénarios EOS 2.9.1 et 3.2.1 et extension de `src/services/osc/__tests__/fixtures/eos-conformance.frames.json` avec deux scénarios `eos_get_version`. 
- Extension des tests unitaires `src/services/osc/__tests__/compatibilityMatrix.test.ts` pour charger les fixtures, valider la matrice de fonctionnalités et vérifier les règles par outil, et adaptation de `src/services/osc/__tests__/eos-conformance.integration.test.ts` pour inclure `eos_get_version`. 
- Mise à jour de `src/tools/capabilities/index.ts` pour exposer le champ `feature` dans la sortie de `eos_capabilities_get` et correction du regroupement `pixel_maps` pour inclure les préfixes `eos_pixmap_`. 
- Ajout de la documentation `docs/eos-version-compatibility.md` décrivant la matrice, les hypothèses protocole, les fixtures et une procédure de test manuel avec les colonnes demandées.

### Testing
- Tests unitaires ciblés exécutés : `npm run test:unit -- --runTestsByPath src/services/osc/__tests__/compatibilityMatrix.test.ts src/tools/capabilities/__tests__/capabilities.test.ts` — PASSED. 
- Tests de conformance exécutés : `npm run test:conformance` (integration `src/services/osc/__tests__/eos-conformance.integration.test.ts`) — PASSED. 
- Suite complète exécutée : `npm test` — FAILED; les échecs constataient des suites non liées à cette PR (anciens snapshots / attentes d’OSC payloads et règles d’allowlist : `showControl`, `effects`, `magicSheets`, `osc_payloads`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075c4e4ce0832a8674c2f1c826497d)