### PR TITLE
Verify sensitive workflow commands and fail on unverified sends

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4325,6 +4325,7 @@ oscsend 127.0.0.1 8001 /eos/param/wheel/tick s:'{"parameter_name":"exemple","tic
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `user` | number | Non | — |
+| `verification_timeout_ms` | number | Non | Timeout en millisecondes pour verifier apres envoi les commandes EOS sensibles. |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -4357,6 +4358,7 @@ _Pas de mapping OSC documenté._
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `user` | number | Non | — |
+| `verification_timeout_ms` | number | Non | Timeout en millisecondes pour verifier apres envoi les commandes EOS sensibles. |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -4389,6 +4391,7 @@ _Pas de mapping OSC documenté._
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `user` | number | Non | — |
+| `verification_timeout_ms` | number | Non | Timeout en millisecondes pour verifier apres envoi les commandes EOS sensibles. |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -4424,6 +4427,7 @@ _Pas de mapping OSC documenté._
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `user` | number | Non | — |
+| `verification_timeout_ms` | number | Non | Timeout en millisecondes pour verifier apres envoi les commandes EOS sensibles. |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -4460,6 +4464,7 @@ _Pas de mapping OSC documenté._
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `user` | number | Non | — |
+| `verification_timeout_ms` | number | Non | Timeout en millisecondes pour verifier apres envoi les commandes EOS sensibles. |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -4502,6 +4507,7 @@ _Pas de mapping OSC documenté._
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `user` | number | Non | — |
+| `verification_timeout_ms` | number | Non | Timeout en millisecondes pour verifier apres envoi les commandes EOS sensibles. |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -4574,6 +4580,7 @@ _Pas de mapping OSC documenté._
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `user` | number | Non | — |
+| `verification_timeout_ms` | number | Non | Timeout en millisecondes pour verifier apres envoi les commandes EOS sensibles. |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.
 
@@ -4608,6 +4615,7 @@ _Pas de mapping OSC documenté._
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `user` | number | Non | — |
+| `verification_timeout_ms` | number | Non | Timeout en millisecondes pour verifier apres envoi les commandes EOS sensibles. |
 | `warmify` | boolean | Non | — |
 
 **Retour :** Les handlers renvoient un `ToolExecutionResult` avec un résumé texte et les données renvoyées par la console EOS.

--- a/src/tools/workflows/__tests__/workflows.test.ts
+++ b/src/tools/workflows/__tests__/workflows.test.ts
@@ -31,6 +31,8 @@ class FakeOscService implements OscGateway {
 
   public consoleErrorOnCueList = false;
 
+  public suppressCommandLineReply = false;
+
   public patchReadErrors = new Set<number>();
 
   private readonly recordedCues: Array<{ cuelist: number | null; cue: string }> = [];
@@ -94,7 +96,7 @@ class FakeOscService implements OscGateway {
       });
     }
 
-    if (message.address === '/eos/get/cmd_line') {
+    if (message.address === '/eos/get/cmd_line' && !this.suppressCommandLineReply) {
       const reply: OscMessage = {
         address: '/eos/get/cmd_line',
         args: [{ type: 's', value: JSON.stringify({ text: this.commandLineText, user: 0 }) }]
@@ -139,7 +141,7 @@ describe('workflow tools', () => {
       require_confirmation: true
     });
 
-    expect(service.sentMessages).toHaveLength(7);
+    expect(service.sentMessages).toHaveLength(8);
     expect(service.sentMessages.map((msg) => msg.address)).toEqual([
       '/eos/newcmd',
       '/eos/newcmd',
@@ -147,7 +149,8 @@ describe('workflow tools', () => {
       '/eos/newcmd',
       '/eos/newcmd',
       '/eos/get/cuelist',
-      '/eos/newcmd'
+      '/eos/newcmd',
+      '/eos/get/cmd_line'
     ]);
 
     const structured = getStructuredContent(result);
@@ -306,6 +309,36 @@ describe('workflow tools', () => {
         size: 100
       }
     });
+  });
+
+
+  it('retourne partial_failure quand Record Effect reste non verifie apres envoi', async () => {
+    service.suppressCommandLineReply = true;
+
+    const result = await runTool(eosWorkflowCreateEffectTool, {
+      channels: '10',
+      effect_number: 23,
+      require_confirmation: true,
+      verification_timeout_ms: 10
+    });
+
+    const structured = getStructuredContent(result);
+    expect(structured?.status).toBe('partial_failure');
+    expect(result.content[0]?.text).toContain('Workflow creation effet interrompu');
+    expect(structured?.partialErrors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ step: 'record_effect', error: 'commande envoyée mais non vérifiée dans EOS' })
+    ]));
+    expect(structured?.warnings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ step: 'record_effect', detail: 'commande envoyée mais non vérifiée dans EOS' })
+    ]));
+    expect(structured?.executedSteps).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        step: 'record_effect',
+        status: 'error',
+        command: 'Record Effect 23',
+        detail: 'verification_after_send_failed'
+      })
+    ]));
   });
 
   it('retourne un echec partiel sur erreur intermediaire de workflow create_look', async () => {
@@ -665,7 +698,7 @@ describe('workflow tools', () => {
       require_confirmation: true
     });
 
-    expect(service.sentMessages).toHaveLength(3);
+    expect(service.sentMessages).toHaveLength(4);
     const structured = getStructuredContent(result);
     expect(structured?.status).toBe('ok');
     expect(structured?.commandsSent).toEqual([
@@ -792,6 +825,34 @@ describe('workflow tools', () => {
       'Record FP 2',
       'FP 2 Label "Down"'
     ]);
+  });
+
+
+  it('retourne partial_failure pour build_groups_and_palettes si Record CP est non verifie', async () => {
+    service.suppressCommandLineReply = true;
+
+    const result = await runTool(eosWorkflowBuildGroupsAndPalettesTool, {
+      color_palettes: [{ number: 10, label: 'Warm', channels: '5', hue: 'Amber' }],
+      require_confirmation: true,
+      verification_timeout_ms: 10
+    });
+
+    const structured = getStructuredContent(result);
+    expect(structured?.status).toBe('partial_failure');
+    expect(structured?.partialErrors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ step: 'cp_10_record', error: 'commande envoyée mais non vérifiée dans EOS' })
+    ]));
+    expect(structured?.warnings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ step: 'cp_10_record', detail: 'commande envoyée mais non vérifiée dans EOS' })
+    ]));
+    expect(structured?.executedSteps).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        step: 'cp_10_record',
+        status: 'error',
+        command: 'Record CP 10',
+        detail: 'verification_after_send_failed'
+      })
+    ]));
   });
 
   it('genere commands_preview en dry run pour build_groups_and_palettes', async () => {

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -7,6 +7,7 @@ import { validateCueArgumentsPair, optionalTimeoutMsSchema } from '../../utils/v
 import { getOscClient } from '../../services/osc/client';
 import { buildCueJsonMessage } from '../../services/osc/messageBuilders';
 import { oscMappings } from '../../services/osc/mappings';
+import { isSensitiveCommandText } from '../common/safety';
 import { sendDeterministicCommand } from '../commands/command_tools';
 import {
   buildCueCommandPayload,
@@ -36,7 +37,10 @@ const primaryWorkflowAnnotations = {
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
   targetPort: z.coerce.number().int().min(1).max(65535).optional(),
-  user: z.coerce.number().int().min(0).optional()
+  user: z.coerce.number().int().min(0).optional(),
+  verification_timeout_ms: z.coerce.number().int().positive().max(10000).optional().describe(
+    'Timeout en millisecondes pour verifier apres envoi les commandes EOS sensibles.'
+  )
 } satisfies ZodRawShape;
 
 const workflowDryRunSchema = z.boolean().optional().describe(
@@ -261,23 +265,77 @@ async function verifyRecordCueStep(
   }
 }
 
+interface WorkflowCommandStepOptions {
+  user?: number;
+  targetAddress?: string;
+  targetPort?: number;
+  verification_timeout_ms?: number;
+}
+
+interface WorkflowRunCommandStepOptions {
+  verify_after_send?: boolean;
+}
+
+function commandStepRequiresVerification(command: string, options: WorkflowRunCommandStepOptions = {}): boolean {
+  return options.verify_after_send ?? isSensitiveCommandText(command);
+}
+
+function getWorkflowCommandVerificationError(result: ToolExecutionResult, requireVerification: boolean): string | null {
+  if (!requireVerification) {
+    return null;
+  }
+
+  const structuredContent = result.structuredContent ?? {};
+  if (structuredContent.verified === true && structuredContent.accepted_by_eos === true) {
+    return null;
+  }
+
+  const verification = structuredContent.verification;
+  const warning = Array.isArray(structuredContent.warnings)
+    ? structuredContent.warnings.find((entry): entry is { detail: string } => (
+        typeof entry === 'object' && entry !== null && typeof (entry as { detail?: unknown }).detail === 'string'
+      ))?.detail
+    : undefined;
+
+  if (verification && typeof verification === 'object' && !Array.isArray(verification)) {
+    const verificationWarning = (verification as { warning?: unknown }).warning;
+    if (typeof verificationWarning === 'string' && verificationWarning.length > 0) {
+      return verificationWarning;
+    }
+  }
+
+  return warning ?? 'commande envoyée mais non vérifiée dans EOS';
+}
+
 async function runCommandStep(
   steps: WorkflowStepLog[],
   partialErrors: Array<{ step: string; error: string }>,
   step: string,
   command: string,
-  options: { user?: number; targetAddress?: string; targetPort?: number }
+  options: WorkflowCommandStepOptions,
+  stepOptions: WorkflowRunCommandStepOptions = {}
 ): Promise<boolean> {
+  const verifyAfterSend = commandStepRequiresVerification(command, stepOptions);
+
   try {
-    await sendDeterministicCommand({
+    const result = await sendDeterministicCommand({
       command,
       clearLine: true,
       terminateWithEnter: true,
       user: options.user,
       targetAddress: options.targetAddress,
       targetPort: options.targetPort,
+      verification_timeout_ms: options.verification_timeout_ms,
+      verify_after_send: verifyAfterSend,
       safety_level: 'off'
     });
+    const verificationError = getWorkflowCommandVerificationError(result, verifyAfterSend);
+    if (verificationError != null) {
+      steps.push({ step, status: 'error', command, detail: 'verification_after_send_failed', error: verificationError });
+      partialErrors.push({ step, error: verificationError });
+      return false;
+    }
+
     steps.push({ step, status: 'ok', command });
     return true;
   } catch (error) {
@@ -378,7 +436,14 @@ export const eosWorkflowCreateLookTool: ToolDefinition<typeof createLookInputSch
         continue;
       }
 
-      const ok = await runCommandStep(steps, partialErrors, commandStep.step, commandStep.command, options);
+      const ok = await runCommandStep(
+        steps,
+        partialErrors,
+        commandStep.step,
+        commandStep.command,
+        options,
+        { verify_after_send: ('verifyCue' in commandStep && commandStep.verifyCue != null) ? false : undefined }
+      );
       if (!ok) {
         return buildWorkflowResult(
           'eos_workflow_create_look',
@@ -650,7 +715,14 @@ export const eosWorkflowCreateCueSeriesTool: ToolDefinition<typeof createCueSeri
           continue;
         }
 
-        const ok = await runCommandStep(steps, partialErrors, commandStep.step, commandStep.command, options);
+        const ok = await runCommandStep(
+          steps,
+          partialErrors,
+          commandStep.step,
+          commandStep.command,
+          options,
+          { verify_after_send: ('verifyCue' in commandStep && commandStep.verifyCue != null) ? false : undefined }
+        );
         if (!ok) {
           return buildWorkflowResult(
             'eos_workflow_create_cue_series',


### PR DESCRIPTION
### Motivation
- Assurer que les commandes sensibles envoyées aux consoles EOS (Record Cue/CP/FP/Effect, Delete, Label, etc.) soient vérifiées et qu'un résultat non vérifié ne soit pas rapporté comme succès.

### Description
- Ajout de l'option `verification_timeout_ms` aux options partagées des workflows pour piloter le délai de vérification après envoi des commandes sensibles et exposition dans la doc outils (`docs/tools.md`).
- Mise à jour de `runCommandStep` pour activer `verify_after_send` automatiquement pour les commandes sensibles (via `isSensitiveCommandText`), transmettre `verification_timeout_ms`, et considérer un résultat non vérifié comme erreur étape (`verification_after_send_failed`) entraînant `partial_failure`.
- Préservation des vérifications spécialisées existantes (ex. vérification explicite après `Record Cue`) pour éviter les doubles vérifications et permettre de désactiver la vérification automatique lorsque la vérification explicite est déjà effectuée.
- Ajout de tests unitaires pour couvrir les scénarios où `sendDeterministicCommand` renvoie des résultats non vérifiés (tests pour `Record Effect` et `Record CP`) afin de garantir que les workflows retournent `partial_failure` et publient des warnings/partialErrors appropriés.

### Testing
- Tests unitaires ciblés exécutés: `npm run test:unit -- --runTestsByPath src/tools/workflows/__tests__/workflows.test.ts --runInBand` et ensuite la suite complète `npm run test:unit`, tous passés.
- Vérifications de conformité et intégration OSC exécutées avec `npm run test:conformance`, ainsi que `npm run docs:generate`, `npm run lint` et `npm run tsc`, et toutes ont réussi.
- Tests ajoutés dans `src/tools/workflows/__tests__/workflows.test.ts` valident les comportements d'échec partiel lorsque la vérification après envoi échoue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22ea5a2c64832a925b871227e37e67)