### PR TITLE
docs: add OSC Eos troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Formats à utiliser selon le langage :
 
 - [Cookbook d’automatisation](docs/cookbook.md) : scénarios prêts à l’emploi pour déclencher des cues, manipuler les presets et ajuster des niveaux d’intensité.
 - [Guide agent LLM](docs/llm-agent-guide.md) : règles de conduite pour assistants IA, exemples dry-run/confirmation et table d’orientation outil par intention utilisateur.
+- [Dépannage OSC Eos](docs/troubleshooting-osc-eos.md) : checklist réseau/OSC et règles de fallback showfile lorsque les lectures live ne sont pas fiables.
 - [Architecture technique](docs/architecture.md) : diagrammes du flux MCP → OSC, composants internes et guide “où modifier quoi” pour contribuer.
 - [`docs/tools.md`](docs/tools.md) : référence exhaustive générée automatiquement pour chaque outil MCP.
 - [Ajouter un outil MCP](docs/adding-a-tool.md) : procédure contributeur pour créer une famille d’outils, déclarer les mappings OSC, écrire les schémas Zod, tester et régénérer la référence.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,3 +69,7 @@ Ce guide explique comment executer Eos MCP en tant que service durable sous Linu
    ```
 
 > **Astuce :** ajoutez un planificateur de taches ou une supervision externe pour redemarrer le service si vos conditions d'exploitation l'exigent. NSSM peut gerer la relance automatique et la rotation des fichiers de logs comme illustre dans le script fourni.
+
+## Depannage OSC Eos
+
+Apres installation ou changement reseau, utilisez la [checklist de depannage OSC Eos](troubleshooting-osc-eos.md) pour valider version EOS, OSC RX/TX, IP TX, ports UDP/TCP, firewall, interface reseau et limites Nomad offline/legacy avant de conclure a un incident applicatif.

--- a/docs/llm-agent-guide.md
+++ b/docs/llm-agent-guide.md
@@ -1,6 +1,7 @@
 # Guide agent LLM pour Eos MCP
 
 Ce guide décrit le comportement attendu d'un assistant LLM qui pilote une console ETC Eos via Eos MCP. Il complète le [cookbook](cookbook.md) et la [référence des outils](tools.md) avec des règles opérationnelles, des exemples complets et une grille de choix d'outils.
+Pour diagnostiquer une liaison OSC/Eos avant toute action métier, consultez aussi le [guide de dépannage OSC Eos](troubleshooting-osc-eos.md).
 
 ## Règles générales obligatoires
 

--- a/docs/troubleshooting-osc-eos.md
+++ b/docs/troubleshooting-osc-eos.md
@@ -1,0 +1,50 @@
+# Dépannage OSC Eos
+
+Ce guide aide l'opérateur et l'assistant à diagnostiquer une liaison OSC entre Eos MCP et une console ETC Eos, Eos Nomad ou une session offline. Il doit être utilisé avant de supposer un problème applicatif : une lecture Eos incomplète indique souvent une configuration OSC, réseau ou firewall à corriger.
+
+## Checklist de diagnostic
+
+Validez chaque point dans l'ordre, puis relancez `eos_readiness_check` avant toute action métier.
+
+- [ ] **Version EOS** : noter la version exacte d'Eos/Nomad et confirmer qu'elle supporte les lectures OSC/JSON attendues par le serveur.
+- [ ] **OSC RX/TX** : dans Eos, vérifier que la réception OSC (RX) et l'émission OSC (TX) sont activées. Une configuration uniquement RX permet d'envoyer des commandes mais empêche les lectures fiables.
+- [ ] **IP TX** : contrôler que l'adresse IP de destination TX configurée dans Eos pointe vers la machine qui exécute Eos MCP, et non vers une ancienne station, une interface virtuelle ou `127.0.0.1` sauf si tout tourne localement.
+- [ ] **Ports UDP/TCP** : confirmer les ports OSC configurés côté Eos et côté Eos MCP. Vérifier séparément le port d'entrée Eos, le port de retour TX et les éventuels ports TCP/HTTP de la passerelle.
+- [ ] **Firewall** : autoriser le trafic entrant et sortant sur les ports OSC/UDP et sur les ports TCP utilisés par la passerelle. Tester aussi les règles antivirus/EDR et les profils réseau privés/publics.
+- [ ] **Interface réseau** : sélectionner l'interface connectée au réseau régie, désactiver ou prioriser correctement les interfaces VPN, Wi-Fi invité, Docker/VM et adaptateurs virtuels qui pourraient capter la route.
+- [ ] **Nomad offline vs console** : distinguer une session Nomad offline d'une console matérielle. En offline, certaines lectures ou retours live peuvent être absents, simulés ou dépendants de la configuration locale.
+- [ ] **Mode legacy** : identifier si Eos MCP fonctionne en mode legacy/non confirmé. Dans ce cas, les lectures JSON peuvent être indisponibles; ne pas interpréter un timeout comme une donnée métier vide.
+- [ ] **Test ping** : depuis la machine Eos MCP, pinger l'adresse de la console ou de Nomad. Si ICMP est bloqué par politique réseau, documenter cette limitation et tester tout de même les ports applicatifs.
+- [ ] **Test show name** : lancer une lecture read-only du nom de show. Un échec indique souvent un problème TX, port de retour, firewall ou mode legacy.
+- [ ] **Test count** : lancer une lecture read-only de type count (cues, channels ou patch selon les outils disponibles). Comparer la réponse avec le show ouvert, sans inventer les valeurs manquantes.
+- [ ] **Test patch** : lire un canal de patch connu et documenté par l'opérateur. Si le canal n'est pas connu ou si la lecture échoue, marquer le patch comme inconnu.
+
+## Procédure recommandée pour l'assistant
+
+1. Annoncer que le diagnostic reste read-only et qu'aucune modification de show ne sera envoyée.
+2. Appeler `eos_readiness_check`, idéalement avec un `patchChannel` fourni par l'opérateur si un canal connu existe.
+3. Restituer les statuts techniques (`overall_status`, `transport_status`, `handshake_mode`, `json_read_supported`, `failed_checks`, `operator_actions`) sans les transformer en suppositions métier.
+4. Demander à l'opérateur de corriger les points de checklist encore bloquants.
+5. Relancer les tests read-only avant de proposer un dry-run ou une action réelle.
+
+## Quand utiliser le fallback showfile
+
+Le fallback showfile consiste à utiliser un fichier de show, un export ou une source documentaire fournie par l'opérateur pour répondre à une question lorsque la lecture live OSC n'est pas disponible ou pas fiable.
+
+Utilisez ce fallback uniquement si toutes les conditions suivantes sont réunies :
+
+- la lecture OSC live a échoué, est incomplète, ou indique `json_read_supported=false` / mode legacy non confirmé;
+- l'opérateur fournit explicitement le fichier, l'export ou l'emplacement de la source à analyser;
+- l'opérateur autorise explicitement l'usage du fallback showfile pour cette demande précise;
+- la réponse indique clairement que la source est non-live, potentiellement obsolète, et distincte de l'état actuel de la console;
+- aucune modification live n'est déclenchée à partir de ces données sans nouveau dry-run et confirmation explicite.
+
+Formulation recommandée : « La lecture OSC live n'est pas confirmée. Avec votre autorisation explicite, je peux utiliser le showfile fourni comme source non-live pour répondre, en signalant ses limites. M'autorisez-vous à utiliser ce fallback showfile pour cette demande ? »
+
+## Ce que l'assistant ne doit pas faire
+
+- Ne pas demander ni utiliser de capture écran pour contourner une lecture OSC défaillante, sauf demande explicite de l'opérateur et avec mention que cette source est manuelle, partielle et non-live.
+- Ne pas basculer implicitement vers Windows-MCP, un contrôle distant de poste, un export local ou tout autre outil externe sans autorisation explicite.
+- Ne pas inventer de patch, de cues, de counts, de labels, d'adresses DMX ou d'état de show lorsque les lectures OSC échouent ou sont incomplètes.
+- Ne pas masquer un échec de lecture en présentant des valeurs par défaut, des exemples ou des hypothèses comme des données réelles.
+- Ne pas envoyer d'action de programmation, de GO, de patch ou de commande texte pendant le diagnostic, sauf après dry-run et confirmation explicite de l'opérateur.


### PR DESCRIPTION
### Motivation

- Provide operators and LLM agents a focused troubleshooting checklist to diagnose OSC connectivity issues between Eos MCP and ETC Eos/Nomad before assuming an application bug. 
- Make the fallback showfile policy explicit so assistants only use non-live sources with operator authorization. 
- Prevent unsafe assistant behaviours by listing forbidden actions when live OSC reads are unavailable.

### Description

- Add `docs/troubleshooting-osc-eos.md` containing a diagnostic checklist covering `Version EOS`, `OSC RX/TX`, `IP TX`, `Ports UDP/TCP`, `Firewall`, `Interface réseau`, `Nomad offline vs console`, `Mode legacy`, `Test ping`, `Test show name`, `Test count` and `Test patch`.
- Document a recommended read-only procedure for the assistant that starts with `eos_readiness_check` and requires re-running read-only tests before any dry-run or action. 
- Add a clear “When to use the fallback showfile” section that requires explicit operator authorization and marks the source as non-live. 
- Add a “Ce que l’assistant ne doit pas faire” section that forbids screenshots, implicit Windows-MCP fallbacks, inventing patch/show data, masking failed reads, and sending live programming during diagnostics. 
- Link the new guide from `README.md`, `docs/llm-agent-guide.md` and `docs/deployment.md` so it is discoverable from the main docs set.

### Testing

- Ran `npm run docs:check` which executed the documentation check script and completed successfully. 
- Ran `git diff --check` (whitespace/diff check) which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0eecc0f0832a8c70eb962afe7d72)