### PR TITLE
Renforcement de la vérification des commandes sensibles EOS

### DIFF
--- a/src/tools/commands/__tests__/command_tools.test.ts
+++ b/src/tools/commands/__tests__/command_tools.test.ts
@@ -36,10 +36,11 @@ describe('command tools', () => {
   }
 
   let service: FakeOscService;
+  let client: OscClient;
 
   beforeEach(() => {
     service = new FakeOscService();
-    const client = new OscClient(service, { defaultTimeoutMs: 50 });
+    client = new OscClient(service, { defaultTimeoutMs: 50 });
     setOscClient(client);
     clearCurrentUserId();
   });
@@ -107,6 +108,65 @@ describe('command tools', () => {
         warning: 'commande envoyée mais non vérifiée dans EOS'
       }
     });
+  });
+
+  it('active la verification par defaut pour une commande sensible quand la lecture JSON est confirmee', async () => {
+    const probe = client.probeCapabilities({ timeoutMs: 20 });
+    queueMicrotask(() => {
+      service.emit({
+        address: '/eos/get/version',
+        args: [{ type: 's', value: JSON.stringify({ version: '3.2.10' }) }]
+      });
+    });
+    await probe;
+    service.sentMessages.length = 0;
+
+    const result = await runTool(eosCommandTool, {
+      command: 'Record Cue 1',
+      require_confirmation: true,
+      verification_timeout_ms: 10
+    });
+    const structured = getStructuredContent(result);
+
+    expect(service.sentMessages.map((message) => message.address)).toEqual(['/eos/cmd', '/eos/get/cuelist']);
+    expect(structured).toMatchObject({
+      status: 'partial_failure',
+      verification: {
+        status: 'not_verified',
+        method: 'eos_cue_list_all'
+      }
+    });
+  });
+
+  it('ajoute un warning fort et des next_actions quand une commande sensible reste non verifiee en lecture legacy', async () => {
+    const result = await runTool(eosCommandWithSubstitutionTool, {
+      template: 'Delete Cue %1',
+      values: [7],
+      require_confirmation: true,
+      safety_level: 'off'
+    });
+    const structured = getStructuredContent(result);
+
+    expect(service.sentMessages.map((message) => message.address)).toEqual(['/eos/cmd']);
+    expect(structured).toMatchObject({
+      status: 'ok',
+      sent_to_transport: true,
+      accepted_by_eos: null,
+      verified: false,
+      verification: {
+        status: 'skipped',
+        details: {
+          reason: 'json_read_unavailable'
+        }
+      }
+    });
+    expect(structured?.warnings).toEqual([
+      expect.objectContaining({ detail: expect.stringContaining('COMMANDE SENSIBLE ENVOYEE MAIS NON VERIFIEE') })
+    ]);
+    expect(structured?.next_actions).toEqual(expect.arrayContaining([
+      expect.stringContaining('relecture manuelle'),
+      expect.stringContaining('Confirmer explicitement')
+    ]));
   });
 
   it('envoie une commande en respectant le terminateur', async () => {

--- a/src/tools/commands/command_tools.ts
+++ b/src/tools/commands/command_tools.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { z } from 'zod';
-import { getOscClient, type CommandLineState } from '../../services/osc/client';
+import { getOscClient, type CommandLineState, type OscRuntimeCapabilities } from '../../services/osc/client';
 import { buildCueJsonMessage } from '../../services/osc/messageBuilders';
 import { oscMappings } from '../../services/osc/mappings';
 import { getCurrentUserId } from '../session/index';
@@ -256,10 +256,18 @@ interface CommandVerificationResult {
   verified: boolean;
   method: string | null;
   warning?: string;
+  warnings?: string[];
+  next_actions?: string[];
   details?: unknown;
 }
 
 const unverifiedWarning = 'commande envoyée mais non vérifiée dans EOS';
+const sensitiveUnverifiedWarning =
+  'COMMANDE SENSIBLE ENVOYEE MAIS NON VERIFIEE DANS EOS: ne pas enchainer d operation destructive avant relecture explicite.';
+const manualRereadNextAction =
+  'Effectuer une relecture manuelle de la console EOS ou relancer eos_readiness_check/eos_connect avant toute operation destructive.';
+const confirmStateNextAction =
+  'Confirmer explicitement l etat EOS attendu avec un operateur avant d enchainer record/update/delete/patch.';
 
 function parseRecordCueIdentifier(command: string): CueIdentifier | null {
   const normalized = command.replace(/#/g, ' ').replace(/\s+/g, ' ').trim();
@@ -378,6 +386,69 @@ async function safelyVerifySensitiveCommandAfterSend(
   }
 }
 
+function getRuntimeCapabilitiesSafe(): OscRuntimeCapabilities {
+  const client = getOscClient() as { getRuntimeCapabilities?: () => OscRuntimeCapabilities };
+  return client.getRuntimeCapabilities?.() ?? {
+    canReadJsonQueries: false,
+    readJsonQueriesStatus: 'read_capability_unconfirmed',
+    reason: 'Client OSC de test ou legacy sans API de capacites de lecture JSON.'
+  };
+}
+
+function buildSensitiveSkippedVerification(command: string, requestedVerifyAfterSend?: boolean): CommandVerificationResult {
+  const capability = getRuntimeCapabilitiesSafe();
+  const readUnavailable = !capability.canReadJsonQueries;
+  const warning = requestedVerifyAfterSend === false
+    ? `${sensitiveUnverifiedWarning} Verification desactivee explicitement par verify_after_send=false.`
+    : `${sensitiveUnverifiedWarning} Lecture JSON EOS non disponible (${capability.readJsonQueriesStatus}).`;
+  const nextActions = readUnavailable
+    ? [manualRereadNextAction, confirmStateNextAction]
+    : [confirmStateNextAction];
+
+  return {
+    status: 'skipped',
+    accepted_by_eos: null,
+    verified: false,
+    method: null,
+    warning,
+    warnings: [warning],
+    next_actions: nextActions,
+    details: {
+      reason: requestedVerifyAfterSend === false ? 'verify_after_send_disabled' : 'json_read_unavailable',
+      command,
+      runtime_capabilities: capability
+    }
+  };
+}
+
+async function resolveSensitiveCommandVerification(
+  command: string,
+  options: {
+    user?: number;
+    targetAddress?: string;
+    targetPort?: number;
+    timeoutMs?: number;
+    verifyAfterSend?: boolean;
+  }
+): Promise<CommandVerificationResult | undefined> {
+  if (!isSensitiveCommandText(command)) {
+    return undefined;
+  }
+
+  const capability = getRuntimeCapabilitiesSafe();
+  const shouldVerify = options.verifyAfterSend ?? capability.canReadJsonQueries;
+  if (!shouldVerify) {
+    return buildSensitiveSkippedVerification(command, options.verifyAfterSend);
+  }
+
+  return safelyVerifySensitiveCommandAfterSend(command, {
+    user: options.user,
+    targetAddress: options.targetAddress,
+    targetPort: options.targetPort,
+    timeoutMs: options.timeoutMs
+  });
+}
+
 function formatSendResult(
   command: string,
   user: number | null,
@@ -385,10 +456,11 @@ function formatSendResult(
   verification?: CommandVerificationResult
 ): ToolExecutionResult {
   const isPartialFailure = verification?.status === 'not_verified';
+  const isSensitiveUnverified = verification?.status === 'not_verified' || verification?.status === 'skipped';
   const suffix = verification?.verified === true
     ? ' Verification EOS reussie.'
-    : verification?.status === 'not_verified'
-      ? ` ${unverifiedWarning}.`
+    : isSensitiveUnverified
+      ? ` ${verification.warning ?? unverifiedWarning}.`
       : ' Acceptation EOS non verifiee.';
 
   const text = `Commande remise au transport OSC sur ${oscAddress}: ${command}.${suffix}`;
@@ -397,8 +469,12 @@ function formatSendResult(
     status: isPartialFailure ? 'partial_failure' : 'ok',
     summary: text,
     commandsSent: [command],
-    warnings: verification?.warning ? [{ detail: verification.warning }] : [],
-    next_actions: verification?.status === 'not_verified' ? ['Relire l etat EOS avant d enchainer une action destructive.'] : [],
+    warnings: verification?.warnings?.length
+      ? verification.warnings.map((warning) => ({ detail: warning }))
+      : verification?.warning
+        ? [{ detail: verification.warning }]
+        : [],
+    next_actions: verification?.next_actions ?? (verification?.status === 'not_verified' ? [manualRereadNextAction] : []),
     structuredContent: {
       command,
       user,
@@ -481,14 +557,13 @@ export async function sendDeterministicCommand(options: DeterministicCommandOpti
       targetAddress: options.targetAddress,
       targetPort: options.targetPort
     });
-    const verification = options.verify_after_send && isSensitiveCommandText(command)
-      ? await safelyVerifySensitiveCommandAfterSend(command, {
-          user,
-          targetAddress: options.targetAddress,
-          targetPort: options.targetPort,
-          timeoutMs: options.verification_timeout_ms
-        })
-      : undefined;
+    const verification = await resolveSensitiveCommandVerification(command, {
+      user,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort,
+      timeoutMs: options.verification_timeout_ms,
+      verifyAfterSend: options.verify_after_send
+    });
     return formatSendResult(command, user ?? null, oscMappings.commands.newCommand, verification);
   }
 
@@ -498,14 +573,13 @@ export async function sendDeterministicCommand(options: DeterministicCommandOpti
     targetPort: options.targetPort
   });
 
-  const verification = options.verify_after_send && isSensitiveCommandText(command)
-    ? await safelyVerifySensitiveCommandAfterSend(command, {
-        user,
-        targetAddress: options.targetAddress,
-        targetPort: options.targetPort,
-        timeoutMs: options.verification_timeout_ms
-      })
-    : undefined;
+  const verification = await resolveSensitiveCommandVerification(command, {
+    user,
+    targetAddress: options.targetAddress,
+    targetPort: options.targetPort,
+    timeoutMs: options.verification_timeout_ms,
+    verifyAfterSend: options.verify_after_send
+  });
 
   return formatSendResult(command, user ?? null, oscMappings.commands.command, verification);
 }
@@ -569,14 +643,13 @@ export const eosCommandTool: ToolDefinition<typeof commandInputSchema> = {
       targetPort: options.targetPort
     });
 
-    const verification = options.verify_after_send && isSensitiveCommandText(command)
-      ? await safelyVerifySensitiveCommandAfterSend(command, {
-          user,
-          targetAddress: options.targetAddress,
-          targetPort: options.targetPort,
-          timeoutMs: options.verification_timeout_ms
-        })
-      : undefined;
+    const verification = await resolveSensitiveCommandVerification(command, {
+      user,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort,
+      timeoutMs: options.verification_timeout_ms,
+      verifyAfterSend: options.verify_after_send
+    });
 
     return formatSendResult(command, user ?? null, oscMappings.commands.command, verification);
   }
@@ -695,14 +768,13 @@ export const eosCommandWithSubstitutionTool: ToolDefinition<typeof substitutionC
       targetPort: options.targetPort
     });
 
-    const verification = options.verify_after_send && isSensitiveCommandText(command)
-      ? await safelyVerifySensitiveCommandAfterSend(command, {
-          user,
-          targetAddress: options.targetAddress,
-          targetPort: options.targetPort,
-          timeoutMs: options.verification_timeout_ms
-        })
-      : undefined;
+    const verification = await resolveSensitiveCommandVerification(command, {
+      user,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort,
+      timeoutMs: options.verification_timeout_ms,
+      verifyAfterSend: options.verify_after_send
+    });
 
     return formatSendResult(command, user ?? null, oscMappings.commands.command, verification);
   }


### PR DESCRIPTION
### Motivation
- Éviter d’enchaîner des opérations destructrices après l’envoi d’une commande sensible quand la lecture JSON EOS n’est pas disponible ou n’a pas confirmé l’état, et proposer un comportement par défaut plus sûr lorsque la lecture JSON est confirmée.

### Description
- Ajout de types et de messages d’avertissement plus explicites (`sensitiveUnverifiedWarning`, `manualRereadNextAction`, `confirmStateNextAction`) et extension de `CommandVerificationResult` pour inclure `warnings` et `next_actions` dans `src/tools/commands/command_tools.ts`.
- Introduction d’un résolveur central `resolveSensitiveCommandVerification` et d’un utilitaire `getRuntimeCapabilitiesSafe` qui activent par défaut la vérification post-envoi pour les commandes sensibles si la capacité de lecture JSON est confirmée, et construisent un résultat `skipped` avec warnings/next_actions quand la lecture est indisponible ou que `verify_after_send` est explicitement désactivé.
- Remplacement des appels ad hoc à `safelyVerifySensitiveCommandAfterSend` par `resolveSensitiveCommandVerification` dans `sendDeterministicCommand` et les handlers `eos_command`, `eos_new_command`, `eos_command_with_substitution`, et mise à jour de `formatSendResult` pour exposer les warnings et `next_actions` dans le résultat outil.
- Fichiers modifiés principaux : `src/tools/commands/command_tools.ts` et tests complémentaires `src/tools/commands/__tests__/command_tools.test.ts` ajoutant des scénarios pour la vérification par défaut et le comportement en mode legacy.

### Testing
- Type-check et lint réussis avec `npm run tsc` et `npm run lint`.
- Tests ciblés passés avec `npx jest --passWithNoTests src/tools/commands/__tests__/command_tools.test.ts --runInBand` et `npx jest --passWithNoTests src/tools/__tests__/osc_contracts.test.ts --runInBand`.
- Suite complète d’unitaires et conformance exécutées via `npm run test:unit -- --runInBand` et `npm run test:conformance`, toutes réussies (tous les tests verts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22ec96acd0832aa0793f106f2ce98b)