### PR TITLE
Add eos_workflow_patch_scan workflow and factor patch read helper

### DIFF
--- a/docs/osc-coverage.md
+++ b/docs/osc-coverage.md
@@ -17,6 +17,7 @@ Les contrats centralisés sont vérifiés dans `src/tools/__tests__/osc_contract
 | workflows | `eos_workflow_create_effect` | — | — (outil non OSC ou orchestrateur) |
 | workflows | `eos_workflow_create_cue_series` | — | — (outil non OSC ou orchestrateur) |
 | workflows | `eos_workflow_patch_fixture` | — | — (outil non OSC ou orchestrateur) |
+| workflows | `eos_workflow_patch_scan` | — | — (outil non OSC ou orchestrateur) |
 | workflows | `eos_workflow_autopatch_band` | — | — (outil non OSC ou orchestrateur) |
 | workflows | `eos_workflow_rehearsal_go_safe` | — | — (outil non OSC ou orchestrateur) |
 | workflows | `eos_workflow_build_groups_and_palettes` | — | — (outil non OSC ou orchestrateur) |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -82,6 +82,7 @@ Workflows tolerants recenses :
 - `eos_workflow_create_effect`
 - `eos_workflow_create_look`
 - `eos_workflow_patch_fixture`
+- `eos_workflow_patch_scan`
 - `eos_workflow_rehearsal_go_safe`
 - `eos_workflow_update_cue_look`
 
@@ -4246,6 +4247,42 @@ _CLI_
 
 ```bash
 npx @modelcontextprotocol/cli call --tool eos_workflow_patch_fixture --args '{"channel_number":1,"dmx_address":"exemple","label":"exemple"}'
+```
+
+_OSC_
+
+_Pas de mapping OSC documenté._
+
+<a id="eos-workflow-patch-scan"></a>
+## Scanner le patch de plusieurs canaux (`eos_workflow_patch_scan`)
+
+**Description :** Lit les informations de patch canal par canal avec concurrence basse, pause entre requetes et arret de securite sur taux d echec configurable.
+
+**Arguments :**
+
+| Nom | Type | Requis | Description |
+| --- | --- | --- | --- |
+| `channels` | array<number> | Non | — |
+| `continue_on_error` | boolean | Non | — |
+| `dry_run` | boolean | Non | — |
+| `end_channel` | number | Non | — |
+| `failure_rate_threshold` | number | Non | — |
+| `max_concurrency` | number | Non | — |
+| `part_mode` | enum(all, part_1) | Non | — |
+| `rate_limit_ms` | number | Non | — |
+| `start_channel` | number | Non | — |
+| `targetAddress` | string | Non | — |
+| `targetPort` | number | Non | — |
+| `timeoutMs` | number | Non | — |
+
+**Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
+
+**Exemples :**
+
+_CLI_
+
+```bash
+npx @modelcontextprotocol/cli call --tool eos_workflow_patch_scan --args '{"start_channel":1}'
 ```
 
 _OSC_

--- a/manifest.json
+++ b/manifest.json
@@ -93,6 +93,7 @@
           "eos_workflow_create_effect",
           "eos_workflow_create_look",
           "eos_workflow_patch_fixture",
+          "eos_workflow_patch_scan",
           "eos_workflow_rehearsal_go_safe"
         ]
       }

--- a/src/tools/__tests__/__snapshots__/osc_contracts.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/osc_contracts.test.ts.snap
@@ -880,6 +880,7 @@ exports[`OSC tool contracts exported from src/tools/index.ts lists every tool ex
   "eos_workflow_create_effect",
   "eos_workflow_create_cue_series",
   "eos_workflow_patch_fixture",
+  "eos_workflow_patch_scan",
   "eos_workflow_autopatch_band",
   "eos_workflow_rehearsal_go_safe",
   "eos_workflow_build_groups_and_palettes",

--- a/src/tools/patch/index.ts
+++ b/src/tools/patch/index.ts
@@ -43,7 +43,7 @@ const partNumberWithAllSchema = z.coerce
   .max(99)
   .describe('Numero de partie (0 = toutes les parties, 1-99).');
 
-interface PatchChannelTextFields {
+export interface PatchChannelTextFields {
   text1: string | null;
   text2: string | null;
   text3: string | null;
@@ -71,7 +71,7 @@ const TEXT_KEYS = [
 
 type PatchChannelTextKey = (typeof TEXT_KEYS)[number];
 
-interface PatchChannelPartInfo {
+export interface PatchChannelPartInfo {
   part_number: number;
   label: string | null;
   manufacturer: string | null;
@@ -82,7 +82,7 @@ interface PatchChannelPartInfo {
   notes: string | null;
 }
 
-interface PatchChannelInfo {
+export interface PatchChannelInfo {
   channel_number: number;
   label: string | null;
   part_count: number | null;
@@ -182,15 +182,15 @@ function annotate(osc: string): Record<string, unknown> {
 
 const OSC_CONSOLE_CHECK_MESSAGE = 'Vérifiez côté console: OSC RX activé, OSC TX activé, IP TX vers le serveur MCP, ports UDP 8000/8001 ou TCP 3032 cohérents.';
 
-function shouldExposeOscDiagnostics(response: OscJsonResponse): boolean {
+function shouldExposeOscDiagnostics(response: Pick<OscJsonResponse, 'status'>): boolean {
   return response.status === 'timeout' || response.status === 'error';
 }
 
-function appendConsoleCheck(text: string, response: OscJsonResponse): string {
+function appendConsoleCheck(text: string, response: Pick<OscJsonResponse, 'status'>): string {
   return shouldExposeOscDiagnostics(response) ? `${text} ${OSC_CONSOLE_CHECK_MESSAGE}` : text;
 }
 
-function withOscDiagnostics(response: OscJsonResponse): Record<string, unknown> {
+function withOscDiagnostics(response: Pick<OscJsonResponse, 'status' | 'diagnostics'>): Record<string, unknown> {
   return shouldExposeOscDiagnostics(response) && response.diagnostics
     ? { diagnostics: response.diagnostics }
     : {};
@@ -669,6 +669,87 @@ const channelInfoInputSchema = {
   ...targetOptionsSchema
 } satisfies ZodRawShape;
 
+export interface ReadPatchChannelInfoOptions {
+  channel_number: number;
+  part_number?: number;
+  timeoutMs?: number;
+  targetAddress?: string;
+  targetPort?: number;
+}
+
+export interface ReadPatchChannelInfoResult {
+  status: OscJsonResponse['status'];
+  channel: PatchChannelInfo;
+  error?: string;
+  diagnostics?: OscJsonResponse['diagnostics'];
+  osc: {
+    address: string;
+    args: {
+      channel: number;
+      part: number;
+    };
+  };
+}
+
+export async function readPatchChannelInfo(options: ReadPatchChannelInfoOptions): Promise<ReadPatchChannelInfoResult> {
+  const client = getOscClient();
+  const payload = {
+    channel: options.channel_number,
+    part: options.part_number ?? 0
+  };
+  const cacheKey = createCacheKey({
+    address: oscMappings.patch.channelInfo,
+    payload,
+    targetAddress: options.targetAddress,
+    targetPort: options.targetPort
+  });
+  const cache = getResourceCache();
+
+  return cache.fetch<ReadPatchChannelInfoResult>({
+    resourceType: 'patch',
+    key: cacheKey,
+    tags: [
+      createResourceTag('patch'),
+      createResourceTag('patch', `channel:${options.channel_number}`)
+    ],
+    prefixTags: [createOscPrefixTag('/eos/out/')],
+    fetcher: async () => {
+      const response: OscJsonResponse = await client.requestJson(oscMappings.patch.channelInfo, {
+        payload,
+        timeoutMs: options.timeoutMs,
+        targetAddress: options.targetAddress,
+        targetPort: options.targetPort,
+        responseAddresses: oscResponseMappings.patch.channelInfo
+      });
+
+      const responseRecord = response.data && typeof response.data === 'object' && !Array.isArray(response.data)
+        ? response.data as Record<string, unknown>
+        : null;
+      const channelPayload = responseRecord?.channel && typeof responseRecord.channel === 'object'
+        ? responseRecord.channel
+        : response.data;
+      const channelData = normaliseChannelInfo(
+        channelPayload,
+        options.channel_number,
+        options.part_number ?? null
+      );
+
+      const validatedChannel = patchChannelInfoOutputSchema.parse(channelData);
+
+      return {
+        status: response.status,
+        ...(response.error ? { error: response.error } : {}),
+        ...withOscDiagnostics(response),
+        channel: validatedChannel,
+        osc: {
+          address: oscMappings.patch.channelInfo,
+          args: payload
+        }
+      };
+    }
+  });
+}
+
 const augment3dInputSchema = {
   channel_number: channelNumberSchema,
   part_number: partNumberSchema,
@@ -697,7 +778,6 @@ export const eosPatchGetChannelInfoTool: ToolDefinition<typeof channelInfoInputS
   handler: async (args, _extra) => {
     const schema = z.object(channelInfoInputSchema).strict();
     const options = schema.parse(args ?? {});
-    const client = getOscClient();
     const payload = {
       channel: options.channel_number,
       part: options.part_number ?? 0
@@ -714,60 +794,18 @@ export const eosPatchGetChannelInfoTool: ToolDefinition<typeof channelInfoInputS
       });
     }
 
-    const cacheKey = createCacheKey({
-      address: oscMappings.patch.channelInfo,
-      payload,
-      targetAddress: options.targetAddress,
-      targetPort: options.targetPort
-    });
-    const cache = getResourceCache();
+    const result = await readPatchChannelInfo(options);
+    const baseText =
+      result.status === 'ok'
+        ? `Informations recues pour le canal ${result.channel.channel_number}.`
+        : `Lecture des informations du canal ${result.channel.channel_number} terminee avec le statut ${result.status}.`;
 
-    return cache.fetch<ToolExecutionResult>({
-      resourceType: 'patch',
-      key: cacheKey,
-      tags: [
-        createResourceTag('patch'),
-        createResourceTag('patch', `channel:${options.channel_number}`)
-      ],
-      prefixTags: [createOscPrefixTag('/eos/out/')],
-      fetcher: async () => {
-        const response: OscJsonResponse = await client.requestJson(oscMappings.patch.channelInfo, {
-          payload,
-          timeoutMs: options.timeoutMs,
-          targetAddress: options.targetAddress,
-          targetPort: options.targetPort,
-          responseAddresses: oscResponseMappings.patch.channelInfo
-        });
-
-        const responseRecord = response.data && typeof response.data === 'object' && !Array.isArray(response.data)
-          ? response.data as Record<string, unknown>
-          : null;
-        const channelPayload = responseRecord?.channel && typeof responseRecord.channel === 'object'
-          ? responseRecord.channel
-          : response.data;
-        const channelData = normaliseChannelInfo(
-          channelPayload,
-          options.channel_number,
-          options.part_number ?? null
-        );
-
-        const validatedChannel = patchChannelInfoOutputSchema.parse(channelData);
-
-        const baseText =
-          response.status === 'ok'
-            ? `Informations recues pour le canal ${validatedChannel.channel_number}.`
-            : `Lecture des informations du canal ${validatedChannel.channel_number} terminee avec le statut ${response.status}.`;
-
-        return createResult(appendConsoleCheck(baseText, response), {
-          status: response.status,
-          ...withOscDiagnostics(response),
-          channel: validatedChannel,
-          osc: {
-            address: oscMappings.patch.channelInfo,
-            args: payload
-          }
-        });
-      }
+    return createResult(appendConsoleCheck(baseText, result), {
+      status: result.status,
+      ...(result.error ? { error: result.error } : {}),
+      ...(result.diagnostics ? { diagnostics: result.diagnostics } : {}),
+      channel: result.channel,
+      osc: result.osc
     });
   }
 };

--- a/src/tools/workflows/__tests__/workflows.test.ts
+++ b/src/tools/workflows/__tests__/workflows.test.ts
@@ -13,6 +13,7 @@ import {
   eosWorkflowCreateCueSeriesTool,
   eosWorkflowAutopatchBandTool,
   eosWorkflowPatchFixtureTool,
+  eosWorkflowPatchScanTool,
   eosWorkflowRehearsalGoSafeTool,
   eosWorkflowBuildGroupsAndPalettesTool,
   eosWorkflowUpdateCueLookTool
@@ -29,6 +30,8 @@ class FakeOscService implements OscGateway {
   public omitRecordedCuesFromVerification = false;
 
   public consoleErrorOnCueList = false;
+
+  public patchReadErrors = new Set<number>();
 
   private readonly recordedCues: Array<{ cuelist: number | null; cue: string }> = [];
 
@@ -57,6 +60,32 @@ class FakeOscService implements OscGateway {
       const reply: OscMessage = {
         address: '/eos/get/cuelist',
         args: [{ type: 's', value: JSON.stringify(payload) }]
+      };
+      queueMicrotask(() => {
+        for (const listener of this.listeners) {
+          listener(reply);
+        }
+      });
+    }
+
+
+    if (message.address === '/eos/get/patch/chan_info') {
+      const rawPayload = message.args?.[0]?.value;
+      const payload = typeof rawPayload === 'string' ? JSON.parse(rawPayload) as { channel?: number; part?: number } : {};
+      const channel = Number(payload.channel ?? 0);
+      const responsePayload = this.patchReadErrors.has(channel)
+        ? { status: 'error', error: `Erreur patch simulee canal ${channel}` }
+        : {
+            channel: {
+              channel_number: channel,
+              label: `Fixture ${channel}`,
+              part_count: 1,
+              parts: [{ part_number: Number(payload.part ?? 0) || 1, label: `Fixture ${channel}`, manufacturer: 'ETC', model: 'Source Four', dmx_address: `1/${channel}` }]
+            }
+          };
+      const reply: OscMessage = {
+        address: '/eos/out/get/patch/chan_info',
+        args: [{ type: 's', value: JSON.stringify(responsePayload) }]
       };
       queueMicrotask(() => {
         for (const listener of this.listeners) {
@@ -151,6 +180,47 @@ describe('workflow tools', () => {
     ]);
     expect(structured?.command_log).toEqual(expect.arrayContaining([
       expect.objectContaining({ step: 'select_channels', status: 'skipped', command: 'Chan 1 Thru 3' })
+    ]));
+  });
+
+  it('scanne le patch en dry_run sans envoyer de requete OSC', async () => {
+    const result = await runTool(eosWorkflowPatchScanTool, {
+      start_channel: 1,
+      end_channel: 3,
+      dry_run: true
+    });
+
+    expect(service.sentMessages).toHaveLength(0);
+    const structured = getStructuredContent(result);
+    expect(structured?.status).toBe('ok');
+    expect(structured?.channels).toEqual([1, 2, 3]);
+    expect(structured?.results).toEqual([
+      expect.objectContaining({ status: 'skipped', channel: { channel_number: 1 }, source: expect.objectContaining({ type: 'dry_run' }) }),
+      expect.objectContaining({ status: 'skipped', channel: { channel_number: 2 }, source: expect.objectContaining({ type: 'dry_run' }) }),
+      expect.objectContaining({ status: 'skipped', channel: { channel_number: 3 }, source: expect.objectContaining({ type: 'dry_run' }) })
+    ]);
+  });
+
+  it('scanne le patch avec garde-fous de concurrence et arret sur taux d echec', async () => {
+    service.patchReadErrors = new Set([2]);
+
+    const result = await runTool(eosWorkflowPatchScanTool, {
+      channels: [1, 2, 3],
+      max_concurrency: 1,
+      rate_limit_ms: 0,
+      failure_rate_threshold: 0.25
+    });
+
+    const structured = getStructuredContent(result);
+    expect(service.sentMessages.map((msg) => msg.address)).toEqual([
+      '/eos/get/patch/chan_info',
+      '/eos/get/patch/chan_info'
+    ]);
+    expect(structured?.status).toBe('partial_failure');
+    expect(structured?.scan).toEqual(expect.objectContaining({ processed: 2, failures: 1, aborted: true }));
+    expect(structured?.results).toEqual(expect.arrayContaining([
+      expect.objectContaining({ status: 'ok', channel: expect.objectContaining({ channel_number: 1 }), error: null }),
+      expect.objectContaining({ status: 'error', channel: expect.objectContaining({ channel_number: 2 }), error: 'Erreur patch simulee canal 2' })
     ]));
   });
 
@@ -373,6 +443,10 @@ describe('workflow tools', () => {
         }
       },
       {
+        tool: eosWorkflowPatchScanTool,
+        args: { channels: [1, 2], dry_run: true, client_trace_id: 'trace-patch-scan' }
+      },
+      {
         tool: eosWorkflowRehearsalGoSafeTool,
         args: { cuelist_number: 1, dry_run: true, client_trace_id: 'trace-rehearsal-go-safe' }
       },
@@ -448,6 +522,7 @@ describe('workflow tools', () => {
       eosWorkflowCreateEffectTool,
       eosWorkflowCreateCueSeriesTool,
       eosWorkflowPatchFixtureTool,
+      eosWorkflowPatchScanTool,
       eosWorkflowAutopatchBandTool,
       eosWorkflowRehearsalGoSafeTool,
       eosWorkflowBuildGroupsAndPalettesTool,

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -25,6 +25,8 @@ import {
   executePatchSequence,
   extractPatchSequenceError
 } from './patchSequence';
+import { eosWorkflowPatchScanTool } from './patchScan';
+export { eosWorkflowPatchScanTool } from './patchScan';
 
 const primaryWorkflowAnnotations = {
   recommended: true,
@@ -1333,6 +1335,7 @@ export const workflowTools = [
   eosWorkflowCreateEffectTool,
   eosWorkflowCreateCueSeriesTool,
   eosWorkflowPatchFixtureTool,
+  eosWorkflowPatchScanTool,
   eosWorkflowAutopatchBandTool,
   eosWorkflowRehearsalGoSafeTool,
   eosWorkflowBuildGroupsAndPalettesTool,

--- a/src/tools/workflows/patchScan.ts
+++ b/src/tools/workflows/patchScan.ts
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { z, type ZodRawShape } from 'zod';
+import { buildToolResult, type ToolDefinition } from '../types';
+import { readPatchChannelInfo, type PatchChannelInfo } from '../patch/index';
+
+const channelNumberSchema = z.coerce.number().int().min(1).max(99999);
+const timeoutSchema = z.coerce.number().int().min(50).optional();
+const partModeSchema = z.enum(['all', 'part_1']).optional().default('all');
+
+const patchScanInputSchema = {
+  start_channel: channelNumberSchema.optional(),
+  end_channel: channelNumberSchema.optional(),
+  channels: z.array(channelNumberSchema).min(1).max(1000).optional(),
+  part_mode: partModeSchema,
+  timeoutMs: timeoutSchema,
+  max_concurrency: z.coerce.number().int().min(1).max(5).optional().default(2),
+  rate_limit_ms: z.coerce.number().int().min(0).max(5000).optional().default(100),
+  continue_on_error: z.boolean().optional().default(true),
+  failure_rate_threshold: z.coerce.number().min(0).max(1).optional().default(0.5),
+  dry_run: z.boolean().optional().default(false),
+  targetAddress: z.string().min(1).optional(),
+  targetPort: z.coerce.number().int().min(1).max(65535).optional()
+} satisfies ZodRawShape;
+
+interface PatchScanItem {
+  status: string;
+  channel: PatchChannelInfo | { channel_number: number };
+  error: string | null;
+  diagnostics: unknown | null;
+  source: Record<string, unknown>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+}
+
+function uniqueSortedChannels(values: number[]): number[] {
+  return [...new Set(values)].sort((left, right) => left - right);
+}
+
+function resolveChannels(options: z.infer<z.ZodObject<typeof patchScanInputSchema>>): number[] {
+  if (options.channels != null) {
+    return uniqueSortedChannels(options.channels);
+  }
+
+  if (options.start_channel == null || options.end_channel == null) {
+    throw new Error('channels ou start_channel + end_channel sont requis.');
+  }
+
+  if (options.end_channel < options.start_channel) {
+    throw new Error('end_channel doit etre superieur ou egal a start_channel.');
+  }
+
+  const channels: number[] = [];
+  for (let channel = options.start_channel; channel <= options.end_channel; channel += 1) {
+    channels.push(channel);
+  }
+  return channels;
+}
+
+function partNumberFromMode(partMode: z.infer<typeof partModeSchema>): number {
+  return partMode === 'part_1' ? 1 : 0;
+}
+
+function shouldAbort(processed: number, failures: number, threshold: number): boolean {
+  return processed > 0 && failures / processed > threshold;
+}
+
+/**
+ * @tool eos_workflow_patch_scan
+ * @summary Scanner le patch de plusieurs canaux
+ * @description Lit les informations de patch canal par canal avec concurrence basse, pause entre requetes et arret de securite sur taux d echec configurable.
+ * @arguments Voir docs/tools.md#eos-workflow-patch-scan pour le schema complet.
+ * @returns ToolExecutionResult avec contenu texte et objet.
+ * @example CLI Consultez docs/tools.md#eos-workflow-patch-scan pour un exemple CLI.
+ * @example OSC Consultez docs/tools.md#eos-workflow-patch-scan pour un exemple OSC.
+ */
+export const eosWorkflowPatchScanTool: ToolDefinition<typeof patchScanInputSchema> = {
+  name: 'eos_workflow_patch_scan',
+  config: {
+    title: 'Scanner le patch de plusieurs canaux',
+    description: 'Lit les informations de patch canal par canal avec concurrence basse, pause entre requetes et arret de securite sur taux d echec configurable.',
+    inputSchema: patchScanInputSchema
+  },
+  handler: async (args) => {
+    const schema = z.object(patchScanInputSchema).passthrough();
+    const options = schema.parse(args ?? {});
+    const requestedChannels = resolveChannels(options);
+    const partNumber = partNumberFromMode(options.part_mode);
+    const results: PatchScanItem[] = [];
+    const errors: Array<{ channel_number: number; error: string }> = [];
+    let nextIndex = 0;
+    let processed = 0;
+    let failures = 0;
+    let aborted = false;
+    let abortReason: string | null = null;
+    let nextAllowedAt = 0;
+
+    const takeNext = (): number | null => {
+      if (aborted || nextIndex >= requestedChannels.length) {
+        return null;
+      }
+      const channel = requestedChannels[nextIndex];
+      nextIndex += 1;
+      return channel;
+    };
+
+    const waitForRateLimit = async (): Promise<void> => {
+      const now = Date.now();
+      const waitMs = Math.max(0, nextAllowedAt - now);
+      nextAllowedAt = Math.max(now, nextAllowedAt) + options.rate_limit_ms;
+      await sleep(waitMs);
+    };
+
+    if (options.dry_run) {
+      for (const channelNumber of requestedChannels) {
+        results.push({
+          status: 'skipped',
+          channel: { channel_number: channelNumber },
+          error: null,
+          diagnostics: null,
+          source: {
+            type: 'dry_run',
+            action: 'eos_patch_get_channel_info',
+            args: { channel: channelNumber, part: partNumber }
+          }
+        });
+      }
+
+      return buildToolResult({
+        text: `Dry run patch scan genere pour ${requestedChannels.length} canal(aux).`,
+        structuredContent: {
+          workflow: 'eos_workflow_patch_scan',
+          status: 'ok',
+          steps: results.map((entry) => ({ step: `scan_channel_${entry.channel.channel_number}`, status: entry.status, detail: 'dry_run' })),
+          executedSteps: results.map((entry) => ({ step: `scan_channel_${entry.channel.channel_number}`, status: entry.status, detail: 'dry_run' })),
+          applied_defaults: [],
+          warnings: [],
+          results,
+          channels: requestedChannels,
+          scan: {
+            requested: requestedChannels.length,
+            processed: 0,
+            failures: 0,
+            aborted: false,
+            max_concurrency: options.max_concurrency,
+            rate_limit_ms: options.rate_limit_ms,
+            failure_rate_threshold: options.failure_rate_threshold,
+            part_mode: options.part_mode
+          },
+          commands_preview: requestedChannels.map((channelNumber) => `eos_patch_get_channel_info channel=${channelNumber} part=${partNumber}`)
+        }
+      });
+    }
+
+    const worker = async (): Promise<void> => {
+      while (true) {
+        const channelNumber = takeNext();
+        if (channelNumber == null) {
+          return;
+        }
+
+        await waitForRateLimit();
+
+        try {
+          const info = await readPatchChannelInfo({
+            channel_number: channelNumber,
+            part_number: partNumber,
+            timeoutMs: options.timeoutMs,
+            targetAddress: options.targetAddress,
+            targetPort: options.targetPort
+          });
+          const ok = info.status === 'ok';
+          if (!ok) {
+            failures += 1;
+            errors.push({ channel_number: channelNumber, error: info.error ?? `status=${info.status}` });
+          }
+          results.push({
+            status: info.status,
+            channel: info.channel,
+            error: info.error ?? null,
+            diagnostics: info.diagnostics ?? null,
+            source: { type: 'osc', ...info.osc }
+          });
+        } catch (error) {
+          failures += 1;
+          const message = error instanceof Error ? error.message : String(error);
+          errors.push({ channel_number: channelNumber, error: message });
+          results.push({
+            status: 'error',
+            channel: { channel_number: channelNumber },
+            error: message,
+            diagnostics: null,
+            source: { type: 'exception', action: 'eos_patch_get_channel_info', args: { channel: channelNumber, part: partNumber } }
+          });
+        } finally {
+          processed += 1;
+          if (!options.continue_on_error && failures > 0) {
+            aborted = true;
+            abortReason = 'continue_on_error=false';
+          } else if (shouldAbort(processed, failures, options.failure_rate_threshold)) {
+            aborted = true;
+            abortReason = `failure_rate_threshold depasse (${failures}/${processed} > ${options.failure_rate_threshold})`;
+          }
+        }
+      }
+    };
+
+    const concurrency = Math.min(options.max_concurrency, requestedChannels.length);
+    await Promise.all(Array.from({ length: concurrency }, () => worker()));
+    results.sort((left, right) => (left.channel.channel_number ?? 0) - (right.channel.channel_number ?? 0));
+
+    const status = aborted ? 'partial_failure' : failures > 0 ? 'partial_failure' : 'ok';
+    return buildToolResult({
+      text: aborted
+        ? `Patch scan interrompu apres ${processed}/${requestedChannels.length} canal(aux): ${abortReason}.`
+        : `Patch scan termine pour ${processed}/${requestedChannels.length} canal(aux).`,
+      structuredContent: {
+        workflow: 'eos_workflow_patch_scan',
+        status,
+        steps: results.map((entry) => ({
+          step: `scan_channel_${entry.channel.channel_number}`,
+          status: entry.status === 'ok' ? 'ok' : 'error',
+          ...(entry.error ? { error: entry.error } : {})
+        })),
+        executedSteps: results.map((entry) => ({
+          step: `scan_channel_${entry.channel.channel_number}`,
+          status: entry.status === 'ok' ? 'ok' : 'error',
+          ...(entry.error ? { error: entry.error } : {})
+        })),
+        applied_defaults: [],
+        warnings: errors.map((entry) => ({ step: `scan_channel_${entry.channel_number}`, detail: entry.error })),
+        results,
+        channels: requestedChannels,
+        errors,
+        scan: {
+          requested: requestedChannels.length,
+          processed,
+          failures,
+          failure_rate: processed > 0 ? failures / processed : 0,
+          aborted,
+          abort_reason: abortReason,
+          max_concurrency: options.max_concurrency,
+          rate_limit_ms: options.rate_limit_ms,
+          failure_rate_threshold: options.failure_rate_threshold,
+          part_mode: options.part_mode
+        }
+      }
+    });
+  }
+};
+
+export default eosWorkflowPatchScanTool;


### PR DESCRIPTION
### Motivation

- Provide a safe, high-level workflow to read patch information across ranges or lists of channels with controlled concurrency, rate limiting and an abort-on-failure-rate safety mechanism. 
- Reuse existing patch read logic to avoid duplication and expose a programmatic helper for other tools.

### Description

- Add `src/tools/workflows/patchScan.ts` implementing `eos_workflow_patch_scan` with arguments `start_channel`, `end_channel`, `channels`, `part_mode`, `timeoutMs`, `max_concurrency`, `rate_limit_ms`, `continue_on_error`, `failure_rate_threshold` and `dry_run`, returning per-channel `status`, `channel`, `error`, `diagnostics` and `source` and providing default low concurrency, rate pause and failure-rate abort protection. 
- Factor patch read logic into `readPatchChannelInfo` and typed interfaces in `src/tools/patch/index.ts`, and make `eos_patch_get_channel_info` reuse this helper. 
- Register and export the new workflow in `src/tools/workflows/index.ts`, add unit tests in `src/tools/workflows/__tests__/workflows.test.ts`, update snapshots and OSC coverage (`src/tools/__tests__/__snapshots__/osc_contracts.test.ts.snap`, `docs/osc-coverage.md`), update docs (`docs/tools.md`) and add the workflow to `manifest.json` presentation order. 

### Testing

- Typecheck and static checks: ran `npm run tsc -- --noEmit`, `npm run lint`, `npm run docs:check` and `npm run lint:manifest` which succeeded. 
- Unit tests: added tests in `src/tools/workflows/__tests__/workflows.test.ts`; exercised targeted suites with `npx jest src/tools/workflows/__tests__/workflows.test.ts src/tools/__tests__/osc_contracts.test.ts --runInBand` which passed after updating contract snapshots and docs coverage. 
- Notes: an initial run of the full unit suite surfaced pre-existing snapshot/allowlist mismatches in unrelated tests; those were addressed by updating the coverage/docs/snapshots required for the new workflow, and the targeted workflow + contract tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077ca73678832a916ad3c87f94a174)