### PR TITLE
Guard JSON reads by OSC runtime capability

### DIFF
--- a/docs/llm-agent-guide.md
+++ b/docs/llm-agent-guide.md
@@ -7,7 +7,8 @@ Ce guide décrit le comportement attendu d'un assistant LLM qui pilote une conso
 1. **Toujours commencer par `eos_capabilities_get`.**
    - Lire `structuredContent.context` avant de proposer une action métier.
    - Vérifier l'état OSC, l'utilisateur Eos, le mode Live/Blind, les limitations de lecture et les garde-fous de sécurité disponibles.
-   - Si `structuredContent.context.osc_limitations.can_read_queries=false`, ne jamais inventer le patch, la cuelist, les cues ou l'état du show : les présenter comme inconnus et demander une lecture réussie ou une confirmation opérateur.
+   - Si `structuredContent.context.osc_limitations.can_read_queries=false` ou `canReadJsonQueries=false`, ne jamais inventer le patch, la cuelist, les cues ou l'état du show : les présenter comme inconnus et demander une lecture réussie ou une confirmation opérateur.
+   - En mode legacy/non confirmé, les outils de lecture peuvent retourner `unsupported_transport_mode` ou `read_capability_unconfirmed` au lieu d'attendre un timeout. Dans ce cas, demander explicitement une reconfiguration OSC qui confirme les requêtes JSON, ou une source showfile fournie par l'opérateur; ne pas reconstruire ou deviner le patch depuis des suppositions.
 2. **Privilégier les workflows `eos_workflow_*`.**
    - Utiliser un workflow haut niveau dès qu'il existe pour l'intention utilisateur : cue series, update cue, look, patch fixture, autopatch, rehearsal GO, groupes/palettes, effet.
    - Réserver les outils bas niveau (`eos_cue_*`, `eos_patch_*`, `eos_command`, `eos_new_command`, `*_fire`) aux cas où aucun workflow ne couvre l'action ou lorsque l'intégration sait exactement quelle commande Eos envoyer.
@@ -488,7 +489,7 @@ Les outils MCP renvoient généralement un résumé texte et des données struct
 
 - Source principale pour le raisonnement de l'agent.
 - Peut contenir `context`, `steps`, `applied_defaults`, `command_log`, données métier lues depuis Eos, et champs de sécurité.
-- Pour `eos_capabilities_get`, lire notamment `structuredContent.context` et les limitations OSC avant d'inférer l'état du show.
+- Pour `eos_capabilities_get`, lire notamment `structuredContent.context`, `structuredContent.context.osc_limitations.canReadJsonQueries`, `read_json_queries_status` et les limitations OSC avant d'inférer l'état du show.
 
 ### `commands_preview`
 

--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -768,6 +768,23 @@ describe('OscClient', () => {
 
 
 
+
+  it('refuse les lectures JSON quand la capacite de lecture reste non confirmee', async () => {
+    const service = new FakeOscService();
+    const client = new OscClient(service, { defaultTimeoutMs: 10 });
+
+    const capability = await client.probeCapabilities({ timeoutMs: 10 });
+    expect(capability.canReadJsonQueries).toBe(false);
+    expect(capability.readJsonQueriesStatus).toBe('read_capability_unconfirmed');
+
+    const sentBeforeRead = service.sentMessages.length;
+    const result = await client.requestJson('/eos/get/cue', { timeoutMs: 10 });
+
+    expect(result.status).toBe('read_capability_unconfirmed');
+    expect(result.error).toContain('Reconfigurez OSC');
+    expect(service.sentMessages).toHaveLength(sentBeforeRead);
+  });
+
   it('expose les diagnostics enrichis pour timeout, payload texte, payload vide et JSON invalide', async () => {
     const timeoutService = new FakeOscService();
     const timeoutClient = new OscClient(timeoutService, { defaultTimeoutMs: 20 });

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -57,7 +57,15 @@ const DEFAULT_HANDSHAKE_TIMEOUT_MS = 2000;
 
 type PredicateResult<T> = T | null;
 
-export type StepStatus = 'ok' | 'timeout' | 'error' | 'skipped';
+export type StepStatus = 'ok' | 'timeout' | 'error' | 'skipped' | 'unsupported_transport_mode' | 'read_capability_unconfirmed';
+
+export type ReadJsonCapabilityStatus = 'confirmed' | 'unsupported_transport_mode' | 'read_capability_unconfirmed';
+
+export interface OscRuntimeCapabilities {
+  canReadJsonQueries: boolean;
+  readJsonQueriesStatus: ReadJsonCapabilityStatus;
+  reason: string | null;
+}
 
 export interface OscGatewaySendOptions {
   targetAddress?: string;
@@ -208,6 +216,7 @@ export interface OscJsonRequestOptions extends TargetOptions {
   responseAddress?: string;
   responseAddresses?: readonly string[];
   timeoutMs?: number;
+  bypassReadCapabilityCheck?: boolean;
 }
 
 export type OscPayloadParseType = 'json' | 'plain_text' | 'empty' | 'invalid_json';
@@ -241,6 +250,7 @@ export interface OscJsonResponse {
 interface InternalOscJsonRequestOptions {
   strictJsonObjectResponse?: boolean;
   requireStatusResponse?: boolean;
+  bypassReadCapabilityCheck?: boolean;
 }
 
 interface SendQueueOptions extends RequestQueueRunOptions {
@@ -265,10 +275,61 @@ export class OscClient {
 
   private lastProtocolMode: string | null = null;
 
+  private readJsonCapability: OscRuntimeCapabilities = {
+    canReadJsonQueries: false,
+    readJsonQueriesStatus: 'read_capability_unconfirmed',
+    reason: 'Aucun handshake/probe OSC de lecture JSON reussi dans cette session.'
+  };
+
+  private readJsonCapabilityChecked = false;
+
   constructor(private readonly gateway: OscGateway, private readonly config: OscClientConfig = {}) {
     this.requestQueue = new RequestQueue({ concurrency: config.requestConcurrency });
     this.requestQueueTimeoutMs =
       config.queueTimeoutMs ?? config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS;
+  }
+
+  public getRuntimeCapabilities(): OscRuntimeCapabilities {
+    return { ...this.readJsonCapability };
+  }
+
+  public get canReadJsonQueries(): boolean {
+    return this.readJsonCapability.canReadJsonQueries;
+  }
+
+  public async probeCapabilities(options: TargetOptions & { timeoutMs?: number } = {}): Promise<OscRuntimeCapabilities> {
+    const timeoutMs = options.timeoutMs ?? Math.min(this.config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS, 400);
+    const response = await this.requestJsonInternal('/eos/get/version', {
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort,
+      toolId: options.toolId,
+      transportPreference: options.transportPreference,
+      timeoutMs,
+      responseAddresses: ['/eos/get/version', '/eos/out/get/version'],
+      bypassReadCapabilityCheck: true
+    }, {
+      strictJsonObjectResponse: false,
+      bypassReadCapabilityCheck: true
+    });
+
+    const capability: OscRuntimeCapabilities = response.status === 'ok'
+      ? {
+        canReadJsonQueries: true,
+        readJsonQueriesStatus: 'confirmed',
+        reason: null
+      }
+      : {
+        canReadJsonQueries: false,
+        readJsonQueriesStatus: 'read_capability_unconfirmed',
+        reason: response.error ?? `Probe JSON EOS termine avec le statut ${response.status}.`
+      };
+
+    this.setReadJsonCapability(
+      capability.canReadJsonQueries,
+      capability.readJsonQueriesStatus,
+      capability.reason
+    );
+    return this.getRuntimeCapabilities();
   }
 
   public async connect(options: ConnectOptions = {}): Promise<ConnectResult> {
@@ -280,6 +341,19 @@ export class OscClient {
     try {
       const handshake = await this.performHandshake(options, handshakeTimeout);
       const protocolResult = await this.selectProtocol(handshake, options, protocolTimeout);
+      const capability = handshake.mode === 'canonical'
+        ? this.setReadJsonCapability(true, 'confirmed', null)
+        : await this.probeCapabilities({
+          targetAddress: options.targetAddress,
+          targetPort: options.targetPort,
+          toolId: options.toolId,
+          transportPreference: options.transportPreference,
+          timeoutMs: Math.min(protocolTimeout, 400)
+        });
+      if (!capability.canReadJsonQueries && handshake.mode === 'legacy') {
+        this.setReadJsonCapability(false, 'unsupported_transport_mode', capability.reason ?? 'Handshake legacy: lecture JSON non confirmee.');
+      }
+      const runtimeCapability = this.getRuntimeCapabilities();
       this.lastHandshakeStatus = 'ok';
       this.lastProtocolMode = protocolResult.selectedProtocol ?? handshake.mode;
 
@@ -291,14 +365,14 @@ export class OscClient {
         protocolStatus: protocolResult.status,
         handshakePayload: handshake.raw,
         can_send_commands: true,
-        can_read_queries: handshake.mode === 'canonical',
+        can_read_queries: runtimeCapability.canReadJsonQueries,
         handshake_mode: handshake.mode,
         limitations: this.buildConnectionLimitations(
           handshake.mode,
           true,
-          handshake.mode === 'canonical',
+          runtimeCapability.canReadJsonQueries,
           protocolResult.status,
-          protocolResult.error
+          protocolResult.error ?? runtimeCapability.reason ?? undefined
         ),
         protocolResponse: protocolResult.payload,
         ...(protocolResult.error ? { error: protocolResult.error } : {})
@@ -313,6 +387,7 @@ export class OscClient {
       if (connectionLostError) {
         this.lastHandshakeStatus = 'error';
         this.lastProtocolMode = 'timeout';
+        this.setReadJsonCapability(false, 'read_capability_unconfirmed', connectionLostError.message);
         return {
           status: 'error',
           version: null,
@@ -330,6 +405,16 @@ export class OscClient {
 
       throw error;
     }
+  }
+
+  private setReadJsonCapability(
+    canReadJsonQueries: boolean,
+    readJsonQueriesStatus: ReadJsonCapabilityStatus,
+    reason: string | null
+  ): OscRuntimeCapabilities {
+    this.readJsonCapabilityChecked = true;
+    this.readJsonCapability = { canReadJsonQueries, readJsonQueriesStatus, reason };
+    return this.getRuntimeCapabilities();
   }
 
   public async ping(options: PingOptions = {}): Promise<PingResult> {
@@ -588,13 +673,21 @@ export class OscClient {
         `requestJson n'est pas autorise pour l'adresse '${address}'. Utilisez un builder specialise + sendMessage.`
       );
     }
+    const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS;
+    if (options.bypassReadCapabilityCheck !== true && internalOptions.bypassReadCapabilityCheck !== true && this.readJsonCapabilityChecked && !this.readJsonCapability.canReadJsonQueries) {
+      const responseAddresses = this.normaliseResponseAddresses(
+        address,
+        options.responseAddress,
+        options.responseAddresses
+      );
+      return this.buildReadCapabilityRefusal(address, responseAddresses, timeoutMs);
+    }
     const targetOptions: TargetOptions = {
       targetAddress: options.targetAddress,
       targetPort: options.targetPort,
       toolId: options.toolId,
       transportPreference: options.transportPreference
     };
-    const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS;
     const responseAddresses = this.normaliseResponseAddresses(
       address,
       options.responseAddress,
@@ -669,6 +762,16 @@ export class OscClient {
         });
       }
 
+      if (statusResult.status === 'ok') {
+        this.setReadJsonCapability(true, 'confirmed', null);
+      } else if (options.bypassReadCapabilityCheck === true || internalOptions.bypassReadCapabilityCheck === true) {
+        this.setReadJsonCapability(
+          false,
+          'read_capability_unconfirmed',
+          statusResult.error ?? `Probe JSON EOS termine avec le statut ${statusResult.status}.`
+        );
+      }
+
       return {
         status: statusResult.status,
         data,
@@ -679,6 +782,9 @@ export class OscClient {
     } catch (error) {
       const timeoutError = this.asAppError(error, ErrorCode.OSC_TIMEOUT);
       if (timeoutError) {
+        if (options.bypassReadCapabilityCheck === true || internalOptions.bypassReadCapabilityCheck === true) {
+          this.setReadJsonCapability(false, 'read_capability_unconfirmed', timeoutError.message);
+        }
         return {
           status: 'timeout',
           data: null,
@@ -712,6 +818,34 @@ export class OscClient {
       ...options,
       payload: extractJsonPayloadFromMessage(request.message)
     });
+  }
+
+  private buildReadCapabilityRefusal(
+    address: string,
+    responseAddresses: string[],
+    timeoutMs: number
+  ): OscJsonResponse {
+    const capability = this.getRuntimeCapabilities();
+    const status: Extract<StepStatus, 'unsupported_transport_mode' | 'read_capability_unconfirmed'> =
+      capability.readJsonQueriesStatus === 'unsupported_transport_mode'
+        ? 'unsupported_transport_mode'
+        : 'read_capability_unconfirmed';
+    const reason = capability.reason ?? 'Lecture JSON EOS non confirmee par le handshake/probe courant.';
+
+    return {
+      status,
+      data: null,
+      payload: null,
+      diagnostics: this.buildJsonDiagnostics(
+        address,
+        null,
+        responseAddresses,
+        this.emptyPayloadParseResult(),
+        timeoutMs,
+        'unknown'
+      ),
+      error: `${status}: ${reason} Reconfigurez OSC pour confirmer les requetes JSON ou fournissez une source showfile explicite.`
+    };
   }
 
   private normaliseResponseAddresses(
@@ -997,6 +1131,11 @@ export class OscClient {
     }
 
     const handshakeMode: HandshakeMode = canSendCommands ? 'degraded' : 'timeout';
+    this.setReadJsonCapability(
+      canReadQueries,
+      canReadQueries ? 'confirmed' : handshakeMode === 'degraded' ? 'unsupported_transport_mode' : 'read_capability_unconfirmed',
+      canReadQueries ? null : [errorMessage, ...probeErrors].join(' ')
+    );
     const limitations = this.buildConnectionLimitations(
       handshakeMode,
       canSendCommands,

--- a/src/tools/capabilities/index.ts
+++ b/src/tools/capabilities/index.ts
@@ -146,20 +146,23 @@ export const eosCapabilitiesGetTool: ToolDefinition<typeof emptySchema> = {
     let detectedEosVersion: string | null = null;
 
     try {
-      liveBlindRaw = await client.requestJson(oscMappings.showControl.liveBlindState, { timeoutMs: 400 });
+      liveBlindRaw = await client.requestJson(oscMappings.showControl.liveBlindState, { timeoutMs: 400, bypassReadCapabilityCheck: true });
       liveBlindMode = parseLiveBlindLabel(liveBlindRaw.data);
     } catch (_error) {
       liveBlindMode = 'unknown';
     }
 
     try {
-      versionRaw = await client.requestJson(oscMappings.system.getVersion, { timeoutMs: 400 });
+      versionRaw = await client.requestJson(oscMappings.system.getVersion, { timeoutMs: 400, bypassReadCapabilityCheck: true });
       detectedEosVersion = parseDetectedEosVersion(versionRaw.data);
     } catch (_error) {
       detectedEosVersion = null;
     }
 
-    const canReadQueries = liveBlindRaw?.status === 'ok' || versionRaw?.status === 'ok';
+    const runtimeCapabilities = typeof client.getRuntimeCapabilities === 'function'
+      ? client.getRuntimeCapabilities()
+      : { canReadJsonQueries: false, readJsonQueriesStatus: 'read_capability_unconfirmed', reason: null };
+    const canReadQueries = liveBlindRaw?.status === 'ok' || versionRaw?.status === 'ok' || runtimeCapabilities.canReadJsonQueries;
     const canSendCommands = oscConnection.health !== 'offline';
     const limitations = [
       ...(canSendCommands ? [] : ['Envoi de commandes EOS non confirmé par l’état de transport OSC.']),
@@ -171,6 +174,9 @@ export const eosCapabilitiesGetTool: ToolDefinition<typeof emptySchema> = {
     const connectionLimitations = {
       can_send_commands: canSendCommands,
       can_read_queries: canReadQueries,
+      canReadJsonQueries: runtimeCapabilities.canReadJsonQueries || canReadQueries,
+      read_json_queries_status: canReadQueries ? 'confirmed' : runtimeCapabilities.readJsonQueriesStatus,
+      read_json_queries_reason: canReadQueries ? null : runtimeCapabilities.reason,
       handshake_mode: oscConnection.health === 'online' ? 'canonical' : oscConnection.health === 'degraded' ? 'degraded' : 'timeout',
       limitations
     };

--- a/src/tools/curves/index.ts
+++ b/src/tools/curves/index.ts
@@ -407,7 +407,7 @@ export const eosCurveGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
           )
           .describe('Points constitutifs de la courbe normalises (input/output).')
       }),
-      status: z.enum(['ok', 'timeout', 'error', 'skipped'])
+      status: z.enum(['ok', 'timeout', 'error', 'skipped', 'unsupported_transport_mode', 'read_capability_unconfirmed'])
     },
     annotations: annotate(oscMappings.curves.info)
   },

--- a/src/tools/effects/index.ts
+++ b/src/tools/effects/index.ts
@@ -458,7 +458,7 @@ function normaliseEffectDetails(data: unknown, fallbackNumber: number): EffectDe
 
 function formatEffectInfoText(
   details: EffectDetails,
-  status: 'ok' | 'timeout' | 'error' | 'skipped',
+  status: OscJsonResponse['status'],
   errorMessage: string | null
 ): string {
   if (status === 'timeout') {
@@ -624,7 +624,7 @@ export const eosEffectGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
     inputSchema: getInfoInputSchema,
     outputSchema: {
       effect: effectDetailsOutputSchema,
-      status: z.enum(['ok', 'timeout', 'error', 'skipped'])
+      status: z.enum(['ok', 'timeout', 'error', 'skipped', 'unsupported_transport_mode', 'read_capability_unconfirmed'])
     },
     annotations: {
       mapping: {

--- a/src/tools/macros/index.ts
+++ b/src/tools/macros/index.ts
@@ -455,7 +455,7 @@ export const eosMacroGetInfoTool: ToolDefinition<typeof getInfoInputSchema> = {
     inputSchema: getInfoInputSchema,
     outputSchema: {
       macro: macroDetailsOutputSchema,
-      status: z.enum(['ok', 'timeout', 'error', 'skipped'])
+      status: z.enum(['ok', 'timeout', 'error', 'skipped', 'unsupported_transport_mode', 'read_capability_unconfirmed'])
     },
     annotations: {
       mapping: {

--- a/src/tools/magicSheets/index.ts
+++ b/src/tools/magicSheets/index.ts
@@ -410,7 +410,7 @@ export const eosMagicSheetGetInfoTool: ToolDefinition<typeof getInfoInputSchema>
     inputSchema: getInfoInputSchema,
     outputSchema: {
       magic_sheet: magicSheetInfoOutputSchema,
-      status: z.enum(['ok', 'timeout', 'error', 'skipped'])
+      status: z.enum(['ok', 'timeout', 'error', 'skipped', 'unsupported_transport_mode', 'read_capability_unconfirmed'])
     },
     annotations: {
       mapping: {

--- a/src/tools/queries/index.ts
+++ b/src/tools/queries/index.ts
@@ -158,7 +158,7 @@ const TARGET_TYPE_ERROR_MESSAGE = [
   'Valeurs supportees: cue, cuelist, group, macro, ms, ip, fp, cp, bp, preset, sub, fx, curve, snap, pixmap.'
 ].join(' ');
 
-const statusSchema = z.enum(['ok', 'timeout', 'error', 'skipped']);
+const statusSchema = z.enum(['ok', 'timeout', 'error', 'skipped', 'unsupported_transport_mode', 'read_capability_unconfirmed']);
 
 const listItemOutputSchema = z.object({
   number: z.string(),

--- a/src/tools/snapshots/index.ts
+++ b/src/tools/snapshots/index.ts
@@ -336,7 +336,7 @@ export const eosSnapshotGetInfoTool: ToolDefinition<typeof getInfoInputSchema> =
         label: z.string().nullable(),
         uid: z.string().nullable()
       }),
-      status: z.enum(['ok', 'timeout', 'error', 'skipped'])
+      status: z.enum(['ok', 'timeout', 'error', 'skipped', 'unsupported_transport_mode', 'read_capability_unconfirmed'])
     },
     annotations: annotate(oscMappings.snapshots.info)
   },


### PR DESCRIPTION
### Motivation
- Empêcher les outils de lecture JSON d’inférer ou d’« inventer » l’état du show quand le handshake/transport OSC ne confirme pas la lecture JSON, et remplacer les timeouts ambigus par des statuts structurés plus explicites. 
- Fournir une capacité runtime exposée (`canReadJsonQueries`) dérivée du handshake canonique/legacy et d’un probe léger, pour que les outils et l’agent prennent des décisions cohérentes de refus ou de fallback.

### Description
- Ajout de la capacité runtime et API d’investigation dans `OscClient`: `getRuntimeCapabilities()`, `probeCapabilities()` et la propriété `canReadJsonQueries`, plus stockage interne `readJsonCapability` et méthode `setReadJsonCapability`. (`src/services/osc/client.ts`).
- `requestJsonInternal` refuse désormais proprement les lectures JSON si la capacité est vérifiée comme non disponible, en retournant un statut structuré `unsupported_transport_mode` ou `read_capability_unconfirmed` plutôt qu’un timeout ambigu; un flag `bypassReadCapabilityCheck` permet aux probes de contourner le garde-fou. (`src/services/osc/client.ts`).
- `eos_capabilities_get` enrichi pour exposer `canReadJsonQueries`, `read_json_queries_status` et `read_json_queries_reason`, et les probes de capacités appellent désormais `bypassReadCapabilityCheck`. (`src/tools/capabilities/index.ts`).
- Les outils de lecture (`eos_get_count`, `eos_get_list_all`, `*_get_info` et autres) acceptent désormais les nouveaux statuts de sortie (`unsupported_transport_mode`, `read_capability_unconfirmed`) dans leurs schémas Zod afin de propager le refus structuré aux workflows et à l’agent. (plusieurs fichiers sous `src/tools/*`).
- Documentation mise à jour pour l’agent LLM: préciser que l’assistant ne doit pas inventer le patch en mode legacy/non confirmé et doit demander reconfiguration OSC ou une source showfile fournie. (`docs/llm-agent-guide.md`).
- Test ajouté pour couvrir le refus de lecture JSON après probe non confirmé; ajustements mineurs dans tests existants. (`src/services/osc/__tests__/client.test.ts`).

### Testing
- Type-check: `npx tsc --noEmit` — réussi. 
- Lint: `npm run lint` — réussi. 
- Docs check: `npm run docs:check` — réussi. 
- Tests unitaires ciblés: `npx jest src/services/osc/__tests__/client.test.ts src/tools/capabilities/__tests__/capabilities.test.ts src/tools/queries/__tests__/queries.test.ts src/tools/patch/__tests__/patch.test.ts src/tools/cues/__tests__/cues.test.ts src/tools/groups/__tests__/groups.test.ts --runInBand` — réussite complète. 
- Exécution de la suite complète: `npm test -- --runInBand` — échec sur tests existants d’attentes payload/snapshots (non liés au garde-fou JSON) dans `effects`, `showControl`, `magicSheets` et `osc_payloads`; ces échecs proviennent d’attentes de payload/snapshot antérieures (format/contrats OSC) et ne bloquent pas la logique de refus ajoutée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0775e810f0832aa878d418c8636dce)