### PR TITLE
Vérification des effets créés dans eos_workflow_create_effect

### DIFF
--- a/src/tools/workflows/__tests__/workflows.test.ts
+++ b/src/tools/workflows/__tests__/workflows.test.ts
@@ -33,9 +33,15 @@ class FakeOscService implements OscGateway {
 
   public suppressCommandLineReply = false;
 
+  public suppressEffectInfoReply = false;
+
   public patchReadErrors = new Set<number>();
 
   private readonly recordedCues: Array<{ cuelist: number | null; cue: string }> = [];
+
+  private readonly recordedEffects = new Map<number, { direction: string; speed: number; size: number }>();
+
+  private pendingEffect: { effect: number; direction?: string; speed?: number; size?: number } | null = null;
 
   private readonly listeners = new Set<(message: OscMessage) => void>();
 
@@ -52,6 +58,31 @@ class FakeOscService implements OscGateway {
       const match = /Record\s+Cue\s+(?:(\d+)\s*\/\s*)?([^#\s]+)/i.exec(command);
       if (match) {
         this.recordedCues.push({ cuelist: match[1] == null ? null : Number(match[1]), cue: match[2] ?? '' });
+      }
+
+      const speedMatch = /Effect\s+(\d+)\s+Speed\s+([0-9.]+)/i.exec(command);
+      if (speedMatch) {
+        this.pendingEffect = { ...(this.pendingEffect ?? { effect: Number(speedMatch[1]) }), effect: Number(speedMatch[1]), speed: Number(speedMatch[2]) };
+      }
+
+      const sizeMatch = /Effect\s+(\d+)\s+Size\s+([0-9.]+)/i.exec(command);
+      if (sizeMatch) {
+        this.pendingEffect = { ...(this.pendingEffect ?? { effect: Number(sizeMatch[1]) }), effect: Number(sizeMatch[1]), size: Number(sizeMatch[2]) };
+      }
+
+      const directionMatch = /Effect\s+(\d+)\s+Direction\s+(.+)/i.exec(command);
+      if (directionMatch) {
+        this.pendingEffect = { ...(this.pendingEffect ?? { effect: Number(directionMatch[1]) }), effect: Number(directionMatch[1]), direction: directionMatch[2]?.replace(/#$/, '').trim() };
+      }
+
+      const effectMatch = /Record\s+Effect\s+(\d+)/i.exec(command);
+      if (effectMatch) {
+        const effect = Number(effectMatch[1]);
+        this.recordedEffects.set(effect, {
+          direction: this.pendingEffect?.effect === effect ? this.pendingEffect.direction ?? 'Left To Right' : 'Left To Right',
+          speed: this.pendingEffect?.effect === effect ? this.pendingEffect.speed ?? 1 : 1,
+          size: this.pendingEffect?.effect === effect ? this.pendingEffect.size ?? 100 : 100
+        });
       }
     }
 
@@ -70,6 +101,25 @@ class FakeOscService implements OscGateway {
       });
     }
 
+
+    if (message.address === '/eos/get/effect' && !this.suppressEffectInfoReply) {
+      const rawPayload = message.args?.[0]?.value;
+      const payload = typeof rawPayload === 'string' ? JSON.parse(rawPayload) as { effect?: number } : {};
+      const effect = Number(payload.effect ?? 0);
+      const recorded = this.recordedEffects.get(effect);
+      const responsePayload = recorded == null
+        ? { status: 'error', error: 'Effect not found' }
+        : { effect: { effect_number: effect, direction: recorded.direction, speed: recorded.speed, size: recorded.size } };
+      const reply: OscMessage = {
+        address: '/eos/get/effect',
+        args: [{ type: 's', value: JSON.stringify(responsePayload) }]
+      };
+      queueMicrotask(() => {
+        for (const listener of this.listeners) {
+          listener(reply);
+        }
+      });
+    }
 
     if (message.address === '/eos/get/patch/chan_info') {
       const rawPayload = message.args?.[0]?.value;
@@ -280,6 +330,20 @@ describe('workflow tools', () => {
         size: 75
       }
     });
+    expect(structured?.verification).toEqual(expect.objectContaining({
+      status: 'verified',
+      verified: true,
+      method: 'effect_json',
+      exists: true,
+      parameters: {
+        direction: { expected: 'right_to_left', actual: 'Right To Left', confirmed: true },
+        speed: { expected: 1.5, actual: 1.5, confirmed: true },
+        size: { expected: 75, actual: 75, confirmed: true }
+      }
+    }));
+    expect(structured?.executedSteps).toEqual(expect.arrayContaining([
+      expect.objectContaining({ step: 'record_effect_verify', status: 'ok', detail: 'effect_verified' })
+    ]));
   });
 
   it('applique les valeurs par defaut et dry_run pour create_effect', async () => {
@@ -312,7 +376,8 @@ describe('workflow tools', () => {
   });
 
 
-  it('retourne partial_failure quand Record Effect reste non verifie apres envoi', async () => {
+  it('retourne un warning not_verified quand Record Effect ne peut pas etre confirme apres envoi', async () => {
+    service.suppressEffectInfoReply = true;
     service.suppressCommandLineReply = true;
 
     const result = await runTool(eosWorkflowCreateEffectTool, {
@@ -323,20 +388,28 @@ describe('workflow tools', () => {
     });
 
     const structured = getStructuredContent(result);
-    expect(structured?.status).toBe('partial_failure');
-    expect(result.content[0]?.text).toContain('Workflow creation effet interrompu');
-    expect(structured?.partialErrors).toEqual(expect.arrayContaining([
-      expect.objectContaining({ step: 'record_effect', error: 'commande envoyée mais non vérifiée dans EOS' })
-    ]));
+    expect(structured?.status).toBe('ok');
+    expect(structured?.partialErrors).toEqual([]);
+    expect(structured?.verification).toEqual(expect.objectContaining({
+      status: 'not_verified',
+      verified: false,
+      method: 'command_line',
+      exists: null,
+      warning: 'not_verified'
+    }));
     expect(structured?.warnings).toEqual(expect.arrayContaining([
-      expect.objectContaining({ step: 'record_effect', detail: 'commande envoyée mais non vérifiée dans EOS' })
+      expect.objectContaining({ step: 'record_effect_verify', detail: 'not_verified' })
     ]));
     expect(structured?.executedSteps).toEqual(expect.arrayContaining([
       expect.objectContaining({
         step: 'record_effect',
-        status: 'error',
-        command: 'Record Effect 23',
-        detail: 'verification_after_send_failed'
+        status: 'ok',
+        command: 'Record Effect 23'
+      }),
+      expect.objectContaining({
+        step: 'record_effect_verify',
+        status: 'skipped',
+        detail: 'not_verified'
       })
     ]));
   });

--- a/src/tools/workflows/index.ts
+++ b/src/tools/workflows/index.ts
@@ -346,6 +346,246 @@ async function runCommandStep(
   }
 }
 
+
+interface EffectWorkflowVerification {
+  status: 'verified' | 'not_verified';
+  verified: boolean;
+  accepted_by_eos: boolean | null;
+  method: 'effect_json' | 'command_line' | 'unavailable';
+  effect_number: number;
+  exists: boolean | null;
+  parameters: {
+    direction: { expected: EffectDirection; actual: string | null; confirmed: boolean | null };
+    speed: { expected: number; actual: number | string | null; confirmed: boolean | null };
+    size: { expected: number; actual: number | string | null; confirmed: boolean | null };
+  };
+  warning?: 'not_verified';
+  detail?: string;
+  command_line?: Record<string, unknown>;
+  osc?: {
+    address: string;
+    response_status?: string;
+    error?: string;
+  };
+}
+
+function isWorkflowRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null && !Array.isArray(value);
+}
+
+function normalizeWorkflowToken(value: unknown): string | null {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null;
+  }
+  const normalized = String(value)
+    .trim()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return normalized.length > 0 ? normalized : null;
+}
+
+function parseWorkflowFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return null;
+    }
+    const parsed = Number.parseFloat(trimmed.replace(',', '.').replace(/[^0-9.+-]/g, ''));
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function extractWorkflowEffectRecord(data: unknown): Record<string, unknown> | null {
+  if (!isWorkflowRecord(data)) {
+    return null;
+  }
+  if (isWorkflowRecord(data.effect)) {
+    return data.effect;
+  }
+  if (Array.isArray(data.effects)) {
+    const firstRecord = data.effects.find((entry): entry is Record<string, unknown> => isWorkflowRecord(entry));
+    if (firstRecord) {
+      return firstRecord;
+    }
+  }
+  return data;
+}
+
+function workflowResponseMentionsEffectNotFound(value: unknown, depth = 0): boolean {
+  if (depth > 5 || value == null) {
+    return false;
+  }
+  if (typeof value === 'string') {
+    const lower = value.toLowerCase();
+    return lower.includes('effect not found') || (lower.includes('not found') && lower.includes('effect'));
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => workflowResponseMentionsEffectNotFound(item, depth + 1));
+  }
+  if (isWorkflowRecord(value)) {
+    return Object.values(value).some((item) => workflowResponseMentionsEffectNotFound(item, depth + 1));
+  }
+  return false;
+}
+
+function readWorkflowEffectNumber(record: Record<string, unknown>): number | null {
+  for (const candidate of [record.effect_number, record.number, record.effect, record.id, record.index]) {
+    const numeric = parseWorkflowFiniteNumber(candidate);
+    if (numeric != null) {
+      return Math.trunc(numeric);
+    }
+  }
+  return null;
+}
+
+function readFirstRecordValue(record: Record<string, unknown>, keys: string[]): unknown {
+  for (const key of keys) {
+    if (record[key] != null) {
+      return record[key];
+    }
+  }
+  return null;
+}
+
+function numbersClose(actual: number | null, expected: number): boolean | null {
+  if (actual == null) {
+    return null;
+  }
+  return Math.abs(actual - expected) < 0.0001;
+}
+
+function buildUnverifiedEffectVerification(
+  effectNumber: number,
+  expected: { direction: EffectDirection; speed: number; size: number },
+  method: EffectWorkflowVerification['method'],
+  detail: string,
+  extra: Partial<EffectWorkflowVerification> = {}
+): EffectWorkflowVerification {
+  return {
+    status: 'not_verified',
+    verified: false,
+    accepted_by_eos: null,
+    method,
+    effect_number: effectNumber,
+    exists: null,
+    parameters: {
+      direction: { expected: expected.direction, actual: null, confirmed: null },
+      speed: { expected: expected.speed, actual: null, confirmed: null },
+      size: { expected: expected.size, actual: null, confirmed: null }
+    },
+    warning: 'not_verified',
+    detail,
+    ...extra
+  };
+}
+
+async function verifyEffectAfterRecord(
+  effectNumber: number,
+  expected: { direction: EffectDirection; speed: number; size: number },
+  options: { targetAddress?: string; targetPort?: number; user?: number; verification_timeout_ms?: number }
+): Promise<EffectWorkflowVerification> {
+  const client = getOscClient();
+  try {
+    const response = await client.requestJson(oscMappings.effects.info, {
+      payload: { effect: effectNumber },
+      timeoutMs: options.verification_timeout_ms,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort
+    });
+    if (workflowResponseMentionsEffectNotFound(response.data)) {
+      return buildUnverifiedEffectVerification(effectNumber, expected, 'effect_json', 'effect_absent_after_record', {
+        accepted_by_eos: false,
+        exists: false,
+        osc: { address: oscMappings.effects.info, response_status: response.status, ...(response.error ? { error: response.error } : {}) }
+      });
+    }
+
+    if (response.status === 'ok') {
+      const record = extractWorkflowEffectRecord(response.data);
+      const actualEffectNumber = record ? readWorkflowEffectNumber(record) : null;
+      const exists = actualEffectNumber == null ? record != null : actualEffectNumber === effectNumber;
+      const directionRaw = record == null ? null : readFirstRecordValue(record, ['direction', 'effect_direction', 'pattern_direction', 'grouping']);
+      const speedRaw = record == null ? null : readFirstRecordValue(record, ['speed', 'rate', 'tempo']);
+      const sizeRaw = record == null ? null : readFirstRecordValue(record, ['size', 'scale', 'effect_scale']);
+      const actualDirection = normalizeWorkflowToken(directionRaw);
+      const actualSpeed = parseWorkflowFiniteNumber(speedRaw);
+      const actualSize = parseWorkflowFiniteNumber(sizeRaw);
+      const parameters = {
+        direction: {
+          expected: expected.direction,
+          actual: directionRaw == null ? null : String(directionRaw),
+          confirmed: actualDirection == null ? null : actualDirection === expected.direction
+        },
+        speed: {
+          expected: expected.speed,
+          actual: actualSpeed ?? (speedRaw == null ? null : String(speedRaw)),
+          confirmed: numbersClose(actualSpeed, expected.speed)
+        },
+        size: {
+          expected: expected.size,
+          actual: actualSize ?? (sizeRaw == null ? null : String(sizeRaw)),
+          confirmed: numbersClose(actualSize, expected.size)
+        }
+      };
+      const parametersConfirmed = parameters.direction.confirmed === true
+        && parameters.speed.confirmed === true
+        && parameters.size.confirmed === true;
+      const verified = exists === true && parametersConfirmed;
+      return {
+        status: verified ? 'verified' : 'not_verified',
+        verified,
+        accepted_by_eos: exists === true ? true : null,
+        method: 'effect_json',
+        effect_number: effectNumber,
+        exists,
+        parameters,
+        ...(verified ? {} : { warning: 'not_verified' as const, detail: 'effect_json_incomplete_or_mismatch' }),
+        osc: {
+          address: oscMappings.effects.info,
+          response_status: response.status,
+          ...(response.error ? { error: response.error } : {})
+        }
+      };
+    }
+
+  } catch {
+    // Fallback below: relire la ligne de commande si la lecture JSON dediee n'est pas exploitable.
+  }
+
+  try {
+    const commandLine = await client.getCommandLine({
+      user: options.user,
+      targetAddress: options.targetAddress,
+      targetPort: options.targetPort,
+      timeoutMs: options.verification_timeout_ms
+    });
+    const text = typeof commandLine.text === 'string' ? commandLine.text : '';
+    const lower = text.toLowerCase();
+    const hasConsoleError = lower.includes('error') || lower.includes('erreur');
+    return buildUnverifiedEffectVerification(effectNumber, expected, 'command_line', hasConsoleError ? 'command_line_reports_error' : 'command_line_reread_did_not_confirm_effect', {
+      accepted_by_eos: hasConsoleError ? false : null,
+      command_line: { ...commandLine }
+    });
+  } catch {
+    return buildUnverifiedEffectVerification(effectNumber, expected, 'unavailable', 'effect_verification_unavailable');
+  }
+}
+
+function logEffectVerificationStep(steps: WorkflowStepLog[], verification: EffectWorkflowVerification): void {
+  steps.push({
+    step: 'record_effect_verify',
+    status: verification.verified ? 'ok' : 'skipped',
+    detail: verification.verified ? 'effect_verified' : 'not_verified'
+  });
+}
+
 const createLookInputSchema = {
   channels: z.string().trim().min(1).max(256),
   cue_number: cueNumberSchema,
@@ -514,6 +754,7 @@ export const eosWorkflowCreateEffectTool: ToolDefinition<typeof createEffectInpu
     const steps: WorkflowStepLog[] = [];
     const partialErrors: Array<{ step: string; error: string }> = [];
     const commandsPreview: string[] = [];
+    let effectVerification: EffectWorkflowVerification | null = null;
     const directionLabel = effectDirectionCommandLabels[options.direction];
 
     const commands = [
@@ -534,7 +775,14 @@ export const eosWorkflowCreateEffectTool: ToolDefinition<typeof createEffectInpu
         continue;
       }
 
-      const ok = await runCommandStep(steps, partialErrors, commandStep.step, commandStep.command, options);
+      const ok = await runCommandStep(
+        steps,
+        partialErrors,
+        commandStep.step,
+        commandStep.command,
+        options,
+        { verify_after_send: commandStep.step === 'record_effect' ? false : undefined }
+      );
       if (!ok) {
         return buildWorkflowResult(
           'eos_workflow_create_effect',
@@ -553,9 +801,19 @@ export const eosWorkflowCreateEffectTool: ToolDefinition<typeof createEffectInpu
                 size: options.size
               }
             },
+            ...(effectVerification ? { verification: effectVerification } : {}),
             ...(dryRun ? { commands_preview: commandsPreview } : {})
           }
         );
+      }
+
+      if (commandStep.step === 'record_effect') {
+        effectVerification = await verifyEffectAfterRecord(
+          options.effect_number,
+          { direction: options.direction, speed: options.speed, size: options.size },
+          options
+        );
+        logEffectVerificationStep(steps, effectVerification);
       }
     }
 
@@ -570,7 +828,13 @@ export const eosWorkflowCreateEffectTool: ToolDefinition<typeof createEffectInpu
             speed: options.speed,
             size: options.size
           }
-        }
+        },
+        verification: buildUnverifiedEffectVerification(
+          options.effect_number,
+          { direction: options.direction, speed: options.speed, size: options.size },
+          'unavailable',
+          previewSkipDetail(dryRun)
+        )
       });
     }
 
@@ -591,6 +855,12 @@ export const eosWorkflowCreateEffectTool: ToolDefinition<typeof createEffectInpu
             size: options.size
           }
         },
+        verification: effectVerification ?? buildUnverifiedEffectVerification(
+          options.effect_number,
+          { direction: options.direction, speed: options.speed, size: options.size },
+          'unavailable',
+          dryRun ? 'dry_run' : 'not_verified'
+        ),
         ...(dryRun ? { commands_preview: commandsPreview } : {})
       }
     );


### PR DESCRIPTION
### Motivation
- S'assurer que le `Record Effect {effect_number}` est vérifié après envoi et exposer le résultat de la vérification dans le `structuredContent` du workflow.
- Utiliser une lecture JSON/OSC dédiée si disponible, ou retomber sur la lecture de la ligne de commande et retourner un avertissement `not_verified` quand l'effet ne peut pas être confirmé.

### Description
- Ajout d'un nouveau type et d'utilitaires de parsing/normalisation pour l'analyse des réponses d'effet et comparaison des paramètres direction/speed/size dans `src/tools/workflows/index.ts`.
- Implémentation de `verifyEffectAfterRecord` qui tente d'abord une lecture JSON via `/eos/get/effect` puis, en fallback, relit la ligne de commande; renvoie un objet `verification` détaillant `status`, `verified`, `method`, `exists`, et l'état de confirmation des paramètres.
- Envoi de `Record Effect` sans la vérification générique après envoi et ajout d'une étape de vérification `record_effect_verify` enregistrée dans le journal d'exécution; inclusion de `verification` dans le `structuredContent` pour les chemins success/failure/dry-run/block.
- Mise à jour des tests pour simuler `/eos/get/effect` et capturer les paramètres d'effet (extension de `FakeOscService`) et ajout d'assertions pour les cas vérifiés et non vérifiés.
- Fichiers modifiés principaux: `src/tools/workflows/index.ts` et `src/tools/workflows/__tests__/workflows.test.ts`.

### Testing
- `npm run tsc` exécuté avec succès (TypeScript compile OK). ✅
- Tests unitaires ciblés exécutés: `npx jest --passWithNoTests src/tools/workflows/__tests__/workflows.test.ts --runInBand` et full run for that suite; tous les tests concernés passent. ✅
- `npm run lint` exécuté et terminé sans erreurs bloquantes. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f6cc8e44832a9a81d743e2ad8c99)