### PR TITLE
Centralize EOS /eos/out/ response variants and use them in patch/queries

### DIFF
--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -225,8 +225,66 @@ export const oscResponseMappings = {
       list: withEosOutResponseVariant(oscMappings.queries.cue.list)
     },
     cuelist: {
+      count: withEosOutResponseVariant(oscMappings.queries.cuelist.count),
       list: withEosOutResponseVariant(oscMappings.queries.cuelist.list)
+    },
+    group: {
+      count: withEosOutResponseVariant(oscMappings.queries.group.count),
+      list: withEosOutResponseVariant(oscMappings.queries.group.list)
+    },
+    macro: {
+      count: withEosOutResponseVariant(oscMappings.queries.macro.count),
+      list: withEosOutResponseVariant(oscMappings.queries.macro.list)
+    },
+    ms: {
+      count: withEosOutResponseVariant(oscMappings.queries.ms.count),
+      list: withEosOutResponseVariant(oscMappings.queries.ms.list)
+    },
+    ip: {
+      count: withEosOutResponseVariant(oscMappings.queries.ip.count),
+      list: withEosOutResponseVariant(oscMappings.queries.ip.list)
+    },
+    fp: {
+      count: withEosOutResponseVariant(oscMappings.queries.fp.count),
+      list: withEosOutResponseVariant(oscMappings.queries.fp.list)
+    },
+    cp: {
+      count: withEosOutResponseVariant(oscMappings.queries.cp.count),
+      list: withEosOutResponseVariant(oscMappings.queries.cp.list)
+    },
+    bp: {
+      count: withEosOutResponseVariant(oscMappings.queries.bp.count),
+      list: withEosOutResponseVariant(oscMappings.queries.bp.list)
+    },
+    preset: {
+      count: withEosOutResponseVariant(oscMappings.queries.preset.count),
+      list: withEosOutResponseVariant(oscMappings.queries.preset.list)
+    },
+    sub: {
+      count: withEosOutResponseVariant(oscMappings.queries.sub.count),
+      list: withEosOutResponseVariant(oscMappings.queries.sub.list)
+    },
+    fx: {
+      count: withEosOutResponseVariant(oscMappings.queries.fx.count),
+      list: withEosOutResponseVariant(oscMappings.queries.fx.list)
+    },
+    curve: {
+      count: withEosOutResponseVariant(oscMappings.queries.curve.count),
+      list: withEosOutResponseVariant(oscMappings.queries.curve.list)
+    },
+    snap: {
+      count: withEosOutResponseVariant(oscMappings.queries.snap.count),
+      list: withEosOutResponseVariant(oscMappings.queries.snap.list)
+    },
+    pixmap: {
+      count: withEosOutResponseVariant(oscMappings.queries.pixmap.count),
+      list: withEosOutResponseVariant(oscMappings.queries.pixmap.list)
     }
+  },
+  patch: {
+    channelInfo: withEosOutResponseVariant(oscMappings.patch.channelInfo),
+    augment3dPosition: withEosOutResponseVariant(oscMappings.patch.augment3dPosition),
+    augment3dBeam: withEosOutResponseVariant(oscMappings.patch.augment3dBeam)
   },
   cues: {
     info: withEosOutResponseVariant(oscMappings.cues.info),

--- a/src/tools/__tests__/osc_contracts.test.ts
+++ b/src/tools/__tests__/osc_contracts.test.ts
@@ -7,6 +7,7 @@ import { resolve } from 'node:path';
 import { z } from 'zod';
 import type { OscMessage, OscMessageArgument } from '../../services/osc/index';
 import { setOscClient, type OscClient, type OscJsonResponse, type TargetOptions } from '../../services/osc/client';
+import { oscResponseMappings, toEosOutResponseAddress } from '../../services/osc/mappings';
 import type { BuiltOscWireMessage } from '../../services/osc/messageBuilders';
 import toolDefinitions from '../index';
 import type { ToolDefinition } from '../types';
@@ -211,6 +212,19 @@ const FIELD_ALIASES: Record<string, string> = {
   target_type_direct_select: 'target_type'
 };
 
+
+function collectResponseAddressVariants(value: unknown): readonly string[][] {
+  if (Array.isArray(value) && value.every((entry) => typeof entry === 'string')) {
+    return [value];
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).flatMap((entry) => collectResponseAddressVariants(entry));
+  }
+
+  return [];
+}
+
 function sampleArgsFor(tool: ToolDefinition): Record<string, unknown> {
   const rawShape = tool.config.inputSchema ?? {};
   const args: Record<string, unknown> = {};
@@ -332,6 +346,23 @@ describe('OSC tool contracts exported from src/tools/index.ts', () => {
 
     for (const tool of toolDefinitions) {
       expect(coverage).toContain(`\`${tool.name}\``);
+    }
+  });
+
+
+  it('accepts /eos/out/get response variants for every centralised /eos/get endpoint', () => {
+    const responseAddressVariants = collectResponseAddressVariants(oscResponseMappings);
+    const getEndpointVariants = responseAddressVariants.filter(([requestAddress]) => requestAddress?.startsWith('/eos/get/'));
+
+    expect(getEndpointVariants.length).toBeGreaterThan(0);
+
+    for (const addresses of getEndpointVariants) {
+      const [requestAddress] = addresses;
+      if (!requestAddress) {
+        throw new Error('Missing request address in OSC response mapping');
+      }
+      expect(addresses).toContain(requestAddress);
+      expect(addresses).toContain(toEosOutResponseAddress(requestAddress));
     }
   });
 

--- a/src/tools/patch/index.ts
+++ b/src/tools/patch/index.ts
@@ -10,7 +10,7 @@ import {
   getResourceCache
 } from '../../services/cache/index';
 import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
-import { oscMappings } from '../../services/osc/mappings';
+import { oscMappings, oscResponseMappings } from '../../services/osc/mappings';
 import { createDryRunResult, resolveSafetyOptions, safetyOptionsSchema } from '../common/safety';
 import { buildToolResult, withToolMetadata, type ToolDefinition, type ToolExecutionResult } from '../types';
 
@@ -735,7 +735,8 @@ export const eosPatchGetChannelInfoTool: ToolDefinition<typeof channelInfoInputS
           payload,
           timeoutMs: options.timeoutMs,
           targetAddress: options.targetAddress,
-          targetPort: options.targetPort
+          targetPort: options.targetPort,
+          responseAddresses: oscResponseMappings.patch.channelInfo
         });
 
         const responseRecord = response.data && typeof response.data === 'object' && !Array.isArray(response.data)
@@ -827,7 +828,8 @@ export const eosPatchGetAugment3dPositionTool: ToolDefinition<typeof augment3dIn
           payload,
           timeoutMs: options.timeoutMs,
           targetAddress: options.targetAddress,
-          targetPort: options.targetPort
+          targetPort: options.targetPort,
+          responseAddresses: oscResponseMappings.patch.augment3dPosition
         });
 
         const positionData = normaliseAugment3dPosition(
@@ -913,7 +915,8 @@ export const eosPatchGetAugment3dBeamTool: ToolDefinition<typeof augment3dInputS
           payload,
           timeoutMs: options.timeoutMs,
           targetAddress: options.targetAddress,
-          targetPort: options.targetPort
+          targetPort: options.targetPort,
+          responseAddresses: oscResponseMappings.patch.augment3dBeam
         });
 
         const beamData = normaliseAugment3dBeam(

--- a/src/tools/queries/index.ts
+++ b/src/tools/queries/index.ts
@@ -10,7 +10,7 @@ import {
   getResourceCache
 } from '../../services/cache/index';
 import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
-import { oscMappings, oscResponseMappings, withEosOutResponseVariant } from '../../services/osc/mappings';
+import { oscMappings, oscResponseMappings } from '../../services/osc/mappings';
 import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 interface QueryListItem {
@@ -43,7 +43,7 @@ const TARGET_TYPE_CONFIGS = {
     label: 'cue lists',
     countAddress: oscMappings.queries.cuelist.count,
     listAddress: oscMappings.queries.cuelist.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.cuelist.count),
+    countResponseAddresses: oscResponseMappings.queries.cuelist.count,
     listResponseAddresses: oscResponseMappings.queries.cuelist.list,
     responseKeys: ['cuelists', 'lists', 'items']
   },
@@ -51,104 +51,104 @@ const TARGET_TYPE_CONFIGS = {
     label: 'groupes',
     countAddress: oscMappings.queries.group.count,
     listAddress: oscMappings.queries.group.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.group.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.group.list),
+    countResponseAddresses: oscResponseMappings.queries.group.count,
+    listResponseAddresses: oscResponseMappings.queries.group.list,
     responseKeys: ['groups', 'items']
   },
   macro: {
     label: 'macros',
     countAddress: oscMappings.queries.macro.count,
     listAddress: oscMappings.queries.macro.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.macro.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.macro.list),
+    countResponseAddresses: oscResponseMappings.queries.macro.count,
+    listResponseAddresses: oscResponseMappings.queries.macro.list,
     responseKeys: ['macros', 'items']
   },
   ms: {
     label: 'magic sheets',
     countAddress: oscMappings.queries.ms.count,
     listAddress: oscMappings.queries.ms.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.ms.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.ms.list),
+    countResponseAddresses: oscResponseMappings.queries.ms.count,
+    listResponseAddresses: oscResponseMappings.queries.ms.list,
     responseKeys: ['magic_sheets', 'magicSheets', 'items']
   },
   ip: {
     label: 'intensity palettes',
     countAddress: oscMappings.queries.ip.count,
     listAddress: oscMappings.queries.ip.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.ip.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.ip.list),
+    countResponseAddresses: oscResponseMappings.queries.ip.count,
+    listResponseAddresses: oscResponseMappings.queries.ip.list,
     responseKeys: ['intensity_palettes', 'ip', 'items']
   },
   fp: {
     label: 'focus palettes',
     countAddress: oscMappings.queries.fp.count,
     listAddress: oscMappings.queries.fp.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.fp.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.fp.list),
+    countResponseAddresses: oscResponseMappings.queries.fp.count,
+    listResponseAddresses: oscResponseMappings.queries.fp.list,
     responseKeys: ['focus_palettes', 'fp', 'items']
   },
   cp: {
     label: 'color palettes',
     countAddress: oscMappings.queries.cp.count,
     listAddress: oscMappings.queries.cp.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.cp.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.cp.list),
+    countResponseAddresses: oscResponseMappings.queries.cp.count,
+    listResponseAddresses: oscResponseMappings.queries.cp.list,
     responseKeys: ['color_palettes', 'cp', 'items']
   },
   bp: {
     label: 'beam palettes',
     countAddress: oscMappings.queries.bp.count,
     listAddress: oscMappings.queries.bp.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.bp.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.bp.list),
+    countResponseAddresses: oscResponseMappings.queries.bp.count,
+    listResponseAddresses: oscResponseMappings.queries.bp.list,
     responseKeys: ['beam_palettes', 'bp', 'items']
   },
   preset: {
     label: 'presets',
     countAddress: oscMappings.queries.preset.count,
     listAddress: oscMappings.queries.preset.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.preset.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.preset.list),
+    countResponseAddresses: oscResponseMappings.queries.preset.count,
+    listResponseAddresses: oscResponseMappings.queries.preset.list,
     responseKeys: ['presets', 'items']
   },
   sub: {
     label: 'submasters',
     countAddress: oscMappings.queries.sub.count,
     listAddress: oscMappings.queries.sub.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.sub.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.sub.list),
+    countResponseAddresses: oscResponseMappings.queries.sub.count,
+    listResponseAddresses: oscResponseMappings.queries.sub.list,
     responseKeys: ['submasters', 'subs', 'items']
   },
   fx: {
     label: 'effects',
     countAddress: oscMappings.queries.fx.count,
     listAddress: oscMappings.queries.fx.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.fx.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.fx.list),
+    countResponseAddresses: oscResponseMappings.queries.fx.count,
+    listResponseAddresses: oscResponseMappings.queries.fx.list,
     responseKeys: ['effects', 'fx', 'items']
   },
   curve: {
     label: 'courbes',
     countAddress: oscMappings.queries.curve.count,
     listAddress: oscMappings.queries.curve.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.curve.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.curve.list),
+    countResponseAddresses: oscResponseMappings.queries.curve.count,
+    listResponseAddresses: oscResponseMappings.queries.curve.list,
     responseKeys: ['curves', 'items']
   },
   snap: {
     label: 'snapshots',
     countAddress: oscMappings.queries.snap.count,
     listAddress: oscMappings.queries.snap.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.snap.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.snap.list),
+    countResponseAddresses: oscResponseMappings.queries.snap.count,
+    listResponseAddresses: oscResponseMappings.queries.snap.list,
     responseKeys: ['snapshots', 'snaps', 'items']
   },
   pixmap: {
     label: 'pixel maps',
     countAddress: oscMappings.queries.pixmap.count,
     listAddress: oscMappings.queries.pixmap.list,
-    countResponseAddresses: withEosOutResponseVariant(oscMappings.queries.pixmap.count),
-    listResponseAddresses: withEosOutResponseVariant(oscMappings.queries.pixmap.list),
+    countResponseAddresses: oscResponseMappings.queries.pixmap.count,
+    listResponseAddresses: oscResponseMappings.queries.pixmap.list,
     responseKeys: ['pixmaps', 'pixel_maps', 'items']
   }
 } as const satisfies Record<string, QueryTargetConfig>;


### PR DESCRIPTION
### Motivation
- Standardiser la gestion des variantes de réponse `/eos/get/...` vs `/eos/out/get/...` en centralisant les paires d'adresses de réponse pour éviter duplication et erreurs.
- S'assurer que les outils `patch` et `queries` utilisent les mêmes variantes de réponse documentées afin d'améliorer la robustesse des `requestJson`.
- Ajouter une vérification contractuelle pour garantir que chaque point d'entrée `/eos/get/...` a bien sa variante `/eos/out/get/...` dans les mappings centralisés.

### Description
- Ajouté des entrées centralisées dans `src/services/osc/mappings.ts` sous `oscResponseMappings` pour toutes les cibles `queries.*.count` et `queries.*.list`, et pour `patch.channelInfo`, `patch.augment3dPosition` et `patch.augment3dBeam`, en utilisant `withEosOutResponseVariant`.
- Modifié `src/tools/patch/index.ts` pour importer `oscResponseMappings` et transmettre `responseAddresses: oscResponseMappings.patch.*` à `client.requestJson` pour les trois outils patch (`channelInfo`, `augment3dPosition`, `augment3dBeam`).
- Modifié `src/tools/queries/index.ts` pour remplacer les variantes ad hoc par les références centralisées `oscResponseMappings.queries.*.{count,list}` et supprimer l'import non utilisé de `withEosOutResponseVariant`.
- Ajouté un test de contrat OSC dans `src/tools/__tests__/osc_contracts.test.ts` qui parcourt `oscResponseMappings` et vérifie que chaque mapping `/eos/get/...` possède aussi sa variante `/eos/out/get/...`.

### Testing
- Type-check: exécuté `npm run tsc` et la compilation TypeScript a réussi.
- Unit tests: exécuté `npm run test:unit -- --runInBand src/tools/__tests__/osc_contracts.test.ts src/tools/queries/__tests__/queries.test.ts` et les suites ciblées ont passé (2 suites, 200 tests, snapshots ok).
- Lint: exécuté `npm run lint` et la vérification ESLint a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0779f3f7e0832a86b287a5a8482315)