### PR TITLE
Assert native EOS OSC payload contracts

### DIFF
--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -208,6 +208,45 @@ export const oscMappings = {
   }
 } as const;
 
+export const oscPayloadAnnotations = {
+  commands: {
+    command: { wireFormat: 'eos-native-command', arguments: 'single OSC string containing an EOS command-line command' },
+    newCommand: { wireFormat: 'eos-native-command', arguments: 'single OSC string containing an EOS command-line command' }
+  },
+  channels: {
+    parameter: { wireFormat: 'json-string', arguments: 'single OSC string containing a JSON object payload' }
+  },
+  dmx: {
+    addressDmx: { wireFormat: 'json-string', arguments: 'single OSC string containing a JSON object payload' }
+  },
+  groups: {
+    level: { wireFormat: 'eos-native-arguments', arguments: 'EOS-native group level float argument' }
+  },
+  keys: {
+    press: { wireFormat: 'eos-native-arguments', arguments: 'EOS-native key press float argument' }
+  },
+  effects: {
+    select: { wireFormat: 'eos-native-command', arguments: 'single OSC string containing `Effect <number>`' },
+    stop: { wireFormat: 'eos-native-command', arguments: 'single OSC string containing `Effect Stop` or `Effect <number> Stop`' }
+  },
+  faders: {
+    bankCreate: { wireFormat: 'eos-native-address', arguments: 'EOS-native address path encodes bank, fader count, and page' }
+  },
+  directSelects: {
+    bankCreate: { wireFormat: 'eos-native-address', arguments: 'EOS-native address path encodes bank, target, buttons, flexi, and page' }
+  },
+  cues: {
+    fire: { wireFormat: 'eos-native-command', arguments: 'single OSC string containing `Cue ... Fire`' }
+  },
+  magicSheets: {
+    open: { wireFormat: 'eos-native-arguments', arguments: 'OSC integer arguments for magic sheet number and optional view number' }
+  },
+  showControl: {
+    setCueSendString: { wireFormat: 'eos-native-command', arguments: 'single OSC string containing `Show_Control Cue_Send_String ...`' },
+    setCueReceiveString: { wireFormat: 'eos-native-command', arguments: 'single OSC string containing `Show_Control Cue_Receive_String ...`' }
+  }
+} as const;
+
 export type OscMappings = typeof oscMappings;
 
 export function toEosOutResponseAddress(address: string): string {

--- a/src/tools/__tests__/__snapshots__/osc_payloads.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/osc_payloads.test.ts.snap
@@ -1,5 +1,135 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`OSC payload snapshots captures EOS-native command line payloads 1`] = `
+{
+  "address": "/eos/cmd",
+  "args": [
+    {
+      "type": "s",
+      "value": "Load Cue 20#",
+    },
+  ],
+  "arguments": "single OSC string containing an EOS command-line command",
+  "wireFormat": "eos-native-command",
+}
+`;
+
+exports[`OSC payload snapshots captures EOS-native command line payloads 2`] = `
+{
+  "address": "/eos/newcmd",
+  "args": [
+    {
+      "type": "s",
+      "value": "Record Cue 1#",
+    },
+  ],
+  "arguments": "single OSC string containing an EOS command-line command",
+  "wireFormat": "eos-native-command",
+}
+`;
+
+exports[`OSC payload snapshots captures EOS-native control surface payloads 1`] = `
+{
+  "address": "/eos/key/go_0",
+  "args": [
+    {
+      "type": "f",
+      "value": 1,
+    },
+  ],
+  "arguments": "EOS-native key press float argument",
+  "wireFormat": "eos-native-arguments",
+}
+`;
+
+exports[`OSC payload snapshots captures EOS-native control surface payloads 2`] = `
+{
+  "address": "/eos/group/5/level",
+  "args": [
+    {
+      "type": "f",
+      "value": 75,
+    },
+  ],
+  "arguments": "EOS-native group level float argument",
+  "wireFormat": "eos-native-arguments",
+}
+`;
+
+exports[`OSC payload snapshots captures EOS-native effect command payloads 1`] = `
+{
+  "address": "/eos/cmd",
+  "args": [
+    {
+      "type": "s",
+      "value": "Effect 12",
+    },
+  ],
+  "arguments": "single OSC string containing \`Effect <number>\`",
+  "wireFormat": "eos-native-command",
+}
+`;
+
+exports[`OSC payload snapshots captures EOS-native effect command payloads 2`] = `
+{
+  "address": "/eos/cmd",
+  "args": [
+    {
+      "type": "s",
+      "value": "Effect 7 Stop",
+    },
+  ],
+  "arguments": "single OSC string containing \`Effect Stop\` or \`Effect <number> Stop\`",
+  "wireFormat": "eos-native-command",
+}
+`;
+
+exports[`OSC payload snapshots captures EOS-native layout payloads 1`] = `
+{
+  "address": "/eos/fader/1/config/10/0",
+  "args": [],
+  "arguments": "EOS-native address path encodes bank, fader count, and page",
+  "wireFormat": "eos-native-address",
+}
+`;
+
+exports[`OSC payload snapshots captures EOS-native layout payloads 2`] = `
+{
+  "address": "/eos/ds/1/config/Chan/10/0/1",
+  "args": [],
+  "arguments": "EOS-native address path encodes bank, target, buttons, flexi, and page",
+  "wireFormat": "eos-native-address",
+}
+`;
+
+exports[`OSC payload snapshots captures EOS-native show-control command payloads 1`] = `
+{
+  "address": "/eos/newcmd",
+  "args": [
+    {
+      "type": "s",
+      "value": "Show_Control Cue_Send_String "Cue %1 -> %2 (%3)"",
+    },
+  ],
+  "arguments": "single OSC string containing \`Show_Control Cue_Send_String ...\`",
+  "wireFormat": "eos-native-command",
+}
+`;
+
+exports[`OSC payload snapshots captures EOS-native show-control command payloads 2`] = `
+{
+  "address": "/eos/newcmd",
+  "args": [
+    {
+      "type": "s",
+      "value": "Show_Control Cue_Receive_String "Receive %1 [%2]"",
+    },
+  ],
+  "arguments": "single OSC string containing \`Show_Control Cue_Receive_String ...\`",
+  "wireFormat": "eos-native-command",
+}
+`;
+
 exports[`OSC payload snapshots captures JSON parameter payloads 1`] = `
 {
   "address": "/eos/chan/param",
@@ -9,6 +139,8 @@ exports[`OSC payload snapshots captures JSON parameter payloads 1`] = `
       "value": "{"channels":[1,2],"parameter":"pan","value":45}",
     },
   ],
+  "arguments": "single OSC string containing a JSON object payload",
+  "wireFormat": "json-string",
 }
 `;
 
@@ -21,91 +153,35 @@ exports[`OSC payload snapshots captures JSON parameter payloads 2`] = `
       "value": "{"address":"1/101","value":255}",
     },
   ],
+  "arguments": "single OSC string containing a JSON object payload",
+  "wireFormat": "json-string",
 }
 `;
 
-exports[`OSC payload snapshots captures command line payloads 1`] = `
+exports[`OSC payload snapshots captures cue/magic sheet EOS-native payloads 1`] = `
 {
   "address": "/eos/cmd",
   "args": [
     {
       "type": "s",
-      "value": "Chan 1 At 50#",
+      "value": "Cue 1 CueList 2 Fire",
     },
   ],
+  "arguments": "single OSC string containing \`Cue ... Fire\`",
+  "wireFormat": "eos-native-command",
 }
 `;
 
-exports[`OSC payload snapshots captures command line payloads 2`] = `
+exports[`OSC payload snapshots captures cue/magic sheet EOS-native payloads 2`] = `
 {
-  "address": "/eos/newcmd",
+  "address": "/eos/ms",
   "args": [
     {
-      "type": "s",
-      "value": "Record Cue 1#",
+      "type": "i",
+      "value": 3,
     },
   ],
-}
-`;
-
-exports[`OSC payload snapshots captures control surface payloads 1`] = `
-{
-  "address": "/eos/key/go_0",
-  "args": [
-    {
-      "type": "f",
-      "value": 1,
-    },
-  ],
-}
-`;
-
-exports[`OSC payload snapshots captures control surface payloads 2`] = `
-{
-  "address": "/eos/group/5/level",
-  "args": [
-    {
-      "type": "f",
-      "value": 75,
-    },
-  ],
-}
-`;
-
-exports[`OSC payload snapshots captures cue/magic sheet payloads 1`] = `
-{
-  "address": "/eos/cue/fire",
-  "args": [
-    {
-      "type": "s",
-      "value": "{"cuelist":2,"list":2,"cuelist_number":2,"cue":"1","cue_number":"1","number":"1","part":0,"cue_part":0}",
-    },
-  ],
-}
-`;
-
-exports[`OSC payload snapshots captures cue/magic sheet payloads 2`] = `
-{
-  "address": "/eos/magic_sheet/open",
-  "args": [
-    {
-      "type": "s",
-      "value": "{"number":3}",
-    },
-  ],
-}
-`;
-
-exports[`OSC payload snapshots captures layout payloads 1`] = `
-{
-  "address": "/eos/fader/1/config/10/0",
-  "args": [],
-}
-`;
-
-exports[`OSC payload snapshots captures layout payloads 2`] = `
-{
-  "address": "/eos/ds/1/config/Chan/10/0/1",
-  "args": [],
+  "arguments": "OSC integer arguments for magic sheet number and optional view number",
+  "wireFormat": "eos-native-arguments",
 }
 `;

--- a/src/tools/__tests__/osc_payloads.test.ts
+++ b/src/tools/__tests__/osc_payloads.test.ts
@@ -4,6 +4,7 @@
  */
 import type { OscMessage } from '../../services/osc/index';
 import { OscClient, setOscClient, type OscGateway, type OscGatewaySendOptions } from '../../services/osc/client';
+import { oscPayloadAnnotations } from '../../services/osc/mappings';
 import { eosCommandTool, eosNewCommandTool } from '../commands/command_tools';
 import { eosChannelSetParameterTool } from '../channels/index';
 import { eosAddressSetDmxTool } from '../dmx/index';
@@ -13,6 +14,8 @@ import { eosFaderBankCreateTool } from '../faders/index';
 import { eosDirectSelectBankCreateTool } from '../directSelects/index';
 import { eosMagicSheetOpenTool } from '../magicSheets/index';
 import { eosCueFireTool } from '../cues/fire';
+import { eosEffectSelectTool, eosEffectStopTool } from '../effects/index';
+import { eosSetCueReceiveStringTool, eosSetCueSendStringTool } from '../showControl/index';
 import { runTool } from './helpers/runTool';
 
 class FakeOscService implements OscGateway {
@@ -36,9 +39,14 @@ class FakeOscService implements OscGateway {
   }
 }
 
-function snapshotLastMessage(service: FakeOscService): void {
+function snapshotLastMessage(service: FakeOscService, annotation: { wireFormat: string; arguments: string }): void {
   const message = service.sentMessages[service.sentMessages.length - 1];
-  expect({ address: message.address, args: message.args ?? [] }).toMatchSnapshot();
+  expect({
+    address: message.address,
+    wireFormat: annotation.wireFormat,
+    arguments: annotation.arguments,
+    args: message.args ?? []
+  }).toMatchSnapshot();
 }
 
 describe('OSC payload snapshots', () => {
@@ -54,41 +62,57 @@ describe('OSC payload snapshots', () => {
     setOscClient(null);
   });
 
-  it('captures command line payloads', async () => {
+  it('captures EOS-native command line payloads', async () => {
     await runTool(eosCommandTool, {
-      command: 'Chan 1 At 50',
+      command: 'Load Cue 20',
       terminateWithEnter: true,
       safety_level: 'standard'
     });
-    snapshotLastMessage(service);
+    snapshotLastMessage(service, oscPayloadAnnotations.commands.command);
 
     await runTool(eosNewCommandTool, {
       command: 'Record Cue 1',
       terminateWithEnter: true,
       require_confirmation: true
     });
-    snapshotLastMessage(service);
+    snapshotLastMessage(service, oscPayloadAnnotations.commands.newCommand);
   });
 
   it('captures JSON parameter payloads', async () => {
     await runTool(eosChannelSetParameterTool, { channels: [1, 2], parameter: 'pan', value: 45 });
-    snapshotLastMessage(service);
+    snapshotLastMessage(service, oscPayloadAnnotations.channels.parameter);
 
     await runTool(eosAddressSetDmxTool, { address_number: '1/101', dmx_value: 255 });
-    snapshotLastMessage(service);
+    snapshotLastMessage(service, oscPayloadAnnotations.dmx.addressDmx);
   });
 
-  it('captures control surface payloads', async () => {
+  it('captures EOS-native effect command payloads', async () => {
+    await runTool(eosEffectSelectTool, { effect_number: 12 });
+    snapshotLastMessage(service, oscPayloadAnnotations.effects.select);
+
+    await runTool(eosEffectStopTool, { effect_number: 7 });
+    snapshotLastMessage(service, oscPayloadAnnotations.effects.stop);
+  });
+
+  it('captures EOS-native show-control command payloads', async () => {
+    await runTool(eosSetCueSendStringTool, { format_string: 'Cue %1 -> %2 (%3)' });
+    snapshotLastMessage(service, oscPayloadAnnotations.showControl.setCueSendString);
+
+    await runTool(eosSetCueReceiveStringTool, { format_string: 'Receive %1 [%2]' });
+    snapshotLastMessage(service, oscPayloadAnnotations.showControl.setCueReceiveString);
+  });
+
+  it('captures EOS-native control surface payloads', async () => {
     await runTool(eosKeyPressTool, { key_name: 'go' });
-    snapshotLastMessage(service);
+    snapshotLastMessage(service, oscPayloadAnnotations.keys.press);
 
     await runTool(eosGroupSetLevelTool, { group_number: 5, level: 75 });
-    snapshotLastMessage(service);
+    snapshotLastMessage(service, oscPayloadAnnotations.groups.level);
   });
 
-  it('captures layout payloads', async () => {
+  it('captures EOS-native layout payloads', async () => {
     await runTool(eosFaderBankCreateTool, { bank_index: 1, fader_count: 10 });
-    snapshotLastMessage(service);
+    snapshotLastMessage(service, oscPayloadAnnotations.faders.bankCreate);
 
     await runTool(eosDirectSelectBankCreateTool, {
       bank_index: 1,
@@ -97,14 +121,14 @@ describe('OSC payload snapshots', () => {
       flexi_mode: false,
       page_number: 1
     });
-    snapshotLastMessage(service);
+    snapshotLastMessage(service, oscPayloadAnnotations.directSelects.bankCreate);
   });
 
-  it('captures cue/magic sheet payloads', async () => {
+  it('captures cue/magic sheet EOS-native payloads', async () => {
     await runTool(eosCueFireTool, { cue_number: 1, cuelist_number: 2, require_confirmation: true });
-    snapshotLastMessage(service);
+    snapshotLastMessage(service, oscPayloadAnnotations.cues.fire);
 
     await runTool(eosMagicSheetOpenTool, { ms_number: 3 });
-    snapshotLastMessage(service);
+    snapshotLastMessage(service, oscPayloadAnnotations.magicSheets.open);
   });
 });

--- a/src/tools/effects/__tests__/effects.test.ts
+++ b/src/tools/effects/__tests__/effects.test.ts
@@ -53,8 +53,9 @@ describe('effect tools', () => {
     expect(service.sentMessages).toHaveLength(1);
     expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.effects.select });
 
-    const payload = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
-    expect(payload).toMatchObject({ effect: 12 });
+    expect(service.sentMessages[0]?.args).toEqual([
+      { type: 's', value: 'Effect 12' }
+    ]);
   });
 
   it("envoie l'ordre d'arret avec le numero d'effet si fourni", async () => {
@@ -63,8 +64,9 @@ describe('effect tools', () => {
     expect(service.sentMessages).toHaveLength(1);
     expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.effects.stop });
 
-    const payload = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
-    expect(payload).toMatchObject({ effect: 7 });
+    expect(service.sentMessages[0]?.args).toEqual([
+      { type: 's', value: 'Effect 7 Stop' }
+    ]);
   });
 
   it("envoie un arret generique lorsque aucun numero n'est fourni", async () => {
@@ -73,8 +75,9 @@ describe('effect tools', () => {
     expect(service.sentMessages).toHaveLength(1);
     expect(service.sentMessages[0]).toMatchObject({ address: oscMappings.effects.stop });
 
-    const payload = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
-    expect(payload).toEqual({});
+    expect(service.sentMessages[0]?.args).toEqual([
+      { type: 's', value: 'Effect Stop' }
+    ]);
   });
 
   it("normalise les informations renvoyees pour un effet dynamique", async () => {

--- a/src/tools/magicSheets/__tests__/magicSheets.test.ts
+++ b/src/tools/magicSheets/__tests__/magicSheets.test.ts
@@ -52,9 +52,10 @@ describe('magic sheet tools', () => {
     expect(service.sentMessages).toHaveLength(1);
     const [message] = service.sentMessages;
     expect(message.address).toBe(oscMappings.magicSheets.open);
-    expect(message.args).toHaveLength(1);
-    const payload = JSON.parse(String(message.args?.[0]?.value ?? '{}'));
-    expect(payload).toMatchObject({ number: 5, view: 2 });
+    expect(message.args).toEqual([
+      { type: 'i', value: 5 },
+      { type: 'i', value: 2 }
+    ]);
   });
 
   it('envoie une commande texte lorsque le role est Primary', async () => {

--- a/src/tools/showControl/__tests__/showControl.test.ts
+++ b/src/tools/showControl/__tests__/showControl.test.ts
@@ -180,8 +180,9 @@ describe('show control tools', () => {
 
     const result = await promise;
     expect(service.sentMessages[0]?.address).toBe(oscMappings.showControl.setCueSendString);
-    const payload = JSON.parse(String(service.sentMessages[0]?.args?.[0]?.value ?? '{}'));
-    expect(payload).toEqual({ format: 'Cue %1 -> %2 (%3)' });
+    expect(service.sentMessages[0]?.args).toEqual([
+      { type: 's', value: 'Show_Control Cue_Send_String "Cue %1 -> %2 (%3)"' }
+    ]);
 
     const structuredContent = getStructuredContent(result);
     expect(structuredContent).toBeDefined();
@@ -214,8 +215,9 @@ describe('show control tools', () => {
 
     await promise;
     const lastMessage = service.sentMessages[service.sentMessages.length - 1];
-    const payload = JSON.parse(String(lastMessage?.args?.[0]?.value ?? '{}'));
-    expect(payload).toEqual({ format: 'Receive %1 [%2]' });
+    expect(lastMessage?.args).toEqual([
+      { type: 's', value: 'Show_Control Cue_Receive_String "Receive %1 [%2]"' }
+    ]);
   });
 
   it('refuse les placeholders invalides pour la reception', async () => {


### PR DESCRIPTION
### Motivation
- Establish that command-oriented tools use EOS-native OSC wire formats (native command strings, native argument arrays, or native address paths) instead of JSON envelopes. 
- Make the expected wire format explicit and discoverable so tests, docs and tooling agree on the same on-the-wire contract. 
- Update tests to assert the real OSC message shapes produced by the handlers to avoid divergent documentation vs runtime behaviour.

### Description
- Add `oscPayloadAnnotations` to `src/services/osc/mappings.ts` describing wire formats for command endpoints, JSON-string endpoints, native-argument endpoints and native-address endpoints. 
- Update snapshot test harness in `src/tools/__tests__/osc_payloads.test.ts` to include the annotated `wireFormat`/`arguments` and to validate EOS-native payload examples from the shared annotations. 
- Change unit tests to assert EOS-native payloads instead of JSON envelopes: `src/tools/showControl/__tests__/showControl.test.ts` now checks `Show_Control Cue_*` command strings, `src/tools/effects/__tests__/effects.test.ts` checks `Effect ...` command strings, and `src/tools/magicSheets/__tests__/magicSheets.test.ts` checks integer OSC args for `eos_magic_sheet_open`. 
- Regenerate and commit updated snapshots under `src/tools/__tests__/__snapshots__/osc_payloads.test.ts.snap` to reflect the native wire formats and adjust a test command to `Load Cue 20` to satisfy the command allowlist validation.

### Testing
- Ran the focused snapshot/unit tests with `npx jest --passWithNoTests --runTestsByPath src/tools/showControl/__tests__/showControl.test.ts src/tools/effects/__tests__/effects.test.ts src/tools/magicSheets/__tests__/magicSheets.test.ts src/tools/__tests__/osc_payloads.test.ts` and they passed. 
- Type-checking and linting were run with `npm run tsc` and `npm run lint` and both succeeded. 
- The full unit test suite (`npm test` unit stage) passed in this environment; the conformance integration scenarios timed out in this environment and may require a network/OSC-enabled test host to run reliably.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2065dc40832a956a7d353eaa79e1)