### PR TITLE
Add OSC officiality strict mode

### DIFF
--- a/docs/conformite-eos.md
+++ b/docs/conformite-eos.md
@@ -4,6 +4,33 @@ Ce document mappe chaque outil MCP aux commandes OSC officielles de la documenta
 
 > **Version de reference :** Eos v3.0.0 (manuel FR, ShowControl p. 594-626).
 
+
+## Mode strict EOS
+
+La variable d'environnement `EOS_STRICT_MODE=true|false` active un garde-fou d'envoi OSC. Par defaut, le mode strict est desactive. Quand `EOS_STRICT_MODE=true` (ou `1`, `yes`, `on`), le client OSC refuse toute adresse dont la classification `strictModeAllowed=false` dans `src/services/osc/officiality.ts`.
+
+Le fichier `src/services/osc/officiality.ts` est la source technique de reference pour chaque adresse OSC utilisee par le projet. Chaque entree declare au minimum `address`, `official`, `strictModeAllowed`, `source` et `notes`.
+
+## Classification claire des familles OSC
+
+### Commandes ETC officielles
+
+Les commandes ETC officielles sont les adresses documentees dans le manuel Eos OSC v3.0.0, par exemple `/eos/key/{key}`, `/eos/group`, `/eos/preset/fire`, `/eos/fader/{index}/{page}/{fader}`, `/eos/ds/{index}/button/{page}/{button}`, `/eos/get/<type>/count`, `/eos/get/<type>/list`, `/eos/get/version`, `/eos/ping`, `/eos/reset` et `/eos/subscribe`. Elles sont marquees `official=true` et `strictModeAllowed=true` lorsqu'elles sont envoyables par MCP.
+
+### Commandes envoyees via `/eos/cmd`
+
+Plusieurs outils MCP n'envoient pas l'adresse OSC specialisee equivalente; ils envoient une commande texte EOS via l'adresse officielle `/eos/cmd` ou `/eos/newcmd`. Cela concerne notamment les outils de canaux, cues, effets, patch et workflows qui construisent des chaines comme `Chan ...`, `Address ...`, `Cue ... Fire`, `CueList ... Go`, `Record`, `Update` ou `Label`. Dans ce cas, l'adresse OSC est officielle et autorisee en mode strict; la conformite de l'action depend de la commande texte documentee indiquee dans les tableaux ci-dessous.
+
+### Extensions MCP
+
+Les extensions MCP sont des endpoints crees pour offrir une lecture ou une ergonomie non exposee comme adresse OSC ETC documentee. Elles sont marquees `official=false`; lorsqu'elles pilotent une adresse non documentee, elles sont marquees `strictModeAllowed=false`. Exemples: `/eos/get/patch/chan_pos`, `/eos/get/patch/chan_beam` et certains endpoints JSON de diagnostic/setup.
+
+Les adresses de runtime MCP (`/eos/handshake`, `/eos/protocol/select` et replies associees) ne sont pas des commandes pupitre ETC, mais restent `strictModeAllowed=true` car elles sont necessaires a la negociation du transport MCP et ne modifient pas le show.
+
+### Endpoints non documentes
+
+Les endpoints non documentes sont les adresses observees ou introduites pour compatibilite qui ne correspondent pas directement a une commande OSC du manuel: `/eos/get/cmd_line`, `/eos/get/softkey_labels`, `/eos/get/channels`, `/eos/get/fpe/*`, `/eos/get/patch/chan_info`, `/eos/get/cuelist/info`, `/eos/get/active/cue`, `/eos/get/pending/cue`, `/eos/get/show/name`, `/eos/get/live/blind` et `/eos/get/setup_defaults`. En mode strict, les endpoints classes `strictModeAllowed=false` sont bloques avant l'appel a la passerelle OSC.
+
 ## Commandes texte & ligne de commande
 
 | Outils MCP | Adresse OSC utilisee | Commande OSC officielle (manuel) | Arguments OSC (manuel) | Version | Reference (section/page) | Notes |

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -23,6 +23,8 @@ const DEFAULT_ALLOWED_TOOL_PROFILE: ToolSafetyProfile = 'read_only';
 
 export const EOS_CONSOLES_ENV = 'EOS_CONSOLES';
 
+export const EOS_STRICT_MODE_ENV = 'EOS_STRICT_MODE';
+
 export const DEFAULT_ALLOWED_TOOL_PROFILE_ENV = 'EOS_MCP_ALLOWED_TOOL_PROFILE';
 
 export function getDefaultAllowedToolProfile(

--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -213,6 +213,7 @@ describe('OscClient', () => {
   afterEach(() => {
     jest.useRealTimers();
     gatewayManagers.splice(0, gatewayManagers.length);
+    delete process.env.EOS_STRICT_MODE;
   });
 
   it('realise un handshake et selectionne le protocole prefere', async () => {
@@ -1327,6 +1328,27 @@ describe('OscClient', () => {
     expect(received.map((message) => message.address)).toContain('/eos/handshake/reply');
 
     gateway.close?.();
+  });
+
+
+  it('bloque les endpoints non autorises lorsque EOS_STRICT_MODE est actif', async () => {
+    process.env.EOS_STRICT_MODE = 'true';
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    await expect(client.sendMessage('/eos/get/patch/chan_pos')).rejects.toThrow(/EOS_STRICT_MODE bloque/);
+    expect(service.sentMessages).toHaveLength(0);
+  });
+
+  it("continue d'autoriser les commandes officielles lorsque EOS_STRICT_MODE est actif", async () => {
+    process.env.EOS_STRICT_MODE = 'true';
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    await client.sendCommand('Chan 1 At 50');
+
+    expect(service.sentMessages).toHaveLength(1);
+    expect(service.sentMessages[0]?.address).toBe('/eos/cmd');
   });
 
   it('propage le correlationId du contexte vers les envois OSC', async () => {

--- a/src/services/osc/__tests__/officiality.test.ts
+++ b/src/services/osc/__tests__/officiality.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  OSC_ADDRESS_OFFICIALITY,
+  assertOscAddressStrictModeAllowed,
+  getOscAddressOfficiality,
+  isEosStrictModeEnabled
+} from '../officiality';
+
+const strictEnv = { EOS_STRICT_MODE: 'true' } as NodeJS.ProcessEnv;
+
+describe('OSC address officiality classification', () => {
+  it('classe les adresses OSC avec les champs requis', () => {
+    expect(OSC_ADDRESS_OFFICIALITY.length).toBeGreaterThan(0);
+    for (const entry of OSC_ADDRESS_OFFICIALITY) {
+      expect(entry.address).toMatch(/^\/eos\//);
+      expect(typeof entry.official).toBe('boolean');
+      expect(typeof entry.strictModeAllowed).toBe('boolean');
+      expect(entry.source.length).toBeGreaterThan(0);
+      expect(entry.notes.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resout les templates utilises par les outils MCP', () => {
+    expect(getOscAddressOfficiality('/eos/fader/1/2/3')?.strictModeAllowed).toBe(true);
+    expect(getOscAddressOfficiality('/eos/group/4/level')?.official).toBe(true);
+    expect(getOscAddressOfficiality('/eos/key/go_0')?.official).toBe(true);
+  });
+
+  it('identifie les extensions MCP bloquees en mode strict', () => {
+    const extension = getOscAddressOfficiality('/eos/get/patch/chan_pos');
+    expect(extension).toMatchObject({ official: false, strictModeAllowed: false, source: 'MCP extension' });
+    expect(() => assertOscAddressStrictModeAllowed('/eos/get/patch/chan_pos', strictEnv)).toThrow(/EOS_STRICT_MODE bloque/);
+  });
+
+  it('autorise /eos/cmd et les commandes runtime necessaires en mode strict', () => {
+    expect(() => assertOscAddressStrictModeAllowed('/eos/cmd', strictEnv)).not.toThrow();
+    expect(() => assertOscAddressStrictModeAllowed('/eos/handshake', strictEnv)).not.toThrow();
+  });
+
+  it('parse EOS_STRICT_MODE comme un booleen opt-in', () => {
+    expect(isEosStrictModeEnabled({ EOS_STRICT_MODE: 'true' } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isEosStrictModeEnabled({ EOS_STRICT_MODE: '1' } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isEosStrictModeEnabled({ EOS_STRICT_MODE: 'false' } as NodeJS.ProcessEnv)).toBe(false);
+    expect(isEosStrictModeEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+});

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -27,6 +27,7 @@ import { getResourceCache } from '../cache/index';
 import { resolveConsoleTarget } from '../consoleTargets';
 import { RequestQueue, type RequestQueueDiagnostics, type RequestQueueRunOptions } from './requestQueue';
 import { getRequestContext } from '../../server/requestContext';
+import { assertOscAddressStrictModeAllowed } from './officiality';
 import {
   extractJsonPayloadFromMessage,
   isDocumentedJsonEndpoint,
@@ -996,6 +997,7 @@ export class OscClient {
     options: TargetOptions,
     queueOptions: SendQueueOptions = {}
   ): Promise<TransportType | null> {
+    assertOscAddressStrictModeAllowed(message.address);
     const operation = queueOptions.operation ?? `l'envoi du message OSC ${message.address}`;
     const timeoutMs = queueOptions.timeoutMs ?? this.requestQueueTimeoutMs;
     const details = {
@@ -1003,15 +1005,18 @@ export class OscClient {
       ...(queueOptions.details ?? {})
     };
 
-    const resolvedTarget = resolveConsoleTarget({
-      targetConsole: options.targetConsole,
-      targetAddress: options.targetAddress,
-      targetPort: options.targetPort
-    });
+    const hasExplicitTarget = Boolean(options.targetConsole ?? options.targetAddress ?? options.targetPort);
+    const resolvedTarget = hasExplicitTarget
+      ? resolveConsoleTarget({
+        targetConsole: options.targetConsole,
+        targetAddress: options.targetAddress,
+        targetPort: options.targetPort
+      })
+      : null;
     const gatewayOptions: OscGatewaySendOptions = {
-      targetConsole: resolvedTarget.targetConsole ?? undefined,
-      targetAddress: resolvedTarget.targetAddress,
-      targetPort: resolvedTarget.targetPort,
+      targetConsole: resolvedTarget?.targetConsole ?? undefined,
+      targetAddress: resolvedTarget?.targetAddress,
+      targetPort: resolvedTarget?.targetPort,
       toolId: options.toolId ?? message.address,
       correlationId: getRequestContext()?.correlationId,
       transportPreference: options.transportPreference

--- a/src/services/osc/officiality.ts
+++ b/src/services/osc/officiality.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { EOS_STRICT_MODE_ENV } from '../../config/env';
+
+export type OscOfficialitySource =
+  | 'ETC Eos OSC manual v3.0.0'
+  | 'ETC Eos command-line via /eos/cmd'
+  | 'MCP transport contract'
+  | 'MCP extension'
+  | 'Undocumented endpoint';
+
+export interface OscAddressOfficiality {
+  address: string;
+  official: boolean;
+  strictModeAllowed: boolean;
+  source: OscOfficialitySource;
+  notes: string;
+}
+
+const OFFICIAL_NOTES = 'Adresse OSC ETC documentee dans le manuel Eos OSC v3.0.0.';
+const COMMAND_NOTES = 'Adresse officielle de ligne de commande ETC; la semantique precise est portee par la commande texte envoyee.';
+const MCP_RUNTIME_NOTES = 'Adresse necessaire a la negociation/runtime MCP; autorisee en mode strict meme si elle ne correspond pas a une commande pupitre ETC documentee.';
+const EXTENSION_NOTES = 'Extension MCP non documentee comme commande OSC ETC; bloquee lorsque EOS_STRICT_MODE=true.';
+const UNDOCUMENTED_NOTES = 'Endpoint utilise par compatibilite ou lecture explicite MCP, non documente comme commande OSC ETC; bloque lorsque EOS_STRICT_MODE=true.';
+
+function official(address: string, notes = OFFICIAL_NOTES): OscAddressOfficiality {
+  return { address, official: true, strictModeAllowed: true, source: 'ETC Eos OSC manual v3.0.0', notes };
+}
+
+function command(address: string): OscAddressOfficiality {
+  return { address, official: true, strictModeAllowed: true, source: 'ETC Eos command-line via /eos/cmd', notes: COMMAND_NOTES };
+}
+
+function runtime(address: string): OscAddressOfficiality {
+  return { address, official: false, strictModeAllowed: true, source: 'MCP transport contract', notes: MCP_RUNTIME_NOTES };
+}
+
+function extension(address: string): OscAddressOfficiality {
+  return { address, official: false, strictModeAllowed: false, source: 'MCP extension', notes: EXTENSION_NOTES };
+}
+
+function undocumented(address: string): OscAddressOfficiality {
+  return { address, official: false, strictModeAllowed: false, source: 'Undocumented endpoint', notes: UNDOCUMENTED_NOTES };
+}
+
+export const OSC_ADDRESS_OFFICIALITY: readonly OscAddressOfficiality[] = [
+  command('/eos/cmd'),
+  command('/eos/newcmd'),
+  official('/eos/get/cmd_line'),
+  official('/eos/key'),
+  official('/eos/key/{key}'),
+  official('/eos/key/softkey{number}'),
+  official('/eos/get/softkey_labels'),
+  official('/eos/chan'),
+  official('/eos/chan/param'),
+  official('/eos/get/channels'),
+  official('/eos/dmx/address/select'),
+  official('/eos/dmx/address/level'),
+  official('/eos/dmx/address/dmx'),
+  official('/eos/group'),
+  official('/eos/group/{group}/level'),
+  official('/eos/get/group'),
+  official('/eos/get/group/count'),
+  official('/eos/get/group/list'),
+  official('/eos/ip/fire'),
+  official('/eos/fp/fire'),
+  official('/eos/cp/fire'),
+  official('/eos/bp/fire'),
+  official('/eos/get/palette'),
+  official('/eos/get/ip'),
+  official('/eos/get/fp'),
+  official('/eos/get/cp'),
+  official('/eos/get/bp'),
+  official('/eos/get/ip/count'),
+  official('/eos/get/fp/count'),
+  official('/eos/get/cp/count'),
+  official('/eos/get/bp/count'),
+  official('/eos/get/ip/list'),
+  official('/eos/get/fp/list'),
+  official('/eos/get/cp/list'),
+  official('/eos/get/bp/list'),
+  official('/eos/preset/fire'),
+  official('/eos/preset'),
+  official('/eos/get/preset'),
+  official('/eos/get/preset/count'),
+  official('/eos/get/preset/list'),
+  official('/eos/macro/fire'),
+  official('/eos/macro'),
+  official('/eos/get/macro'),
+  official('/eos/get/macro/count'),
+  official('/eos/get/macro/list'),
+  official('/eos/snap'),
+  official('/eos/get/snapshot'),
+  official('/eos/get/snapshot/count'),
+  official('/eos/get/snapshot/list'),
+  official('/eos/curve/select'),
+  official('/eos/get/curve'),
+  official('/eos/get/curve/count'),
+  official('/eos/get/curve/list'),
+  official('/eos/get/effect'),
+  official('/eos/get/effect/count'),
+  official('/eos/get/effect/list'),
+  official('/eos/param/wheel/tick'),
+  official('/eos/param/wheel/rate'),
+  official('/eos/param/color/hs'),
+  official('/eos/param/color/rgb'),
+  official('/eos/param/position/xy'),
+  official('/eos/param/position/xyz'),
+  official('/eos/get/active/wheels'),
+  official('/eos/fader'),
+  official('/eos/fader/{index}/config/{faders}/{page}'),
+  official('/eos/fader/{index}/{page}/{fader}'),
+  official('/eos/fader/{index}/page/{delta}'),
+  official('/eos/ds/{index}/button/{page}/{button}'),
+  official('/eos/ds/{index}/config/{target}/{buttons}/{flexi}/{page}'),
+  official('/eos/ds/{index}/page/{delta}'),
+  official('/eos/pixmap'),
+  official('/eos/get/pixmap'),
+  official('/eos/get/pixmap/count'),
+  official('/eos/get/pixmap/list'),
+  official('/eos/ms'),
+  official('/eos/get/magic_sheet'),
+  official('/eos/get/magic_sheet/count'),
+  official('/eos/get/magic_sheet/list'),
+  official('/eos/sub'),
+  official('/eos/get/submaster'),
+  official('/eos/get/submaster/count'),
+  official('/eos/get/submaster/list'),
+  official('/eos/get/cue'),
+  official('/eos/get/cue/count'),
+  official('/eos/get/cue/list'),
+  official('/eos/get/cuelist'),
+  official('/eos/get/cuelist/count'),
+  official('/eos/get/cuelist/list'),
+  official('/eos/cuelist/{bank_index}/config/{cuelist_number}/{num_prev_cues}/{num_pending_cues}'),
+  official('/eos/cuelist/{bank_index}/page/{delta}'),
+  official('/eos/get/version'),
+  official('/eos/set/user_id', 'Equivalent MCP explicite de la commande officielle /eos/user.'),
+  official('/eos/ping'),
+  official('/eos/reset'),
+  official('/eos/subscribe'),
+  runtime('/eos/handshake'),
+  runtime('/eos/handshake/reply'),
+  runtime('/eos/protocol/select'),
+  runtime('/eos/protocol/select/reply'),
+  runtime('/eos/out/ping'),
+  runtime('/eos/reset/reply'),
+  runtime('/eos/subscribe/reply'),
+  runtime('/eos/out/{path}'),
+  undocumented('/eos/get/fpe/set/count'),
+  undocumented('/eos/get/fpe/set'),
+  undocumented('/eos/get/fpe/point'),
+  undocumented('/eos/get/patch/chan_info'),
+  extension('/eos/get/patch/chan_pos'),
+  extension('/eos/get/patch/chan_beam'),
+  undocumented('/eos/get/cuelist/info'),
+  undocumented('/eos/get/active/cue'),
+  undocumented('/eos/get/pending/cue'),
+  undocumented('/eos/get/show/name'),
+  undocumented('/eos/get/live/blind'),
+  undocumented('/eos/get/setup_defaults')
+] as const;
+
+function templateToRegExp(template: string): RegExp {
+  const escaped = template.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = escaped.replace(/\\\{[^/]+\\\}/g, '[^/]+');
+  return new RegExp(`^${pattern}$`);
+}
+
+const EXACT_ENTRIES = new Map(OSC_ADDRESS_OFFICIALITY.map((entry) => [entry.address, entry]));
+const TEMPLATE_ENTRIES = OSC_ADDRESS_OFFICIALITY
+  .filter((entry) => entry.address.includes('{'))
+  .map((entry) => ({ entry, pattern: templateToRegExp(entry.address) }));
+
+export function getOscAddressOfficiality(address: string): OscAddressOfficiality | undefined {
+  return EXACT_ENTRIES.get(address) ?? TEMPLATE_ENTRIES.find(({ pattern }) => pattern.test(address))?.entry;
+}
+
+export function isEosStrictModeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[EOS_STRICT_MODE_ENV];
+  if (raw === undefined || raw === null || raw.trim().length === 0) {
+    return false;
+  }
+  return ['1', 'true', 'yes', 'on'].includes(raw.trim().toLowerCase());
+}
+
+export function assertOscAddressStrictModeAllowed(address: string, env: NodeJS.ProcessEnv = process.env): void {
+  if (!isEosStrictModeEnabled(env)) {
+    return;
+  }
+
+  const classification = getOscAddressOfficiality(address);
+  if (classification?.strictModeAllowed === true) {
+    return;
+  }
+
+  const source = classification?.source ?? 'adresse non classee';
+  const notes = classification?.notes ?? 'Aucune entree dans OSC_ADDRESS_OFFICIALITY.';
+  throw new Error(
+    `EOS_STRICT_MODE bloque l'envoi OSC vers '${address}' (${source}). ${notes}`
+  );
+}


### PR DESCRIPTION
### Motivation

- Introduire une classification explicite pour chaque adresse OSC utilisée par le projet afin de documenter si une adresse est « officielle » ETC et si elle peut être envoyée en "mode strict".
- Ajouter un mécanisme opt-in via une variable d'environnement `EOS_STRICT_MODE` pour empêcher l'envoi d'adresses non autorisées en production stricte.
- Empêcher au plus tôt l'envoi via la passerelle OSC des adresses classées `strictModeAllowed=false` quand le mode strict est activé.

### Description

- Ajouté `src/services/osc/officiality.ts` qui expose `OSC_ADDRESS_OFFICIALITY`, `getOscAddressOfficiality`, `isEosStrictModeEnabled` et `assertOscAddressStrictModeAllowed` et résout les templates d'adresse; chaque entrée contient `address`, `official`, `strictModeAllowed`, `source` et `notes`.
- Ajouté la constante d'environnement `EOS_STRICT_MODE` dans `src/config/env.ts` et parsing opt-in (`'1'|'true'|'yes'|'on'`).
- Intégré le contrôle strict dans le client OSC en appelant `assertOscAddressStrictModeAllowed(message.address)` avant l'appel à la passerelle dans `src/services/osc/client.ts`, et ajusté la résolution cible pour n'appeler `resolveConsoleTarget` que si une cible explicite est fournie.
- Mis à jour la documentation `docs/conformite-eos.md` pour décrire le mode strict, les commandes officielles ETC, les commandes envoyées via `/eos/cmd`, les extensions MCP et les endpoints non documentés.
- Ajouté des tests : `src/services/osc/__tests__/officiality.test.ts` et compléments dans `src/services/osc/__tests__/client.test.ts` pour vérifier la classification, le parsing de l'env var et le blocage/autorisation en mode strict.

### Testing

- Compilation TypeScript et lint : `npm run tsc -- --noEmit` et `npm run lint` (succès).
- Tests unitaires et de bout en bout : `npm test -- --runInBand` (tous les suites unitaires ont réussi; 58 suites passées, 558 tests passés).
- Tests de conformance EOS : `npm run test:conformance` / exécution ciblée de `src/services/osc/__tests__/eos-conformance.integration.test.ts` (intégration de trames capturées) (succès).
- Vérifications de documentation : `npm run docs:check` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22b07ab298832ab0eb6a39ec9b596d)