### PR TITLE
Support flexible EOS JSON response shapes

### DIFF
--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -769,6 +769,60 @@ describe('OscClient', () => {
 
 
 
+
+  it('applique responseShape pour les tableaux, scalaires et textes', async () => {
+    const arrayService = new FakeOscService();
+    const arrayClient = new OscClient(arrayService);
+    const arrayPromise = arrayClient.requestJson('/eos/get/cue/list', { responseShape: 'array' });
+    await waitFor(() => arrayService.sentMessages.length >= 1);
+    arrayService.emit({
+      address: '/eos/get/cue/list',
+      args: [{ type: 's', value: JSON.stringify([{ number: '1', uid: 'cue:1' }]) }]
+    });
+    await expect(arrayPromise).resolves.toMatchObject({
+      status: 'ok',
+      data: [{ number: '1', uid: 'cue:1' }]
+    });
+
+    const scalarService = new FakeOscService();
+    const scalarClient = new OscClient(scalarService);
+    const scalarPromise = scalarClient.requestJson('/eos/get/group/count', { responseShape: 'scalar' });
+    await waitFor(() => scalarService.sentMessages.length >= 1);
+    scalarService.emit({
+      address: '/eos/get/group/count',
+      args: [{ type: 's', value: JSON.stringify('12') }]
+    });
+    await expect(scalarPromise).resolves.toMatchObject({ status: 'ok', data: '12' });
+
+    const textService = new FakeOscService();
+    const textClient = new OscClient(textService);
+    const textPromise = textClient.requestJson('/eos/get/version', { responseShape: 'text' });
+    await waitFor(() => textService.sentMessages.length >= 1);
+    textService.emit({
+      address: '/eos/get/version',
+      args: [{ type: 's', value: 'Eos 3.2.0' }]
+    });
+    await expect(textPromise).resolves.toMatchObject({ status: 'ok', data: 'Eos 3.2.0' });
+  });
+
+  it('accepte un objet JSON sans status pour les endpoints qui ne lexigent pas explicitement', async () => {
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    const responsePromise = client.requestJson('/eos/get/patch/chan_info');
+    await waitFor(() => service.sentMessages.length >= 1);
+
+    service.emit({
+      address: '/eos/get/patch/chan_info',
+      args: [{ type: 's', value: JSON.stringify({ channel: 101, label: 'Fixture' }) }]
+    });
+
+    const result = await responsePromise;
+
+    expect(result.status).toBe('ok');
+    expect(result.data).toEqual({ channel: 101, label: 'Fixture' });
+  });
+
   it('refuse les lectures JSON quand la capacite de lecture reste non confirmee', async () => {
     const service = new FakeOscService();
     const client = new OscClient(service, { defaultTimeoutMs: 10 });

--- a/src/services/osc/__tests__/fixtures/eos-query-payload-variants.json
+++ b/src/services/osc/__tests__/fixtures/eos-query-payload-variants.json
@@ -1,0 +1,55 @@
+{
+  "counts": {
+    "numericScalar": 7,
+    "numericString": "12",
+    "objectCount": {
+      "status": "ok",
+      "count": "5"
+    }
+  },
+  "lists": {
+    "directArray": [
+      { "number": "1", "uid": "cue:1", "label": "Intro" },
+      { "number": "2", "uid": "cue:2", "label": "Blackout" }
+    ],
+    "objectWithItems": {
+      "status": "ok",
+      "items": [
+        { "number": 1, "uid": "group:1", "label": "Wash" }
+      ]
+    },
+    "objectWithList": {
+      "status": "ok",
+      "list": [
+        { "number": "10", "uid": "macro:10", "label": "Preset Reset" }
+      ]
+    },
+    "objectWithParallelArrays": {
+      "status": "ok",
+      "numbers": ["1", "2"],
+      "uids": ["preset:1", "preset:2"],
+      "labels": ["Warm", "Cool"]
+    },
+    "objectWithLabelsOnly": {
+      "status": "ok",
+      "labels": ["Only Label"]
+    }
+  },
+  "patch": {
+    "channelInfoWithoutStatus": {
+      "channel": "101",
+      "label": "No Status Fixture",
+      "part_count": 1,
+      "parts": [
+        {
+          "part": 1,
+          "label": "Main",
+          "manufacturer": "ETC",
+          "model": "Source Four LED",
+          "address": "1/001",
+          "gel": "L201"
+        }
+      ]
+    }
+  }
+}

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -211,12 +211,15 @@ export interface CommandLineState extends Record<string, unknown> {
   error?: string;
 }
 
+export type OscJsonResponseShape = 'object' | 'any-json' | 'scalar' | 'array' | 'text';
+
 export interface OscJsonRequestOptions extends TargetOptions {
   payload?: Record<string, unknown>;
   responseAddress?: string;
   responseAddresses?: readonly string[];
   timeoutMs?: number;
   bypassReadCapabilityCheck?: boolean;
+  responseShape?: OscJsonResponseShape;
 }
 
 export type OscPayloadParseType = 'json' | 'plain_text' | 'empty' | 'invalid_json';
@@ -248,7 +251,7 @@ export interface OscJsonResponse {
 }
 
 interface InternalOscJsonRequestOptions {
-  strictJsonObjectResponse?: boolean;
+  responseShape?: OscJsonResponseShape;
   requireStatusResponse?: boolean;
   bypassReadCapabilityCheck?: boolean;
 }
@@ -308,7 +311,7 @@ export class OscClient {
       responseAddresses: ['/eos/get/version', '/eos/out/get/version'],
       bypassReadCapabilityCheck: true
     }, {
-      strictJsonObjectResponse: false,
+      responseShape: 'any-json',
       bypassReadCapabilityCheck: true
     });
 
@@ -658,7 +661,7 @@ export class OscClient {
 
   public async requestJson(address: string, options: OscJsonRequestOptions = {}): Promise<OscJsonResponse> {
     return this.requestJsonInternal(address, options, {
-      strictJsonObjectResponse: true,
+      responseShape: options.responseShape ?? 'object',
       requireStatusResponse: JSON_STATUS_REQUIRED_ENDPOINTS.has(address)
     });
   }
@@ -737,21 +740,21 @@ export class OscClient {
       const parsed = this.parseOscPayload(response);
       const diagnostics = this.buildJsonDiagnostics(address, response.address, responseAddresses, parsed, timeoutMs, transportType);
 
-      if (internalOptions.strictJsonObjectResponse) {
-        const formatError = this.validateStrictJsonObjectPayload(parsed);
-        if (formatError) {
-          return {
-            status: 'error',
-            data: parsed.type === 'json' ? parsed.data : null,
-            payload: response,
-            diagnostics,
-            error: this.withJsonDiagnostics(formatError, diagnostics)
-          };
-        }
+      const responseShape = internalOptions.responseShape ?? options.responseShape ?? 'object';
+      const requireStatusResponse = internalOptions.requireStatusResponse === true;
+      const formatError = this.validatePayloadShape(parsed, responseShape, requireStatusResponse);
+      if (formatError) {
+        return {
+          status: 'error',
+          data: parsed.type === 'json' ? parsed.data : null,
+          payload: response,
+          diagnostics,
+          error: this.withJsonDiagnostics(formatError, diagnostics)
+        };
       }
 
       const data = parsed.data;
-      const statusResult = this.normaliseJsonStatus(data, internalOptions.requireStatusResponse === true);
+      const statusResult = this.normaliseJsonStatus(data, requireStatusResponse);
       if (statusResult.status === 'error') {
         this.ensureConnectionActive(operation, data, {
           address: response.address,
@@ -1674,24 +1677,80 @@ export class OscClient {
     return normalised.length > 160 ? `${normalised.slice(0, 157)}...` : normalised;
   }
 
-  private validateStrictJsonObjectPayload(parsed: OscPayloadParseResult): string | null {
+  private validatePayloadShape(
+    parsed: OscPayloadParseResult,
+    responseShape: OscJsonResponseShape,
+    requireStatus: boolean
+  ): string | null {
     if (parsed.type === 'invalid_json') {
       return `Payload JSON invalide: ${parsed.error}`;
     }
 
     if (parsed.type === 'empty') {
-      return 'Payload vide: un objet JSON avec un champ status est attendu.';
+      return `Payload vide: ${this.describeExpectedPayload(responseShape, requireStatus)} est attendu.`;
+    }
+
+    if (responseShape === 'text') {
+      if (parsed.type === 'plain_text') {
+        return null;
+      }
+      if (parsed.type === 'json' && typeof parsed.data === 'string') {
+        return null;
+      }
+      return 'Format de payload invalide: un texte est attendu.';
     }
 
     if (parsed.type === 'plain_text') {
-      return 'Payload texte recu: un objet JSON avec un champ status est attendu.';
+      if (responseShape === 'scalar') {
+        return null;
+      }
+      return `Payload texte recu: ${this.describeExpectedPayload(responseShape, requireStatus)} est attendu.`;
+    }
+
+    if (parsed.type !== 'json') {
+      return `Format de payload invalide: ${this.describeExpectedPayload(responseShape, requireStatus)} est attendu.`;
+    }
+
+    if (responseShape === 'any-json') {
+      return null;
+    }
+
+    if (responseShape === 'array') {
+      return Array.isArray(parsed.data) ? null : 'Format de payload invalide: un tableau JSON est attendu.';
+    }
+
+    if (responseShape === 'scalar') {
+      const scalarType = typeof parsed.data;
+      return parsed.data === null || scalarType === 'string' || scalarType === 'number' || scalarType === 'boolean'
+        ? null
+        : 'Format de payload invalide: un scalaire JSON est attendu.';
     }
 
     if (!parsed.data || typeof parsed.data !== 'object' || Array.isArray(parsed.data)) {
-      return 'Format de payload invalide: un objet JSON avec un champ status est attendu.';
+      return `Format de payload invalide: ${this.describeExpectedPayload(responseShape, requireStatus)} est attendu.`;
     }
 
     return null;
+  }
+
+  private describeExpectedPayload(responseShape: OscJsonResponseShape, requireStatus: boolean): string {
+    if (responseShape === 'object') {
+      return requireStatus ? 'un objet JSON avec un champ status' : 'un objet JSON';
+    }
+
+    if (responseShape === 'any-json') {
+      return 'un payload JSON valide';
+    }
+
+    if (responseShape === 'array') {
+      return 'un tableau JSON';
+    }
+
+    if (responseShape === 'scalar') {
+      return 'un scalaire JSON ou texte';
+    }
+
+    return 'un texte';
   }
 
   private normaliseJsonStatus(payload: unknown, requireStatus: boolean): { status: StepStatus; error?: string } {

--- a/src/tools/patch/__tests__/patch.test.ts
+++ b/src/tools/patch/__tests__/patch.test.ts
@@ -5,6 +5,7 @@
 import { getResourceCache } from '../../../services/cache/index';
 import type { OscMessage } from '../../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
+import eosPayloadVariants from '../../../services/osc/__tests__/fixtures/eos-query-payload-variants.json';
 import { oscMappings } from '../../../services/osc/mappings';
 import {
   eosPatchGetAugment3dBeamTool,
@@ -172,6 +173,40 @@ describe('patch tools', () => {
               text1: 'Spare blade'
             },
             notes: null
+          }
+        ]
+      }
+    });
+  });
+
+
+  it('accepte les informations de patch EOS sans champ status quand endpoint ne lexige pas', async () => {
+    const promise = runTool(eosPatchGetChannelInfoTool, { channel_number: 101, part_number: 0 });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: oscMappings.patch.channelInfo,
+        args: [{ type: 's', value: JSON.stringify(eosPayloadVariants.patch.channelInfoWithoutStatus) }]
+      });
+    });
+
+    const result = await promise;
+    const structuredContent = extractStructuredContent(result);
+
+    expect(structuredContent).toMatchObject({
+      status: 'ok',
+      channel: {
+        channel_number: 101,
+        label: 'No Status Fixture',
+        part_count: 1,
+        parts: [
+          {
+            part_number: 1,
+            label: 'Main',
+            manufacturer: 'ETC',
+            model: 'Source Four LED',
+            dmx_address: '1/001',
+            gel: 'L201'
           }
         ]
       }

--- a/src/tools/patch/index.ts
+++ b/src/tools/patch/index.ts
@@ -738,8 +738,14 @@ export const eosPatchGetChannelInfoTool: ToolDefinition<typeof channelInfoInputS
           targetPort: options.targetPort
         });
 
+        const responseRecord = response.data && typeof response.data === 'object' && !Array.isArray(response.data)
+          ? response.data as Record<string, unknown>
+          : null;
+        const channelPayload = responseRecord?.channel && typeof responseRecord.channel === 'object'
+          ? responseRecord.channel
+          : response.data;
         const channelData = normaliseChannelInfo(
-          (response.data as Record<string, unknown> | null)?.channel ?? response.data,
+          channelPayload,
           options.channel_number,
           options.part_number ?? null
         );

--- a/src/tools/queries/__tests__/queries.test.ts
+++ b/src/tools/queries/__tests__/queries.test.ts
@@ -6,6 +6,7 @@ import { getResourceCache } from '../../../services/cache/index';
 import type { OscMessage } from '../../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../../services/osc/client';
 import { oscMappings } from '../../../services/osc/mappings';
+import eosPayloadVariants from '../../../services/osc/__tests__/fixtures/eos-query-payload-variants.json';
 import { eosGetCountTool, eosGetListAllTool } from '../index';
 import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
@@ -48,7 +49,7 @@ const QUERY_TARGET_TYPES = [
   'pixmap'
 ] as const;
 
-function emitJson(service: FakeOscService, address: string, payload: Record<string, unknown>): void {
+function emitJson(service: FakeOscService, address: string, payload: unknown): void {
   service.emit({
     address,
     args: [
@@ -262,6 +263,97 @@ describe('query tools', () => {
     });
   });
 
+
+
+  it('accepte les variantes EOS scalaires pour les comptes', async () => {
+    const numericPromise = runTool(eosGetCountTool, { target_type: 'group' });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: oscMappings.queries.group.count,
+        args: [{ type: 's', value: JSON.stringify(eosPayloadVariants.counts.numericScalar) }]
+      });
+    });
+
+    expect(getStructuredContent(await numericPromise)).toMatchObject({
+      action: 'get_count',
+      status: 'ok',
+      target_type: 'group',
+      count: 7
+    });
+
+    const stringPromise = runTool(eosGetCountTool, { target_type: 'preset' });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: oscMappings.queries.preset.count,
+        args: [{ type: 's', value: JSON.stringify(eosPayloadVariants.counts.numericString) }]
+      });
+    });
+
+    expect(getStructuredContent(await stringPromise)).toMatchObject({
+      action: 'get_count',
+      status: 'ok',
+      target_type: 'preset',
+      count: 12
+    });
+  });
+
+  it('accepte les variantes EOS directes pour les listes', async () => {
+    const directArrayPromise = runTool(eosGetListAllTool, { target_type: 'cue' });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: oscMappings.queries.cue.list,
+        args: [{ type: 's', value: JSON.stringify(eosPayloadVariants.lists.directArray) }]
+      });
+    });
+
+    expect(getStructuredContent(await directArrayPromise)).toMatchObject({
+      action: 'list_all',
+      status: 'ok',
+      target_type: 'cue',
+      items: [
+        { number: '1', uid: 'cue:1', label: 'Intro' },
+        { number: '2', uid: 'cue:2', label: 'Blackout' }
+      ]
+    });
+
+    const listObjectPromise = runTool(eosGetListAllTool, { target_type: 'macro' });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: oscMappings.queries.macro.list,
+        args: [{ type: 's', value: JSON.stringify(eosPayloadVariants.lists.objectWithList) }]
+      });
+    });
+
+    expect(getStructuredContent(await listObjectPromise)).toMatchObject({
+      action: 'list_all',
+      status: 'ok',
+      target_type: 'macro',
+      items: [{ number: '10', uid: 'macro:10', label: 'Preset Reset' }]
+    });
+
+    const parallelPromise = runTool(eosGetListAllTool, { target_type: 'preset' });
+
+    queueMicrotask(() => {
+      service.emit({
+        address: oscMappings.queries.preset.list,
+        args: [{ type: 's', value: JSON.stringify(eosPayloadVariants.lists.objectWithParallelArrays) }]
+      });
+    });
+
+    expect(getStructuredContent(await parallelPromise)).toMatchObject({
+      action: 'list_all',
+      status: 'ok',
+      target_type: 'preset',
+      items: [
+        { number: '1', uid: 'preset:1', label: 'Warm' },
+        { number: '2', uid: 'preset:2', label: 'Cool' }
+      ]
+    });
+  });
 
   it('propage les diagnostics OSC et le message console pour timeout, payload texte, payload vide et JSON invalide', async () => {
     const timeoutResult = await runTool(eosGetCountTool, { target_type: 'group', timeoutMs: 50 });

--- a/src/tools/queries/index.ts
+++ b/src/tools/queries/index.ts
@@ -270,7 +270,8 @@ export const eosGetCountTool: ToolDefinition<typeof countInputSchema> = {
           timeoutMs: options.timeoutMs,
           targetAddress: options.targetAddress,
           targetPort: options.targetPort,
-          responseAddresses: config.countResponseAddresses
+          responseAddresses: config.countResponseAddresses,
+          responseShape: 'any-json'
         });
 
         const count = Math.max(0, normaliseCount(response.data));
@@ -344,7 +345,8 @@ export const eosGetListAllTool: ToolDefinition<typeof listInputSchema> = {
           timeoutMs: options.timeoutMs,
           targetAddress: options.targetAddress,
           targetPort: options.targetPort,
-          responseAddresses: config.listResponseAddresses
+          responseAddresses: config.listResponseAddresses,
+          responseShape: 'any-json'
         });
 
         const items = normaliseList(response.data, config);
@@ -492,14 +494,15 @@ function normaliseList(data: unknown, config: QueryTargetConfig): QueryListItem[
     if (numbers.length > 0 || uids.length > 0 || labels.length > 0) {
       const maxLength = Math.max(numbers.length, uids.length, labels.length);
       for (let index = 0; index < maxLength; index += 1) {
-        const uid = uids[index] ?? numbers[index] ?? '';
+        const label = labels[index] ?? null;
+        const uid = uids[index] ?? numbers[index] ?? label ?? '';
         if (!uid) {
           continue;
         }
         items.push({
           number: numbers[index] ?? uid,
           uid,
-          label: labels[index] ?? null
+          label
         });
       }
       return items;
@@ -527,8 +530,10 @@ function extractListPayload(data: unknown, config: QueryTargetConfig): unknown {
         return record[key];
       }
     }
-    if ('items' in record) {
-      return record.items;
+    for (const key of ['items', 'list'] as const) {
+      if (key in record) {
+        return record[key];
+      }
     }
     if ('all' in record) {
       return record.all;
@@ -542,8 +547,10 @@ function extractListPayload(data: unknown, config: QueryTargetConfig): unknown {
             return nestedRecord[key];
           }
         }
-        if ('items' in nestedRecord) {
-          return nestedRecord.items;
+        for (const key of ['items', 'list'] as const) {
+          if (key in nestedRecord) {
+            return nestedRecord[key];
+          }
         }
       }
       return nested;


### PR DESCRIPTION
### Motivation

- EOS consoles return JSON in several real-world shapes (scalars, direct arrays, objects without `status`) which the client/tools must accept to be robust.
- The `requestJson` flow enforced a single strict object-with-status shape that rejected legitimate EOS responses used by `eos_get_count`, `eos_get_list_all` and some patch endpoints.

### Description

- Add `OscJsonResponseShape` and a `responseShape` option to `requestJson` to allow shapes: `object`, `any-json`, `scalar`, `array`, `text`, and centralize payload-shape validation in `validatePayloadShape` in `src/services/osc/client.ts`.
- Make `eos_get_count` request `responseShape: 'any-json'` and accept numeric scalars or numeric strings via `normaliseCount` in `src/tools/queries/index.ts`.
- Make `eos_get_list_all` accept direct JSON arrays and objects containing `items`, `list`, `numbers`, `uids` or `labels`, with label-only fallbacks, and request `responseShape: 'any-json'` in `src/tools/queries/index.ts`.
- Update `eos_patch_get_channel_info` normalization to preserve strict validation after normalization while accepting a payload where `channel` is provided directly (object or scalar) and also tolerate the absence of a `status` field when the endpoint does not explicitly require it in `src/tools/patch/index.ts`.
- Add fixtures `src/services/osc/__tests__/fixtures/eos-query-payload-variants.json` and new unit tests covering `responseShape` variants, scalar counts, list variants, and status-less patch payloads in the modified test files.

### Testing

- Type-check with `npm run tsc -- --noEmit` succeeded.
- Lint with `npm run lint` succeeded.
- Targeted unit runs `npx jest --runInBand src/services/osc/__tests__/client.test.ts src/tools/queries/__tests__/queries.test.ts src/tools/patch/__tests__/patch.test.ts` all passed.
- Full test suite `npm test -- --runInBand` was executed but reveals unrelated, pre-existing snapshot/format expectations failing in `showControl`, `effects`, `magicSheets` and `osc_payloads`; these are orthogonal to the scope of this change and the targeted behavior changes passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07782f3d6c832aa982292a7f2afc32)