### PR TITLE
Resolve tool role from MCP _meta and pass metadata in e2e calls

### DIFF
--- a/src/server/__tests__/mcp-e2e.test.ts
+++ b/src/server/__tests__/mcp-e2e.test.ts
@@ -26,6 +26,7 @@ import { oscMappings } from '../../services/osc/mappings';
 declare const fetch: typeof globalThis.fetch;
 
 type JsonRpcPayload = Record<string, unknown>;
+type ToolCallMetadata = Record<string, unknown>;
 
 interface ToolCallResult {
   content?: Array<{ type?: string; text?: string }>;
@@ -397,14 +398,21 @@ describe('MCP HTTP e2e with a minimal EOS OSC simulator', () => {
   const callTool = async (
     sessionId: string,
     name: string,
-    args: Record<string, unknown> = {}
+    args: Record<string, unknown> = {},
+    metadata?: ToolCallMetadata
   ): Promise<ToolCallResult> => {
+    const params = {
+      name,
+      arguments: args,
+      ...(metadata ? { _meta: metadata } : {})
+    };
+
     const { response, payload } = await postMcp(
       {
         jsonrpc: '2.0',
         id: `call-${name}`,
         method: 'tools/call',
-        params: { name, arguments: args }
+        params
       },
       sessionId
     );
@@ -487,12 +495,14 @@ describe('MCP HTTP e2e with a minimal EOS OSC simulator', () => {
     expect(capabilities.structuredContent?.server).toBeDefined();
     expect(capabilities.structuredContent?.context).toBeDefined();
 
+    const adminToolMetadata = { grantedRole: 'admin' };
+
     const recordCue = await callTool(sessionId, 'eos_workflow_create_cue_series', {
       base_cuelist_number: 1,
       start_cue_number: 1,
       looks: [{ channels: '101', intensity: 50, cue_label: 'E2E 1' }],
       require_confirmation: true
-    });
+    }, adminToolMetadata);
     expect(recordCue.structuredContent?.status).toBe('ok');
     expect(simulator.received.some((message) => thisIsCommand(message, 'Record Cue 1/1'))).toBe(true);
 
@@ -502,14 +512,14 @@ describe('MCP HTTP e2e with a minimal EOS OSC simulator', () => {
       channels: '101',
       intensity_factor: 1,
       require_confirmation: true
-    });
+    }, adminToolMetadata);
     expect(updateCue.structuredContent?.status).toBe('ok');
     expect(simulator.received.some((message) => thisIsCommand(message, 'Update Cue 1/1'))).toBe(true);
 
     const go = await callTool(sessionId, 'eos_cue_go', {
       cuelist_number: 1,
       cue_number: 1
-    });
+    }, adminToolMetadata);
     expect(go.structuredContent).toMatchObject({ action: 'cue_go' });
     expect(simulator.received.some((message) => thisIsCommand(message, 'Cue 1 CueList 1 Go'))).toBe(true);
 
@@ -519,20 +529,20 @@ describe('MCP HTTP e2e with a minimal EOS OSC simulator', () => {
       device_type: 'Source Four LED Series 3 Lustr X8',
       label: 'Key Wash',
       require_confirmation: true
-    });
+    }, adminToolMetadata);
     expect(patchFixture.structuredContent?.status).toBe('ok');
     expect(simulator.received.some((message) => thisIsCommand(message, 'Patch Chan 101 Part 1 Address 1/101'))).toBe(true);
 
     const dmxRead = await callTool(sessionId, 'eos_address_select', {
       address_number: '1/101'
-    });
+    }, adminToolMetadata);
     expect(dmxRead.structuredContent).toMatchObject({
       status: 'ok',
       address: '1/101',
       osc: expect.objectContaining({ address: oscMappings.dmx.addressSelect })
     });
 
-    const macro = await callTool(sessionId, 'eos_macro_fire', { macro_number: 7 });
+    const macro = await callTool(sessionId, 'eos_macro_fire', { macro_number: 7 }, adminToolMetadata);
     expect(macro.structuredContent).toMatchObject({ action: 'macro_fire', macro_number: 7 });
     expect(simulator.count(oscMappings.macros.fire)).toBeGreaterThanOrEqual(1);
 

--- a/src/server/__tests__/toolRegistry.test.ts
+++ b/src/server/__tests__/toolRegistry.test.ts
@@ -355,6 +355,35 @@ describe('ToolRegistry schema-less tools', () => {
     });
   });
 
+  it('autorise un outil sensible lorsque le profil accorde est fourni dans les metadonnees MCP', async () => {
+    const server = createMockServer();
+    const registry = new ToolRegistry(server);
+    const handler = jest.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] }));
+
+    registry.register({
+      name: 'eos_workflow_create_cue_series',
+      config: { inputSchema: { require_confirmation: z.boolean().optional() } },
+      handler
+    });
+
+    const [, , registeredHandler] = server.registerTool.mock.calls[0];
+
+    await expect(
+      (registeredHandler as RegisteredTestHandler)(
+        { require_confirmation: true },
+        { requestId: 'role-ok-meta', _meta: { grantedRole: 'admin' } }
+      )
+    ).resolves.toBeDefined();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [payload] = mockLogger.info.mock.calls[0] as [Record<string, unknown>];
+    expect(payload).toMatchObject({
+      required_role: 'admin',
+      granted_role: 'admin',
+      confirmation_state: 'confirmed'
+    });
+  });
+
   it('journalise les champs minimaux d\'audit en succes', async () => {
     const server = createMockServer();
     const registry = new ToolRegistry(server);

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -225,7 +225,17 @@ function resolveToolRequiredRole(tool: ToolDefinition): ToolSafetyProfile {
 
 function resolveGrantedToolRole(extra: unknown): ToolSafetyProfile {
   const record = asObject(extra);
-  const candidates = [record.grantedRole, record.granted_role, record.allowedToolProfile, record.allowed_tool_profile];
+  const metadata = asObject(record._meta);
+  const candidates = [
+    record.grantedRole,
+    record.granted_role,
+    record.allowedToolProfile,
+    record.allowed_tool_profile,
+    metadata.grantedRole,
+    metadata.granted_role,
+    metadata.allowedToolProfile,
+    metadata.allowed_tool_profile
+  ];
   const candidate = candidates.find((value) => typeof value === 'string' && value.trim().length > 0);
   if (typeof candidate === 'string') {
     const parsed = toolSafetyProfileSchema.safeParse(candidate.trim());


### PR DESCRIPTION
### Motivation
- The full-flow HTTP e2e test exercised admin-level workflows but the JSON-RPC calls did not supply an admin-capable tool context, causing admin-only tools to be rejected at runtime.
- The MCP transport can include per-call metadata in `params._meta`, and the tool registry must consider that when resolving a caller's granted tool profile.
- Add focused behavior and tests so confirmed sensitive actions remain constrained unless an explicit admin-capable profile is provided via supported metadata names.

### Description
- Update `resolveGrantedToolRole` in `src/server/toolRegistry.ts` to also inspect MCP request metadata at `extra._meta` for the supported names `grantedRole`, `granted_role`, `allowedToolProfile`, and `allowed_tool_profile` when resolving the granted tool profile.
- Extend the HTTP e2e helper in `src/server/__tests__/mcp-e2e.test.ts` by changing `callTool` to accept an optional `metadata` parameter and include it as `params._meta` in the JSON-RPC `tools/call` request, and use an `adminToolMetadata` (`{ grantedRole: 'admin' }`) for full-flow admin operations.
- Keep the full-flow assertion near `recordCue.structuredContent?.status` unchanged and aligned with the successful admin execution when admin metadata is provided.
- Add a focused unit test in `src/server/__tests__/toolRegistry.test.ts` that proves an admin role supplied via MCP `_meta.grantedRole` authorizes a sensitive workflow call and logs the expected confirmed audit state.

### Testing
- Ran lint with `npm run lint -- --quiet` and the linter passed.
- Ran the e2e test with `npm run test:e2e -- --runTestsByPath src/server/__tests__/mcp-e2e.test.ts` and it passed.
- Ran the registry unit tests with `npx jest --runTestsByPath src/server/__tests__/toolRegistry.test.ts --runInBand` and they passed.
- Compiled type-checks with `npm run tsc` and `tsc` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1ebbff94832a8d7a645201b5e87c)