### PR TITLE
Expose OSC JSON diagnostics and propagate them into patch/query tools

### DIFF
--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -172,7 +172,7 @@ describe('OscClient', () => {
 
     public maxActiveSends = 0;
 
-    public async send(message: OscMessage, options?: OscGatewaySendOptions): Promise<void> {
+    public async send(message: OscMessage, options?: OscGatewaySendOptions): Promise<TransportType> {
       this.activeSends += 1;
       this.maxActiveSends = Math.max(this.maxActiveSends, this.activeSends);
       this.sentMessages.push(message);
@@ -181,6 +181,7 @@ describe('OscClient', () => {
         await new Promise<void>((resolve) => setTimeout(resolve, this.delayMs));
       }
       this.activeSends -= 1;
+      return options?.transportPreference === 'reliability' ? 'tcp' : 'udp';
     }
 
     public onMessage(listener: (message: OscMessage) => void): () => void {
@@ -192,6 +193,10 @@ describe('OscClient', () => {
 
     public emit(message: OscMessage): void {
       this.listeners.forEach((listener) => listener(message));
+    }
+
+    public getActiveTransport(_toolId: string): TransportType | null {
+      return 'udp';
     }
   }
 
@@ -619,6 +624,7 @@ describe('OscClient', () => {
 
     const promise = client.ping({ timeoutMs: 5 });
 
+    await Promise.resolve();
     jest.advanceTimersByTime(6);
 
     await expect(promise).resolves.toMatchObject({
@@ -760,6 +766,61 @@ describe('OscClient', () => {
     expect(result.payload).toMatchObject({ address: '/eos/out/get/cue/list' });
   });
 
+
+
+  it('expose les diagnostics enrichis pour timeout, payload texte, payload vide et JSON invalide', async () => {
+    const timeoutService = new FakeOscService();
+    const timeoutClient = new OscClient(timeoutService, { defaultTimeoutMs: 20 });
+
+    const timeoutResult = await timeoutClient.requestJson('/eos/get/cue', { timeoutMs: 20 });
+    expect(timeoutResult).toMatchObject({
+      status: 'timeout',
+      diagnostics: {
+        requestAddress: '/eos/get/cue',
+        responseAddress: null,
+        acceptedResponseAddresses: ['/eos/get/cue'],
+        transportType: 'udp',
+        timeoutMs: 20,
+        payloadType: 'empty',
+        rawPayloadExcerpt: '',
+        handshakeStatus: null,
+        protocolMode: null
+      }
+    });
+
+    const cases = [
+      { name: 'texte', value: 'not json', payloadType: 'plain_text', excerpt: 'not json' },
+      { name: 'vide', value: '', payloadType: 'empty', excerpt: '' },
+      { name: 'json invalide', value: '{"status":', payloadType: 'invalid_json', excerpt: '{"status":' }
+    ] as const;
+
+    for (const testCase of cases) {
+      const service = new FakeOscService();
+      const client = new OscClient(service);
+      const responsePromise = client.requestJson('/eos/get/cue', { timeoutMs: 75 });
+      await waitFor(() => service.sentMessages.length >= 1);
+
+      service.emit({
+        address: '/eos/get/cue',
+        args: [{ type: 's', value: testCase.value }]
+      });
+
+      const result = await responsePromise;
+      expect(result.status).toBe('error');
+      expect(result.diagnostics).toMatchObject({
+        requestAddress: '/eos/get/cue',
+        responseAddress: '/eos/get/cue',
+        acceptedResponseAddresses: ['/eos/get/cue'],
+        transportType: 'udp',
+        timeoutMs: 75,
+        payloadType: testCase.payloadType,
+        rawPayloadExcerpt: testCase.excerpt,
+        handshakeStatus: null,
+        protocolMode: null
+      });
+      expect(result.error).toBeDefined();
+    }
+  });
 
   it('normalise une reponse JSON invalide en erreur diagnostiquee', async () => {
     const service = new FakeOscService();

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -11,7 +11,8 @@ import type {
 } from './index';
 import type {
   ToolTransportPreference,
-  TransportStatus
+  TransportStatus,
+  TransportType
 } from './connectionManager';
 import { createOscGatewayFromEnv } from './gateway';
 import type { OscConnectionStateProvider } from './connectionState';
@@ -67,13 +68,14 @@ export interface OscGatewaySendOptions {
 }
 
 export interface OscGateway {
-  send(message: OscMessage, options?: OscGatewaySendOptions): Promise<void>;
+  send(message: OscMessage, options?: OscGatewaySendOptions): Promise<void | TransportType>;
   onMessage(listener: (message: OscMessage) => void): () => void;
   setLoggingOptions?(options: OscLoggingOptions): OscLoggingState;
   getDiagnostics?(): OscDiagnostics;
   getConnectionStateProvider?(): OscConnectionStateProvider | undefined;
   setToolPreference?(toolId: string, preference: ToolTransportPreference): void;
   getToolPreference?(toolId: string): ToolTransportPreference;
+  getActiveTransport?(toolId: string): TransportType | null;
   removeTool?(toolId: string): void;
   onStatus?(listener: (status: TransportStatus) => void): () => void;
   close?(): void;
@@ -220,8 +222,12 @@ export interface OscJsonDiagnostics {
   requestAddress: string;
   responseAddress: string | null;
   acceptedResponseAddresses: string[];
+  transportType: TransportType | 'unknown';
+  timeoutMs: number;
   payloadType: OscPayloadParseType;
   rawPayloadExcerpt: string;
+  handshakeStatus: StepStatus | null;
+  protocolMode: string | null;
 }
 
 export interface OscJsonResponse {
@@ -255,6 +261,10 @@ export class OscClient {
 
   private readonly requestQueueTimeoutMs: number;
 
+  private lastHandshakeStatus: StepStatus | null = null;
+
+  private lastProtocolMode: string | null = null;
+
   constructor(private readonly gateway: OscGateway, private readonly config: OscClientConfig = {}) {
     this.requestQueue = new RequestQueue({ concurrency: config.requestConcurrency });
     this.requestQueueTimeoutMs =
@@ -270,6 +280,8 @@ export class OscClient {
     try {
       const handshake = await this.performHandshake(options, handshakeTimeout);
       const protocolResult = await this.selectProtocol(handshake, options, protocolTimeout);
+      this.lastHandshakeStatus = 'ok';
+      this.lastProtocolMode = protocolResult.selectedProtocol ?? handshake.mode;
 
       return {
         status: 'ok',
@@ -299,6 +311,8 @@ export class OscClient {
 
       const connectionLostError = this.asAppError(error, ErrorCode.OSC_CONNECTION_LOST);
       if (connectionLostError) {
+        this.lastHandshakeStatus = 'error';
+        this.lastProtocolMode = 'timeout';
         return {
           status: 'error',
           version: null,
@@ -611,12 +625,14 @@ export class OscClient {
       { address: responseAddresses, requestAddress: address }
     );
 
+    let transportType: TransportType | 'unknown' = 'unknown';
+
     try {
-      await this.send(message, targetOptions, {
+      transportType = await this.send(message, targetOptions, {
         operation,
         timeoutMs,
         details: { address, hasPayload }
-      });
+      }) ?? 'unknown';
     } catch (error) {
       awaiter.cancel();
       throw error;
@@ -626,7 +642,7 @@ export class OscClient {
       const response = await awaiter.promise;
 
       const parsed = this.parseOscPayload(response);
-      const diagnostics = this.buildJsonDiagnostics(address, response.address, responseAddresses, parsed);
+      const diagnostics = this.buildJsonDiagnostics(address, response.address, responseAddresses, parsed, timeoutMs, transportType);
 
       if (internalOptions.strictJsonObjectResponse) {
         const formatError = this.validateStrictJsonObjectPayload(parsed);
@@ -667,7 +683,7 @@ export class OscClient {
           status: 'timeout',
           data: null,
           payload: null,
-          diagnostics: this.buildJsonDiagnostics(address, null, responseAddresses, this.emptyPayloadParseResult()),
+          diagnostics: this.buildJsonDiagnostics(address, null, responseAddresses, this.emptyPayloadParseResult(), timeoutMs, transportType),
           error: timeoutError.message
         };
       }
@@ -678,7 +694,7 @@ export class OscClient {
           status: 'error',
           data: null,
           payload: null,
-          diagnostics: this.buildJsonDiagnostics(address, null, responseAddresses, this.emptyPayloadParseResult()),
+          diagnostics: this.buildJsonDiagnostics(address, null, responseAddresses, this.emptyPayloadParseResult(), timeoutMs, transportType),
           error: connectionLostError.message
         };
       }
@@ -830,7 +846,7 @@ export class OscClient {
     message: OscMessage,
     options: TargetOptions,
     queueOptions: SendQueueOptions = {}
-  ): Promise<void> {
+  ): Promise<TransportType | null> {
     const operation = queueOptions.operation ?? `l'envoi du message OSC ${message.address}`;
     const timeoutMs = queueOptions.timeoutMs ?? this.requestQueueTimeoutMs;
     const details = {
@@ -856,9 +872,13 @@ export class OscClient {
 
     const queuePolicy = this.buildQueuePolicy(message.address, gatewayOptions);
 
+    let transportType: TransportType | null = null;
+
     await this.requestQueue.run(
       operation,
-      () => this.gateway.send(message, gatewayOptions),
+      () => this.gateway.send(message, gatewayOptions).then((sentTransport) => {
+        transportType = sentTransport ?? this.gateway.getActiveTransport?.(gatewayOptions.toolId ?? message.address) ?? null;
+      }),
       {
         timeoutMs,
         timeoutMessage: queueOptions.timeoutMessage,
@@ -867,6 +887,8 @@ export class OscClient {
         familyKey: queueOptions.familyKey ?? queuePolicy.familyKey
       }
     );
+
+    return transportType ?? this.gateway.getActiveTransport?.(gatewayOptions.toolId ?? message.address) ?? null;
   }
 
   private buildQueuePolicy(address: string, options: OscGatewaySendOptions): OscQueuePolicy {
@@ -934,6 +956,8 @@ export class OscClient {
   }
 
   private async buildTimeoutConnectResult(options: ConnectOptions, errorMessage: string): Promise<ConnectResult> {
+    this.lastHandshakeStatus = 'timeout';
+    this.lastProtocolMode = 'degraded';
     const timeoutMs = Math.max(1, Math.min(
       options.handshakeTimeoutMs ?? this.config.handshakeTimeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS,
       this.config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS,
@@ -1484,14 +1508,20 @@ export class OscClient {
     requestAddress: string,
     responseAddress: string | null,
     acceptedResponseAddresses: string[],
-    parsed: OscPayloadParseResult
+    parsed: OscPayloadParseResult,
+    timeoutMs: number,
+    transportType: TransportType | 'unknown'
   ): OscJsonDiagnostics {
     return {
       requestAddress,
       responseAddress,
       acceptedResponseAddresses,
+      transportType,
+      timeoutMs,
       payloadType: parsed.type,
-      rawPayloadExcerpt: parsed.rawPayloadExcerpt
+      rawPayloadExcerpt: parsed.rawPayloadExcerpt,
+      handshakeStatus: this.lastHandshakeStatus,
+      protocolMode: this.lastProtocolMode
     };
   }
 

--- a/src/services/osc/gateway.ts
+++ b/src/services/osc/gateway.ts
@@ -148,7 +148,7 @@ export class OscConnectionGateway implements OscGateway {
     this.attachManagerEvents(this.manager);
   }
 
-  public async send(message: OscMessage, options: OscGatewaySendOptions = {}): Promise<void> {
+  public async send(message: OscMessage, options: OscGatewaySendOptions = {}): Promise<TransportType> {
     const toolId = normaliseToolId(options.toolId, message);
     const encoded = this.encodeMessage(message);
     const overrides =
@@ -160,7 +160,7 @@ export class OscConnectionGateway implements OscGateway {
       this.setToolPreference(toolId, options.transportPreference);
     }
 
-    const attemptSend = (): void => {
+    const attemptSend = (): TransportType => {
       const transport = this.manager.send(toolId, encoded, undefined, overrides);
       this.updateStats('outgoing', message, encoded.byteLength);
       if (this.loggingState.outgoing) {
@@ -169,11 +169,11 @@ export class OscConnectionGateway implements OscGateway {
           `[OSC][${transport}] -> ${message.address}`
         );
       }
+      return transport;
     };
 
     try {
-      attemptSend();
-      return;
+      return attemptSend();
     } catch (error) {
       if (this.shouldWaitForTransport(error)) {
         try {
@@ -189,8 +189,7 @@ export class OscConnectionGateway implements OscGateway {
         }
 
         try {
-          attemptSend();
-          return;
+          return attemptSend();
         } catch (retryError) {
           this.logSendError(retryError, message, "Erreur lors de l'envoi OSC", options.correlationId);
           throw retryError instanceof Error
@@ -267,6 +266,10 @@ export class OscConnectionGateway implements OscGateway {
 
   public getToolPreference(toolId: string): ToolTransportPreference {
     return this.manager.getToolPreference(toolId);
+  }
+
+  public getActiveTransport(toolId: string): TransportType | null {
+    return this.manager.getActiveTransport(toolId);
   }
 
   public removeTool(toolId: string): void {

--- a/src/tools/patch/__tests__/patch.test.ts
+++ b/src/tools/patch/__tests__/patch.test.ts
@@ -2,6 +2,7 @@
  * Copyright 2026 Florian Ribes (NairolfConcept)
  * SPDX-License-Identifier: Apache-2.0
  */
+import { getResourceCache } from '../../../services/cache/index';
 import type { OscMessage } from '../../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
@@ -42,6 +43,7 @@ describe('patch tools', () => {
   let service: FakeOscService;
 
   beforeEach(() => {
+    getResourceCache().clearAll();
     service = new FakeOscService();
     const client = new OscClient(service, { defaultTimeoutMs: 50 });
     setOscClient(client);
@@ -49,6 +51,7 @@ describe('patch tools', () => {
 
   afterEach(() => {
     setOscClient(null);
+    getResourceCache().clearAll();
   });
 
 
@@ -271,6 +274,59 @@ describe('patch tools', () => {
         hide_beam: false
       }
     });
+  });
+
+
+  it('propage les diagnostics OSC et le message console pour timeout, payload texte, payload vide et JSON invalide', async () => {
+    const timeoutResult = await runTool(eosPatchGetChannelInfoTool, {
+      channel_number: 301,
+      timeoutMs: 50
+    });
+    const timeoutContent = extractStructuredContent(timeoutResult);
+    expect(timeoutContent).toMatchObject({
+      status: 'timeout',
+      diagnostics: {
+        requestAddress: oscMappings.patch.channelInfo,
+        responseAddress: null,
+        timeoutMs: 50,
+        payloadType: 'empty'
+      }
+    });
+    expect(timeoutResult.content?.[0]?.type).toBe('text');
+    expect(timeoutResult.content?.[0]?.text).toContain('OSC RX activé');
+
+    const cases = [
+      { channel: 302, value: 'not json', payloadType: 'plain_text' },
+      { channel: 303, value: '', payloadType: 'empty' },
+      { channel: 304, value: '{"status":', payloadType: 'invalid_json' }
+    ] as const;
+
+    for (const testCase of cases) {
+      const promise = runTool(eosPatchGetChannelInfoTool, {
+        channel_number: testCase.channel,
+        timeoutMs: 50
+      });
+
+      queueMicrotask(() => {
+        service.emit({
+          address: oscMappings.patch.channelInfo,
+          args: [{ type: 's', value: testCase.value }]
+        });
+      });
+
+      const result = await promise;
+      const structuredContent = extractStructuredContent(result);
+      expect(structuredContent).toMatchObject({
+        status: 'error',
+        diagnostics: {
+          requestAddress: oscMappings.patch.channelInfo,
+          responseAddress: oscMappings.patch.channelInfo,
+          timeoutMs: 50,
+          payloadType: testCase.payloadType
+        }
+      });
+      expect(result.content?.[0]?.text).toContain('ports UDP 8000/8001 ou TCP 3032 cohérents');
+    }
   });
 
   it('valide les numeros de canal et de partie', async () => {

--- a/src/tools/patch/index.ts
+++ b/src/tools/patch/index.ts
@@ -180,6 +180,22 @@ function annotate(osc: string): Record<string, unknown> {
   };
 }
 
+const OSC_CONSOLE_CHECK_MESSAGE = 'Vérifiez côté console: OSC RX activé, OSC TX activé, IP TX vers le serveur MCP, ports UDP 8000/8001 ou TCP 3032 cohérents.';
+
+function shouldExposeOscDiagnostics(response: OscJsonResponse): boolean {
+  return response.status === 'timeout' || response.status === 'error';
+}
+
+function appendConsoleCheck(text: string, response: OscJsonResponse): string {
+  return shouldExposeOscDiagnostics(response) ? `${text} ${OSC_CONSOLE_CHECK_MESSAGE}` : text;
+}
+
+function withOscDiagnostics(response: OscJsonResponse): Record<string, unknown> {
+  return shouldExposeOscDiagnostics(response) && response.diagnostics
+    ? { diagnostics: response.diagnostics }
+    : {};
+}
+
 function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {
   return buildToolResult({
     text,
@@ -735,8 +751,9 @@ export const eosPatchGetChannelInfoTool: ToolDefinition<typeof channelInfoInputS
             ? `Informations recues pour le canal ${validatedChannel.channel_number}.`
             : `Lecture des informations du canal ${validatedChannel.channel_number} terminee avec le statut ${response.status}.`;
 
-        return createResult(baseText, {
+        return createResult(appendConsoleCheck(baseText, response), {
           status: response.status,
+          ...withOscDiagnostics(response),
           channel: validatedChannel,
           osc: {
             address: oscMappings.patch.channelInfo,
@@ -820,8 +837,9 @@ export const eosPatchGetAugment3dPositionTool: ToolDefinition<typeof augment3dIn
             ? `Position Augment3d recue pour le canal ${validatedPosition.channel_number} partie ${validatedPosition.part_number}.`
             : `Lecture de la position Augment3d du canal ${validatedPosition.channel_number} partie ${validatedPosition.part_number} terminee avec le statut ${response.status}.`;
 
-        return createResult(baseText, {
+        return createResult(appendConsoleCheck(baseText, response), {
           status: response.status,
+          ...withOscDiagnostics(response),
           augment3d: validatedPosition,
           osc: {
             address: oscMappings.patch.augment3dPosition,
@@ -905,8 +923,9 @@ export const eosPatchGetAugment3dBeamTool: ToolDefinition<typeof augment3dInputS
             ? `Faisceau Augment3d recu pour le canal ${validatedBeam.channel_number} partie ${validatedBeam.part_number}.`
             : `Lecture du faisceau Augment3d du canal ${validatedBeam.channel_number} partie ${validatedBeam.part_number} terminee avec le statut ${response.status}.`;
 
-        return createResult(baseText, {
+        return createResult(appendConsoleCheck(baseText, response), {
           status: response.status,
+          ...withOscDiagnostics(response),
           augment3d: validatedBeam,
           osc: {
             address: oscMappings.patch.augment3dBeam,

--- a/src/tools/queries/__tests__/queries.test.ts
+++ b/src/tools/queries/__tests__/queries.test.ts
@@ -262,6 +262,58 @@ describe('query tools', () => {
     });
   });
 
+
+  it('propage les diagnostics OSC et le message console pour timeout, payload texte, payload vide et JSON invalide', async () => {
+    const timeoutResult = await runTool(eosGetCountTool, { target_type: 'group', timeoutMs: 50 });
+    const timeoutContent = getStructuredContent(timeoutResult);
+    expect(timeoutContent).toMatchObject({
+      action: 'get_count',
+      status: 'timeout',
+      target_type: 'group',
+      diagnostics: {
+        requestAddress: oscMappings.queries.group.count,
+        responseAddress: null,
+        timeoutMs: 50,
+        payloadType: 'empty'
+      }
+    });
+    expect(timeoutResult.content?.[0]?.type).toBe('text');
+    expect(timeoutResult.content?.[0]?.text).toContain('OSC RX activé');
+
+    const cases = [
+      { target: 'macro', value: 'not json', payloadType: 'plain_text' },
+      { target: 'preset', value: '', payloadType: 'empty' },
+      { target: 'fx', value: '{"status":', payloadType: 'invalid_json' }
+    ] as const;
+
+    for (const testCase of cases) {
+      const mapping = oscMappings.queries[testCase.target];
+      const promise = runTool(eosGetListAllTool, { target_type: testCase.target, timeoutMs: 50 });
+
+      queueMicrotask(() => {
+        service.emit({
+          address: mapping.list,
+          args: [{ type: 's', value: testCase.value }]
+        });
+      });
+
+      const result = await promise;
+      const structuredContent = getStructuredContent(result);
+      expect(structuredContent).toMatchObject({
+        action: 'list_all',
+        status: 'error',
+        target_type: testCase.target,
+        diagnostics: {
+          requestAddress: mapping.list,
+          responseAddress: mapping.list,
+          timeoutMs: 50,
+          payloadType: testCase.payloadType
+        }
+      });
+      expect(result.content?.[0]?.text).toContain('ports UDP 8000/8001 ou TCP 3032 cohérents');
+    }
+  });
+
   it('retourne un structuredContent timeout quand aucune reponse OSC narrive', async () => {
     const result = await runTool(eosGetCountTool, { target_type: 'group', timeoutMs: 50 });
     const structuredContent = getStructuredContent(result);

--- a/src/tools/queries/index.ts
+++ b/src/tools/queries/index.ts
@@ -280,9 +280,10 @@ export const eosGetCountTool: ToolDefinition<typeof countInputSchema> = {
             ? `Nombre de ${config.label}: ${count}.`
             : `Lecture du compte des ${config.label} terminee avec le statut ${response.status}.`;
 
-        return createResult(baseText, {
+        return createResult(appendConsoleCheck(baseText, response), {
           action: 'get_count',
           status: response.status,
+          ...withOscDiagnostics(response),
           target_type: config.key,
           count,
           data: response.data,
@@ -353,9 +354,10 @@ export const eosGetListAllTool: ToolDefinition<typeof listInputSchema> = {
             ? `Elements ${config.label}: ${items.length}.`
             : `Lecture de la liste des ${config.label} terminee avec le statut ${response.status}.`;
 
-        return createResult(baseText, {
+        return createResult(appendConsoleCheck(baseText, response), {
           action: 'list_all',
           status: response.status,
+          ...withOscDiagnostics(response),
           target_type: config.key,
           items,
           data: response.data,
@@ -385,6 +387,22 @@ function annotate(mode: 'count' | 'list'): Record<string, unknown> {
       osc: Object.fromEntries(mappingEntries)
     }
   };
+}
+
+const OSC_CONSOLE_CHECK_MESSAGE = 'Vérifiez côté console: OSC RX activé, OSC TX activé, IP TX vers le serveur MCP, ports UDP 8000/8001 ou TCP 3032 cohérents.';
+
+function shouldExposeOscDiagnostics(response: OscJsonResponse): boolean {
+  return response.status === 'timeout' || response.status === 'error';
+}
+
+function appendConsoleCheck(text: string, response: OscJsonResponse): string {
+  return shouldExposeOscDiagnostics(response) ? `${text} ${OSC_CONSOLE_CHECK_MESSAGE}` : text;
+}
+
+function withOscDiagnostics(response: OscJsonResponse): Record<string, unknown> {
+  return shouldExposeOscDiagnostics(response) && response.diagnostics
+    ? { diagnostics: response.diagnostics }
+    : {};
 }
 
 function createResult(text: string, structuredContent: Record<string, unknown>): ToolExecutionResult {


### PR DESCRIPTION
### Motivation
- Rendre plus verbaux et exploitables les diagnostics des réponses JSON OSC pour faciliter le diagnostic réseau/protocole depuis les outils. 
- Permettre aux outils `patch` et `queries` d’afficher ces diagnostics dans le `structuredContent` quand la réponse est `timeout` ou `error`, et donner à l’utilisateur un message explicite de vérification côté console.
- Couvrir les cas d’erreur fréquents (timeout, payload texte, payload vide, JSON invalide) avec des tests unitaires ciblés.

### Description
- Enrichi la forme des diagnostics JSON en ajoutant `transportType`, `timeoutMs`, `handshakeStatus` et `protocolMode` et en gardant l’adresse requise/réponse/acceptées via `OscJsonDiagnostics` (fichier `src/services/osc/client.ts`).
- Capturé le transport réellement utilisé lors d’un envoi OSC en adaptant la signature de `OscGateway.send` pour retourner le `TransportType` et en exposant `getActiveTransport` depuis la gateway (`src/services/osc/gateway.ts`), puis propagé cette info dans `OscClient.send`/`requestJsonInternal`.
- Mémorisé le statut du handshake et le mode de protocole dans `OscClient` pour les inclure dans les diagnostics (stockage `lastHandshakeStatus` / `lastProtocolMode`).
- Mis à jour la construction des diagnostics via `buildJsonDiagnostics(...)` pour inclure transport/timeout/handshake/mode et retourné ces diagnostics dans les réponses `OscJsonResponse` (fichier `src/services/osc/client.ts`).
- Propagé les diagnostics dans le `structuredContent` des outils `patch` (`src/tools/patch/index.ts`) et `queries` (`src/tools/queries/index.ts`) lorsque `status` vaut `timeout` ou `error`, et ajouté un message utilisateur explicite à afficher (console-check) indiquant les vérifications à faire côté console OSC RX/TX/IP/ports.
- Ajouté tests unitaires couvrant `timeout`, payload texte, payload vide et JSON invalide dans `src/services/osc/__tests__/client.test.ts`, `src/tools/patch/__tests__/patch.test.ts` et `src/tools/queries/__tests__/queries.test.ts` et ajusté quelques helpers/tests pour tenir compte du nouveau comportement.
- Ajustements divers pour la gestion du cache dans les tests (`getResourceCache().clearAll()`) et synchronisation minime des timers dans les tests existants.

### Testing
- Type-check: `npx tsc --noEmit` — success.
- Unit tests (targeted suites): `npx jest --passWithNoTests src/services/osc/__tests__/client.test.ts src/tools/patch/__tests__/patch.test.ts src/tools/queries/__tests__/queries.test.ts --runInBand` — all specified tests passed.
- Lint: `npm run lint` — success.

All automated checks described above completed successfully for the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0773a53a30832ab9bd40bbc8dbd196)