### PR TITLE
Update OSC payload safety snapshot command

### DIFF
--- a/src/tools/__tests__/__snapshots__/osc_payloads.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/osc_payloads.test.ts.snap
@@ -6,7 +6,7 @@ exports[`OSC payload snapshots captures EOS-native command line payloads 1`] = `
   "args": [
     {
       "type": "s",
-      "value": "Load Cue 20#",
+      "value": "Go To Cue 20#",
     },
   ],
   "arguments": "single OSC string containing an EOS command-line command",

--- a/src/tools/__tests__/osc_payloads.test.ts
+++ b/src/tools/__tests__/osc_payloads.test.ts
@@ -64,7 +64,7 @@ describe('OSC payload snapshots', () => {
 
   it('captures EOS-native command line payloads', async () => {
     await runTool(eosCommandTool, {
-      command: 'Load Cue 20',
+      command: 'Go To Cue 20',
       terminateWithEnter: true,
       safety_level: 'standard'
     });


### PR DESCRIPTION
### Motivation
- Align the OSC payload snapshot test with the current command safety contract by using an allowed `standard` playback command instead of a restricted command.

### Description
- Change the test input in `src/tools/__tests__/osc_payloads.test.ts` from `Load Cue 20` to `Go To Cue 20` with `safety_level: 'standard'`.
- Update the corresponding snapshot entry in `src/tools/__tests__/__snapshots__/osc_payloads.test.ts.snap` to expect `"Go To Cue 20#"` and keep all other snapshots untouched.

### Testing
- Ran the focused test with `npx jest --runTestsByPath src/tools/__tests__/osc_payloads.test.ts --runInBand` and it passed (all tests and snapshots in that file succeeded).
- Ran broader CI-local tests earlier (`npm test` / full Jest run) and the suite completed successfully (all suites passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b260d06c4832a8324a862e1ee615e)