### PR TITLE
Handle palette hue value 0 in build_groups_and_palettes

### DIFF
--- a/src/tools/workflows/__tests__/workflows.test.ts
+++ b/src/tools/workflows/__tests__/workflows.test.ts
@@ -857,7 +857,7 @@ describe('workflow tools', () => {
 
   it('genere commands_preview en dry run pour build_groups_and_palettes', async () => {
     const result = await runTool(eosWorkflowBuildGroupsAndPalettesTool, {
-      color_palettes: [{ number: 10, label: 'Warm', channels: '5', hue: 'Amber', saturation: 45 }],
+      color_palettes: [{ number: 10, label: 'Warm', channels: '5', hue: 0, saturation: 45 }],
       dry_run: true
     });
 
@@ -865,7 +865,7 @@ describe('workflow tools', () => {
     const structured = getStructuredContent(result);
     expect(structured?.commands_preview).toEqual([
       'Chan 5',
-      'Hue Amber',
+      'Hue 0',
       'Saturation 45',
       'Record CP 10',
       'CP 10 Label "Warm"'

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -1060,7 +1060,7 @@ const buildGroupsAndPalettesInputSchema = {
     number: z.coerce.number().int().min(1).max(99999),
     label: z.string().trim().min(1).max(128),
     channels: z.string().trim().min(1).max(256),
-    hue: z.string().trim().min(1).max(128).optional(),
+    hue: z.coerce.string().trim().min(1).max(128).optional(),
     saturation: z.coerce.number().finite().optional()
   })).optional(),
   focus_palettes: z.array(workflowObject({
@@ -1278,7 +1278,7 @@ export const eosWorkflowBuildGroupsAndPalettesTool: ToolDefinition<typeof buildG
 
     for (const palette of options.color_palettes ?? []) {
       await queueCommand(`cp_${palette.number}_select_channels`, `Chan ${palette.channels}`);
-      if (palette.hue) await queueCommand(`cp_${palette.number}_set_hue`, `Hue ${palette.hue}`);
+      if (palette.hue != null && palette.hue !== '') await queueCommand(`cp_${palette.number}_set_hue`, `Hue ${palette.hue}`);
       if (palette.saturation != null) await queueCommand(`cp_${palette.number}_set_saturation`, `Saturation ${palette.saturation}`);
       await queueCommand(`cp_${palette.number}_record`, `Record CP ${palette.number}`);
       await queueCommand(`cp_${palette.number}_label`, `CP ${palette.number} Label "${palette.label.replace(/"/g, '\\"')}"`);


### PR DESCRIPTION
### Motivation
- Le test truthy sur `palette.hue` ignorait les valeurs valides équivalentes à `0`, empêchant l'envoi d'une commande `Hue 0` pour des palettes couleur numériques.
- Le schéma d'entrée devait accepter des valeurs numériques coercibles en chaîne afin que `0` soit correctement parsé et rendu.

### Description
- Le champ `hue` du schéma `buildGroupsAndPalettesInputSchema` est maintenant `z.coerce.string()` pour accepter des valeurs numériques comme `0` et les normaliser en chaîne.
- Le test `if (palette.hue)` a été remplacé par une vérification explicite de présence `if (palette.hue != null && palette.hue !== '')` pour ne pas ignorer `0`.
- Le test d'intégration `src/tools/workflows/__tests__/workflows.test.ts` a été mis à jour pour fournir `hue: 0` et vérifier que `commands_preview` contient `Hue 0`.

### Testing
- Exécuté `npm test -- --runInBand src/tools/workflows/__tests__/workflows.test.ts` et les tests ciblés sont passés (suite de tests de workflow passée).
- Exécuté la suite complète de tests (`npm test`) et toutes les suites unitaires et d'intégration pertinentes sont passées (`Test Suites: 58 passed, 58 total`).
- Exécuté la compilation TypeScript avec `npm run tsc` et l'analyse statique `eslint` via `npm run lint`, et les deux ont réussi sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f5f649ac832aa953f480ae38f37d)