### PR TITLE
Normalize EOS command terminators

### DIFF
--- a/src/tools/commands/__tests__/command_tools.test.ts
+++ b/src/tools/commands/__tests__/command_tools.test.ts
@@ -8,10 +8,22 @@ import {
   eosCommandTool,
   eosNewCommandTool,
   eosCommandWithSubstitutionTool,
-  eosGetCommandLineTool
+  eosGetCommandLineTool,
+  ensureTerminator
 } from '../command_tools';
 import { clearCurrentUserId, setCurrentUserId } from '../../session';
 import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
+
+describe('ensureTerminator', () => {
+  it.each([
+    ['Record Cue 2', 'Record Cue 2#'],
+    ['Record Cue 2#', 'Record Cue 2#'],
+    ['Delete Cue 2 Enter', 'Delete Cue 2 Enter'],
+    ['Step 1 Thru 8 Enter Enter', 'Step 1 Thru 8 Enter Enter']
+  ])('normalise le terminateur de %s', (command, expectedCommand) => {
+    expect(ensureTerminator(command, true)).toBe(expectedCommand);
+  });
+});
 
 describe('command tools', () => {
   class FakeOscService implements OscGateway {

--- a/src/tools/commands/command_tools.ts
+++ b/src/tools/commands/command_tools.ts
@@ -217,12 +217,13 @@ function assertCommandSyntaxAllowed(command: string, safetyLevel: SafetyLevel): 
   }
 }
 
-function ensureTerminator(command: string, terminate?: boolean): string {
+export function ensureTerminator(command: string, terminate?: boolean): string {
   if (!terminate) {
     return command;
   }
 
-  return command.endsWith('#') ? command : `${command}#`;
+  const normalizedCommand = command.trimEnd();
+  return /(?:#|\bEnter)$/i.test(normalizedCommand) ? normalizedCommand : `${normalizedCommand}#`;
 }
 
 function applySubstitutions(template: string, values: SubstitutionValue[] = []): string {


### PR DESCRIPTION
### Motivation

- Éviter la concaténation incorrecte du terminateur quand `terminateWithEnter=true`, par exemple empêcher qu'une commande comme `Delete Cue 2 Enter` devienne `Delete Cue 2 Enter#`.

### Description

- Exporte et modifie `ensureTerminator` pour tronquer les espaces de fin et considérer comme terminées les commandes se terminant par `#` ou par le jeton `Enter` (cas insensible), au lieu d'ajouter systématiquement `#`.
- Ajoute des tests unitaires pour `ensureTerminator` couvrant `Record Cue 2`, `Record Cue 2#`, `Delete Cue 2 Enter`, et `Step 1 Thru 8 Enter Enter` dans `src/tools/commands/__tests__/command_tools.test.ts`.

### Testing

- Exécuté `npx jest --passWithNoTests src/tools/commands/__tests__/command_tools.test.ts --runInBand` and the focused test suite passed.
- Type-check with `npm run tsc` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f3a59068832a96a4f4cb098e8b82)