### PR TITLE
Add eos_readiness_check diagnostics tool and document it as mandatory first LLM step

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,15 @@ Formats à utiliser selon le langage :
 
 | Outil | Description | Fiche détaillée |
 | --- | --- | --- |
+| `eos_readiness_check` | Première étape obligatoire read-only : ping, handshake, version, ligne de commande, nom du show, count et lecture patch optionnelle. | [docs/tools.md#eos-readiness-check](docs/tools.md#eos-readiness-check) |
 | `eos_cue_go` | GO sur la liste de cues active. | [docs/tools.md#eos-cue-go](docs/tools.md#eos-cue-go) |
 | `eos_cue_stop_back` | Stop ou retour en arrière sur une liste. | [docs/tools.md#eos-cue-stop-back](docs/tools.md#eos-cue-stop-back) |
 | `eos_preset_fire` | Rappel immédiat d’un preset. | [docs/tools.md#eos-preset-fire](docs/tools.md#eos-preset-fire) |
 | `eos_channel_set_level` | Réglage d’intensité (0–100 %) d’un canal. | [docs/tools.md#eos-channel-set-level](docs/tools.md#eos-channel-set-level) |
+
+### Première étape obligatoire : readiness
+
+Avant toute lecture métier, dry-run ou action réelle, un assistant LLM doit appeler `eos_readiness_check`. L'outil retourne `structuredContent.overall_status`, `transport_status`, `handshake_mode`, `json_read_supported`, `failed_checks` et `operator_actions`; si la lecture JSON n'est pas supportée, l'assistant ne doit pas inventer le patch, les cues ou l'état du show et doit demander une reconfiguration OSC ou une source explicite. Fournissez `patchChannel` lorsque vous voulez aussi valider une lecture patch read-only sur un canal connu.
 
 ### Safety pattern
 

--- a/docs/llm-agent-guide.md
+++ b/docs/llm-agent-guide.md
@@ -4,22 +4,26 @@ Ce guide décrit le comportement attendu d'un assistant LLM qui pilote une conso
 
 ## Règles générales obligatoires
 
-1. **Toujours commencer par `eos_capabilities_get`.**
+1. **Toujours commencer par `eos_readiness_check`.**
+   - C'est la première étape obligatoire de toute session LLM, avant `eos_capabilities_get`, les lectures métier, les dry-runs et toute action réelle.
+   - Lire `structuredContent.overall_status`, `transport_status`, `handshake_mode`, `json_read_supported`, `failed_checks` et `operator_actions`.
+   - Ne poursuivre que si `overall_status=ok` ou si l'opérateur accepte explicitement les limitations signalées. Si `json_read_supported=false`, ne jamais inventer le patch, la cuelist, les cues ou l'état du show : les présenter comme inconnus et demander une reconfiguration OSC, une lecture réussie ou une source showfile explicite.
+   - Fournir `patchChannel` uniquement lorsqu'un canal connu doit valider aussi la lecture patch; sinon cette sous-vérification optionnelle reste `skipped`.
+2. **Enchaîner avec `eos_capabilities_get` pour le contexte métier.**
    - Lire `structuredContent.context` avant de proposer une action métier.
    - Vérifier l'état OSC, l'utilisateur Eos, le mode Live/Blind, les limitations de lecture et les garde-fous de sécurité disponibles.
-   - Si `structuredContent.context.osc_limitations.can_read_queries=false` ou `canReadJsonQueries=false`, ne jamais inventer le patch, la cuelist, les cues ou l'état du show : les présenter comme inconnus et demander une lecture réussie ou une confirmation opérateur.
    - En mode legacy/non confirmé, les outils de lecture peuvent retourner `unsupported_transport_mode` ou `read_capability_unconfirmed` au lieu d'attendre un timeout. Dans ce cas, demander explicitement une reconfiguration OSC qui confirme les requêtes JSON, ou une source showfile fournie par l'opérateur; ne pas reconstruire ou deviner le patch depuis des suppositions.
-2. **Privilégier les workflows `eos_workflow_*`.**
+3. **Privilégier les workflows `eos_workflow_*`.**
    - Utiliser un workflow haut niveau dès qu'il existe pour l'intention utilisateur : cue series, update cue, look, patch fixture, autopatch, rehearsal GO, groupes/palettes, effet.
    - Réserver les outils bas niveau (`eos_cue_*`, `eos_patch_*`, `eos_command`, `eos_new_command`, `*_fire`) aux cas où aucun workflow ne couvre l'action ou lorsque l'intégration sait exactement quelle commande Eos envoyer.
-3. **Utiliser `dry_run=true` avant toute action sensible.**
+4. **Utiliser `dry_run=true` avant toute action sensible.**
    - Sont sensibles : modification de show, patch, record/update/label, commande texte, action live visible, rappel de cue/palette/preset, GO, macro, show control.
    - Lire `structuredContent.commands_preview` à l'utilisateur et attendre une confirmation explicite.
    - Relancer ensuite le même outil avec les mêmes arguments métier, `dry_run=false` ou sans `dry_run`, et `require_confirmation=true` si l'outil l'expose.
-4. **Ne pas concaténer des commandes de programmation complexes dans une seule chaîne libre.**
+5. **Ne pas concaténer des commandes de programmation complexes dans une seule chaîne libre.**
    - Pour une série de cues, utiliser `eos_workflow_create_cue_series` plutôt qu'une commande texte qui mélange `At`, `Record`, `Label` et d'autres actions.
    - Si `eos_new_command` est nécessaire, utiliser `clearLine=true`, `terminateWithEnter=true`, `dry_run=true`, puis confirmation.
-5. **Restituer le plan avant l'appel.**
+6. **Restituer le plan avant l'appel.**
    - Annoncer la cible, les canaux, les numéros de cues/palettes/fixtures, les valeurs d'intensité ou DMX, et le rollback prévu.
    - Ne jamais envoyer une action réelle si l'utilisateur valide seulement une intention vague (« fais-le » après plusieurs propositions ambiguës, par exemple).
 
@@ -38,13 +42,23 @@ Ces champs sont toujours présents sous forme de tableaux pour `commandsSent`, `
 
 ## Exemples complets
 
-Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, lecture de la preview, puis exécution réelle uniquement après confirmation explicite.
+Les exemples ci-dessous suivent le même cycle : readiness obligatoire, audit des capacités, dry-run, lecture de la preview, puis exécution réelle uniquement après confirmation explicite.
 
 ### 1. Programmer une cue
 
 **Intention utilisateur :** « Programme trois cues reggae sur la liste 3 : intro ambre, couplet bleu, refrain blanc full. »
 
-**Étape A — audit obligatoire**
+**Étape A — readiness obligatoire**
+
+```json
+{
+  "type": "call_tool",
+  "tool": "eos_readiness_check",
+  "arguments": {}
+}
+```
+
+**Étape B — audit des capacités**
 
 ```json
 {
@@ -54,7 +68,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape B — dry-run du workflow recommandé**
+**Étape C — dry-run du workflow recommandé**
 
 ```json
 {
@@ -94,7 +108,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 - `structuredContent.applied_defaults` : signaler les valeurs par défaut appliquées.
 - `structuredContent.warnings` : résoudre tout avertissement avant de poursuivre.
 
-**Étape C — exécution après confirmation explicite**
+**Étape D — exécution après confirmation explicite**
 
 ```json
 {
@@ -132,7 +146,17 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 
 **Intention utilisateur :** « Top GO sur la liste 1, avec rattrapage si problème. »
 
-**Étape A — audit obligatoire**
+**Étape A — readiness obligatoire**
+
+```json
+{
+  "type": "call_tool",
+  "tool": "eos_readiness_check",
+  "arguments": {}
+}
+```
+
+**Étape B — audit des capacités**
 
 ```json
 {
@@ -142,7 +166,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape B — lecture de contexte utile**
+**Étape C — lecture de contexte utile**
 
 ```json
 {
@@ -160,7 +184,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape C — dry-run du GO sécurisé**
+**Étape D — dry-run du GO sécurisé**
 
 ```json
 {
@@ -178,7 +202,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape D — exécution après confirmation de régie**
+**Étape E — exécution après confirmation de régie**
 
 ```json
 {
@@ -215,7 +239,17 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 
 **Intention utilisateur :** « Patche le canal 305 en Lustr3 à l'adresse 2/145, label Face Jardin. »
 
-**Étape A — audit obligatoire**
+**Étape A — readiness obligatoire**
+
+```json
+{
+  "type": "call_tool",
+  "tool": "eos_readiness_check",
+  "arguments": {}
+}
+```
+
+**Étape B — audit des capacités**
 
 ```json
 {
@@ -225,7 +259,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape B — lire l'état actuel pour éviter d'écraser un patch critique**
+**Étape C — lire l'état actuel pour éviter d'écraser un patch critique**
 
 ```json
 {
@@ -237,7 +271,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape C — dry-run du patch fixture**
+**Étape D — dry-run du patch fixture**
 
 ```json
 {
@@ -257,7 +291,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape D — exécution après validation du patch précédent et de la preview**
+**Étape E — exécution après validation du patch précédent et de la preview**
 
 ```json
 {
@@ -277,7 +311,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape E — vérification post-patch**
+**Étape F — vérification post-patch**
 
 ```json
 {
@@ -293,7 +327,17 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 
 **Intention utilisateur :** « Vérifie le show chargé puis sauvegarde si tout est bon. »
 
-**Étape A — audit obligatoire**
+**Étape A — readiness obligatoire**
+
+```json
+{
+  "type": "call_tool",
+  "tool": "eos_readiness_check",
+  "arguments": {}
+}
+```
+
+**Étape B — audit des capacités**
 
 ```json
 {
@@ -303,7 +347,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape B — vérifications non destructives**
+**Étape C — vérifications non destructives**
 
 ```json
 {
@@ -329,7 +373,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape C — dry-run de la sauvegarde par commande texte, seulement si aucun outil dédié n'est disponible**
+**Étape D — dry-run de la sauvegarde par commande texte, seulement si aucun outil dédié n'est disponible**
 
 ```json
 {
@@ -345,7 +389,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape D — exécution après confirmation explicite de l'opérateur**
+**Étape E — exécution après confirmation explicite de l'opérateur**
 
 ```json
 {
@@ -369,7 +413,17 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 
 **Intention utilisateur :** « Dis-moi où est patché le canal 42 et vérifie l'adresse DMX 1/42. »
 
-**Étape A — audit obligatoire**
+**Étape A — readiness obligatoire**
+
+```json
+{
+  "type": "call_tool",
+  "tool": "eos_readiness_check",
+  "arguments": {}
+}
+```
+
+**Étape B — audit des capacités**
 
 ```json
 {
@@ -379,7 +433,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape B — lire le patch du canal**
+**Étape C — lire le patch du canal**
 
 ```json
 {
@@ -391,7 +445,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape C — lire les informations de canal utiles au diagnostic**
+**Étape D — lire les informations de canal utiles au diagnostic**
 
 ```json
 {
@@ -403,7 +457,7 @@ Les exemples ci-dessous suivent le même cycle : audit des capacités, dry-run, 
 }
 ```
 
-**Étape D — sélectionner ou tester une adresse DMX sans changer le show**
+**Étape E — sélectionner ou tester une adresse DMX sans changer le show**
 
 ```json
 {

--- a/docs/osc-coverage.md
+++ b/docs/osc-coverage.md
@@ -37,6 +37,7 @@ Les contrats centralisés sont vérifiés dans `src/tools/__tests__/osc_contract
 | groups | `eos_group_get_info` | `/eos/get/group` | `src/tools/__tests__/osc_contracts.test.ts` |
 | groups | `eos_group_list_all` | `/eos/get/group/list` | `src/tools/__tests__/osc_contracts.test.ts` |
 | diagnostics | `eos_enable_logging` | — | — (outil non OSC ou orchestrateur) |
+| diagnostics | `eos_readiness_check` | — | — (outil non OSC ou orchestrateur) |
 | diagnostics | `eos_get_diagnostics` | — | — (outil non OSC ou orchestrateur) |
 | diagnostics | `eos_get_version` | — | — (outil non OSC ou orchestrateur) |
 | diagnostics | `eos_get_setup_defaults` | — | — (outil non OSC ou orchestrateur) |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -310,7 +310,7 @@ Les payloads ci-dessous utilisent le format MCP `tools/call` complet. Les exempl
 
 Les champs `category`, `synonyms`, `riskLevel`, `requiresConfirmation` et `preferredWorkflow` sont publiés dans `config.annotations` pour les clients MCP et repris ci-dessous pour guider le routage LLM.
 
-Catégories documentées : `commands`, `cues`, `dmx`, `keys`, `macros`, `palettes`, `patch`, `presets`, `showControl`.
+Catégories documentées : `commands`, `cues`, `diagnostics`, `dmx`, `keys`, `macros`, `palettes`, `patch`, `presets`, `showControl`.
 
 <a id="eos-address-select"></a>
 ## Selection d'adresse DMX (`eos_address_select`)
@@ -3375,6 +3375,48 @@ _OSC_
 # Exemple d'envoi OSC via oscsend
 oscsend 127.0.0.1 8001 /eos/preset s:'{"preset_number":1}'
 ```
+
+<a id="eos-readiness-check"></a>
+## Verification de readiness EOS (`eos_readiness_check`)
+
+**Description :** Premiere etape obligatoire: controle read-only du transport OSC, du handshake et des lectures JSON EOS.
+
+**Métadonnées :**
+
+| Champ | Valeur |
+| --- | --- |
+| Catégorie | `diagnostics` |
+| Niveau de risque | `low` |
+| Workflow préféré | `first_step` |
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `countTarget` | enum(cue, group, preset) | Non | — |
+| `handshakeTimeoutMs` | number | Non | — |
+| `patchChannel` | number | Non | — |
+| `patchPart` | number | Non | — |
+| `protocolTimeoutMs` | number | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+| `transportPreference` | enum(reliability, speed, auto) | Non | — |
+| `user` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_readiness_check --args '{"timeoutMs":1}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
 
 <a id="eos-reset"></a>
 ## Reset OSC EOS (`eos_reset`)

--- a/src/tools/__tests__/__snapshots__/osc_contracts.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/osc_contracts.test.ts.snap
@@ -900,6 +900,7 @@ exports[`OSC tool contracts exported from src/tools/index.ts lists every tool ex
   "eos_group_get_info",
   "eos_group_list_all",
   "eos_enable_logging",
+  "eos_readiness_check",
   "eos_get_diagnostics",
   "eos_get_version",
   "eos_get_setup_defaults",

--- a/src/tools/diagnostics/index.ts
+++ b/src/tools/diagnostics/index.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { getResourceCache, type CacheStatsByResource } from '../../services/cache/index';
 import { getOscClient } from '../../services/osc/client';
 import type { OscDiagnostics, OscLoggingState } from '../../services/osc/index';
-import { oscMappings } from '../../services/osc/mappings';
+import { oscMappings, oscResponseMappings, withEosOutResponseVariant } from '../../services/osc/mappings';
 import { optionalPortSchema, optionalTimeoutMsSchema } from '../../utils/validators';
 import type { ToolDefinition, ToolExecutionResult } from '../types';
 
@@ -26,6 +26,88 @@ const systemQueryInputSchema = {
   timeoutMs: optionalTimeoutMsSchema,
   ...targetOptionsSchema
 } as const;
+
+const readinessInputSchema = {
+  timeoutMs: optionalTimeoutMsSchema,
+  handshakeTimeoutMs: optionalTimeoutMsSchema,
+  protocolTimeoutMs: optionalTimeoutMsSchema,
+  targetAddress: z.string().min(1).optional(),
+  targetPort: optionalPortSchema,
+  transportPreference: z.enum(['reliability', 'speed', 'auto']).optional(),
+  user: z.coerce.number().int().min(0).max(999).optional(),
+  countTarget: z.enum(['cue', 'group', 'preset']).optional(),
+  patchChannel: z.coerce.number().int().min(1).max(99999).optional(),
+  patchPart: z.coerce.number().int().min(0).max(99).optional()
+} as const;
+
+interface ReadinessCheck {
+  name: string;
+  status: string;
+  details?: Record<string, unknown>;
+  error?: string | null;
+}
+
+const isOkStatus = (status: unknown): boolean => status === 'ok';
+
+const recordFailedCheck = (checks: ReadinessCheck[]): string[] => checks
+  .filter((check) => !isOkStatus(check.status) && check.status !== 'skipped')
+  .map((check) => check.name);
+
+const getReadinessOperatorActions = (
+  failedChecks: string[],
+  handshakeMode: string,
+  jsonReadSupported: boolean
+): string[] => {
+  const actions: string[] = [];
+
+  if (failedChecks.includes('ping')) {
+    actions.push('Verifier l adresse IP, le port OSC, le reseau et l activation OSC RX/TX sur EOS.');
+  }
+
+  if (failedChecks.includes('handshake') || handshakeMode === 'timeout') {
+    actions.push('Relancer eos_configure/eos_connect avec la cible correcte puis verifier que la console EOS accepte le handshake OSC.');
+  }
+
+  if (!jsonReadSupported) {
+    actions.push('Confirmer le support des requetes /eos/get/*: privilegier un transport fiable, activer les reponses OSC et ne pas inventer de patch/cues sans lecture explicite.');
+  }
+
+  if (failedChecks.includes('patch_read')) {
+    actions.push('Si la lecture patch est necessaire, fournir un canal patche valide via patchChannel ou verifier que le canal existe dans le show.');
+  }
+
+  if (actions.length === 0) {
+    actions.push('Readiness validee: continuer avec les outils de lecture ou de workflow adaptes.');
+  }
+
+  return actions;
+};
+
+const normaliseReadinessCountTarget = (target: 'cue' | 'group' | 'preset' | undefined) => target ?? 'cue';
+
+const getCountAddress = (target: 'cue' | 'group' | 'preset'): string => {
+  switch (target) {
+    case 'group':
+      return oscMappings.queries.group.count;
+    case 'preset':
+      return oscMappings.queries.preset.count;
+    case 'cue':
+    default:
+      return oscMappings.queries.cue.count;
+  }
+};
+
+const getCountResponseAddresses = (target: 'cue' | 'group' | 'preset'): readonly string[] => {
+  switch (target) {
+    case 'group':
+      return oscResponseMappings.queries.group.count;
+    case 'preset':
+      return oscResponseMappings.queries.preset.count;
+    case 'cue':
+    default:
+      return oscResponseMappings.queries.cue.count;
+  }
+};
 
 const formatLoggingState = (state: OscLoggingState): string => {
   const lines = [
@@ -184,6 +266,229 @@ export const eosEnableLoggingTool: ToolDefinition<typeof loggingInputSchema> = {
 };
 
 /**
+ * @tool eos_readiness_check
+ * @summary Verification de readiness EOS
+ * @description Premiere etape obligatoire: controle read-only du transport OSC, du handshake et des lectures JSON EOS.
+ * @arguments Voir docs/tools.md#eos-readiness-check pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-readiness-check pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-readiness-check pour un exemple OSC.
+ */
+export const eosReadinessCheckTool: ToolDefinition<typeof readinessInputSchema> = {
+  name: 'eos_readiness_check',
+  config: {
+    title: 'Verification de readiness EOS',
+    description: 'Premiere etape obligatoire: controle read-only du transport OSC, du handshake et des lectures JSON EOS.',
+    inputSchema: readinessInputSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false
+    }
+  },
+  metadata: {
+    category: 'diagnostics',
+    riskLevel: 'low',
+    preferredWorkflow: 'first_step'
+  },
+  handler: async (args, _extra) => {
+    const schema = z.object(readinessInputSchema).strict();
+    const options = schema.parse(args ?? {});
+    const client = getOscClient();
+    const target = extractTargetOptions(options);
+    const timeoutMs = options.timeoutMs;
+    const checks: ReadinessCheck[] = [];
+
+    const ping = await client.ping({
+      ...target,
+      timeoutMs,
+      toolId: 'eos_readiness_check',
+      transportPreference: options.transportPreference
+    });
+    checks.push({
+      name: 'ping',
+      status: ping.status,
+      details: {
+        roundtripMs: ping.roundtripMs,
+        echo: ping.echo
+      },
+      error: ping.error ?? null
+    });
+
+    const handshake = await client.connect({
+      ...target,
+      handshakeTimeoutMs: options.handshakeTimeoutMs,
+      protocolTimeoutMs: options.protocolTimeoutMs,
+      toolId: 'eos_readiness_check',
+      transportPreference: options.transportPreference
+    });
+    checks.push({
+      name: 'handshake',
+      status: handshake.status,
+      details: {
+        handshake_mode: handshake.handshake_mode,
+        selectedProtocol: handshake.selectedProtocol,
+        protocolStatus: handshake.protocolStatus,
+        can_send_commands: handshake.can_send_commands,
+        can_read_queries: handshake.can_read_queries
+      },
+      error: handshake.error ?? null
+    });
+
+    const version = await client.requestJson(oscMappings.system.getVersion, {
+      ...target,
+      timeoutMs,
+      bypassReadCapabilityCheck: true,
+      responseAddresses: withEosOutResponseVariant(oscMappings.system.getVersion),
+      transportPreference: options.transportPreference
+    });
+    checks.push({
+      name: 'version',
+      status: version.status,
+      details: {
+        version: normaliseString(version.data),
+        diagnostics: version.diagnostics ?? null
+      },
+      error: version.error ?? null
+    });
+
+    const commandLine = await client.getCommandLine({
+      ...target,
+      user: options.user,
+      timeoutMs,
+      toolId: 'eos_readiness_check',
+      transportPreference: options.transportPreference
+    });
+    checks.push({
+      name: 'command_line_get',
+      status: commandLine.status,
+      details: {
+        user: commandLine.user,
+        text: commandLine.text
+      },
+      error: commandLine.error ?? null
+    });
+
+    const showName = await client.requestJson(oscMappings.showControl.showName, {
+      ...target,
+      timeoutMs,
+      bypassReadCapabilityCheck: true,
+      responseAddresses: withEosOutResponseVariant(oscMappings.showControl.showName),
+      transportPreference: options.transportPreference
+    });
+    checks.push({
+      name: 'show_name',
+      status: showName.status,
+      details: {
+        show_name: normaliseString(showName.data),
+        diagnostics: showName.diagnostics ?? null
+      },
+      error: showName.error ?? null
+    });
+
+    const countTarget = normaliseReadinessCountTarget(options.countTarget);
+    const count = await client.requestJson(getCountAddress(countTarget), {
+      ...target,
+      timeoutMs,
+      bypassReadCapabilityCheck: true,
+      responseAddresses: getCountResponseAddresses(countTarget),
+      transportPreference: options.transportPreference
+    });
+    checks.push({
+      name: 'count',
+      status: count.status,
+      details: {
+        target: countTarget,
+        data: count.data,
+        diagnostics: count.diagnostics ?? null
+      },
+      error: count.error ?? null
+    });
+
+    if (typeof options.patchChannel === 'number') {
+      const patchPayload = {
+        channel: options.patchChannel,
+        part: options.patchPart ?? 0
+      };
+      const patchRead = await client.requestJson(oscMappings.patch.channelInfo, {
+        ...target,
+        payload: patchPayload,
+        timeoutMs,
+        bypassReadCapabilityCheck: true,
+        responseAddresses: oscResponseMappings.patch.channelInfo,
+        transportPreference: options.transportPreference
+      });
+      checks.push({
+        name: 'patch_read',
+        status: patchRead.status,
+        details: {
+          channel: options.patchChannel,
+          part: options.patchPart ?? 0,
+          data: patchRead.data,
+          diagnostics: patchRead.diagnostics ?? null
+        },
+        error: patchRead.error ?? null
+      });
+    } else {
+      checks.push({
+        name: 'patch_read',
+        status: 'skipped',
+        details: {
+          reason: 'Aucun patchChannel fourni; lecture patch optionnelle non executee.'
+        },
+        error: null
+      });
+    }
+
+    const failedChecks = recordFailedCheck(checks);
+    const jsonReadSupported = ['version', 'show_name', 'count']
+      .every((name) => checks.some((check) => check.name === name && check.status === 'ok'));
+    const transportStatus = ping.status === 'ok' && handshake.status === 'ok'
+      ? 'ok'
+      : ping.status === 'ok' || handshake.can_send_commands
+        ? 'degraded'
+        : 'error';
+    const overallStatus = failedChecks.length === 0
+      ? 'ok'
+      : transportStatus === 'error'
+        ? 'error'
+        : 'degraded';
+    const operatorActions = getReadinessOperatorActions(failedChecks, handshake.handshake_mode, jsonReadSupported);
+
+    const text = [
+      `Readiness EOS: ${overallStatus}`,
+      `Transport: ${transportStatus}`,
+      `Handshake: ${handshake.handshake_mode}`,
+      `Lecture JSON: ${jsonReadSupported ? 'supportee' : 'non confirmee'}`,
+      `Echecs: ${failedChecks.length > 0 ? failedChecks.join(', ') : 'aucun'}`
+    ].join('\n');
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text
+        }
+      ],
+      structuredContent: {
+        status: overallStatus,
+        overall_status: overallStatus,
+        transport_status: transportStatus,
+        handshake_mode: handshake.handshake_mode,
+        json_read_supported: jsonReadSupported,
+        failed_checks: failedChecks,
+        operator_actions: operatorActions,
+        checks,
+        summary: text,
+        commandsSent: [],
+        commands_preview: [],
+        warnings: [],
+        next_actions: operatorActions
+      }
+    } as unknown as ToolExecutionResult;
+  }
+};
+
+/**
  * @tool eos_get_diagnostics
  * @summary Diagnostics OSC
  * @description Recupere les informations de diagnostic du service OSC.
@@ -319,6 +624,7 @@ export const eosGetSetupDefaultsTool: ToolDefinition<typeof systemQueryInputSche
 
 const diagnosticsTools: ToolDefinition[] = [
   eosEnableLoggingTool,
+  eosReadinessCheckTool,
   eosGetDiagnosticsTool,
   eosGetVersionTool,
   eosGetSetupDefaultsTool


### PR DESCRIPTION
### Motivation
- Provide a single read-only readiness probe that LLM agents must call before doing any show-reading or write workflows to ensure OSC transport, handshake and JSON-read capabilities are validated. 
- Reduce accidental guessing of show state when JSON reads are not supported by making a clear, machine-readable readiness summary available.

### Description
- Add `eos_readiness_check` in `src/tools/diagnostics/index.ts` that performs a read-only sequence: `ping`, `connect`/handshake, `requestJson` for version, `getCommandLine`, `requestJson` for show name, a simple `count` query (configurable target), and an optional patch read when `patchChannel` is provided; it records per-check details and failures. 
- The tool returns `structuredContent` containing `overall_status`, `transport_status`, `handshake_mode`, `json_read_supported`, `failed_checks`, `operator_actions` and a `checks` array with detailed diagnostics. 
- Register the tool in the diagnostics tool list so it is exported with the other diagnostics tools. 
- Document usage as the mandatory first LLM step in `docs/llm-agent-guide.md` and add references in `README.md`, `docs/tools.md` and `docs/osc-coverage.md`; regenerate the tools reference and update the test snapshot used by the OSC contracts test.

### Testing
- TypeScript compile: `npm run tsc` — succeeded. 
- Documentation generation / validation: `npm run docs:generate` and `npm run docs:check` — succeeded. 
- Lint and manifest check: `npm run lint` and `npm run lint:manifest` — succeeded. 
- Targeted tests: ran `npx jest --passWithNoTests src/tools/__tests__/osc_contracts.test.ts -u --runInBand` (updated snapshot) — succeeded. 
- Full unit test run via the project `npm test` invoked the whole suite; during that run unrelated pre-existing suites produced failures (showControl, effects, magicSheets, osc_payloads) while the targeted OSC contracts expectations were updated and passed; these unrelated failures are not caused by the readiness tool itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077ad235e0832ab81b8864dfc8c4c9)