### PR TITLE
Use official `/eos/user` for EOS user selection and send integer OSC arg

### DIFF
--- a/docs/conformite-eos.md
+++ b/docs/conformite-eos.md
@@ -180,13 +180,17 @@ Les endpoints non documentes sont les adresses observees ou introduites pour com
 | `eos_toggle_staging_mode` | `/eos/newcmd` | `/eos/newcmd` | Commande texte `Staging Mode` | v3.0.0 | ShowControl > OSC > Ligne de commande (p. 614) | Remplacement de l'extension par une commande officielle. |
 | `eos_set_cue_send_string`, `eos_set_cue_receive_string` | `/eos/newcmd`, `/eos/newcmd` | `/eos/newcmd` | Commande texte de configuration ShowControl | v3.0.0 | ShowControl > OSC > Ligne de commande (p. 614) | Remplacement de l'extension par une commande officielle. |
 
+## Strategie utilisateur OSC
+
+La strategie retenue est unique: le serveur selectionne l'utilisateur courant de la console avec `/eos/user` et un argument OSC entier avant les commandes qui precisent explicitement `user`. Les commandes `/eos/cmd` et `/eos/newcmd` restent envoyees avec leur seul argument texte EOS; l'identifiant utilisateur n'est pas ajoute comme second argument a ces commandes. Les prefixes `/eos/user/<number>/...` ne sont pas utilises dans les mappings MCP actuels, et les arguments utilisateur JSON restent limites aux lectures qui documentent explicitement ce contrat MCP, par exemple `/eos/get/cmd_line`.
+
 ## Systeme & diagnostics
 
 | Outils MCP | Adresse OSC utilisee | Commande OSC officielle (manuel) | Arguments OSC (manuel) | Version | Reference (section/page) | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
 | `eos_get_version` | `/eos/get/version` | `/eos/get/version` | Aucun | v3.0.0 | ShowControl > OSC > Implementer votre application (p. 622) | — |
 | `eos_get_setup_defaults` | `/eos/get/setup_defaults` | _Non documente dans le manuel v3.0.0_ | Requete JSON | n/a | n/a | Extension MCP. |
-| `eos_set_user_id` | `/eos/set/user_id` | `/eos/user` | Numero d'utilisateur OSC | v3.0.0 | ShowControl > OSC > User (p. 613) | MCP utilise un endpoint explicite. |
+| `eos_set_user_id` | `/eos/user` | `/eos/user` | Numero d'utilisateur OSC (argument entier OSC) | v3.0.0 | ShowControl > OSC > User (p. 613) | Strategie unique: selection explicite de l'utilisateur courant via `/eos/user`. |
 | `eos_enable_logging`, `eos_get_diagnostics` | — | _Hors OSC console_ | — | n/a | n/a | Outils serveur MCP. |
 
 ## Outils serveur MCP (hors OSC officiel)

--- a/docs/osc-coverage.md
+++ b/docs/osc-coverage.md
@@ -142,7 +142,7 @@ Les contrats centralisés sont vérifiés dans `src/tools/__tests__/osc_contract
 | dmx | `eos_address_select` | `/eos/addr` | `src/tools/__tests__/osc_contracts.test.ts` |
 | dmx | `eos_address_set_level` | `/eos/addr/{address}` | `src/tools/__tests__/osc_contracts.test.ts` |
 | dmx | `eos_address_set_dmx` | `/eos/addr/{address}/DMX` | `src/tools/__tests__/osc_contracts.test.ts` |
-| programming | `eos_set_user_id` | — | — (outil non OSC ou orchestrateur) |
+| programming | `eos_set_user_id` | `/eos/user` | `src/tools/session/__tests__/session.test.ts` |
 | session | `session_set_current_user` | — | — (outil non OSC ou orchestrateur) |
 | session | `session_get_current_user` | — | — (outil non OSC ou orchestrateur) |
 | session | `session_set_context` | — | — (outil non OSC ou orchestrateur) |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -3702,7 +3702,10 @@ npx @modelcontextprotocol/cli call --tool eos_set_user_id --args '{"user_id":1}'
 
 _OSC_
 
-_Pas de mapping OSC documenté._
+```bash
+# Exemple d'envoi OSC via oscsend
+oscsend 127.0.0.1 8001 /eos/user i:1
+```
 
 <a id="eos-set-xyz-position"></a>
 ## Position XYZ (`eos_set_xyz_position`)

--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -1351,6 +1351,24 @@ describe('OscClient', () => {
     expect(service.sentMessages[0]?.address).toBe('/eos/cmd');
   });
 
+  it('selectionne l utilisateur via /eos/user avant /eos/cmd sans argument utilisateur sur la commande', async () => {
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    await client.sendCommand('Chan 1 At 50', { user: 3 });
+
+    expect(service.sentMessages).toEqual([
+      {
+        address: '/eos/user',
+        args: [{ type: 'i', value: 3 }]
+      },
+      {
+        address: '/eos/cmd',
+        args: [{ type: 's', value: 'Chan 1 At 50' }]
+      }
+    ]);
+  });
+
   it('propage le correlationId du contexte vers les envois OSC', async () => {
     const service = new FakeOscService();
     const client = new OscClient(service);

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -48,6 +48,7 @@ const SUBSCRIBE_REQUEST = '/eos/subscribe';
 const SUBSCRIBE_REPLY = '/eos/subscribe/reply';
 const COMMAND_REQUEST = '/eos/cmd';
 const NEW_COMMAND_REQUEST = '/eos/newcmd';
+const USER_REQUEST = '/eos/user';
 const COMMAND_LINE_GET_REQUEST = '/eos/get/cmd_line';
 const COMMAND_LINE_GET_REPLY = '/eos/get/cmd_line';
 const JSON_STATUS_REQUIRED_ENDPOINTS = new Set<string>([
@@ -1068,7 +1069,12 @@ export class OscClient {
   }
 
   private getSensitiveFamily(address: string): OscQueueFamily | undefined {
-    if (address === COMMAND_REQUEST || address === NEW_COMMAND_REQUEST || address === COMMAND_LINE_GET_REQUEST) {
+    if (
+      address === COMMAND_REQUEST ||
+      address === NEW_COMMAND_REQUEST ||
+      address === USER_REQUEST ||
+      address === COMMAND_LINE_GET_REQUEST
+    ) {
       return 'command-line';
     }
 
@@ -1089,7 +1095,22 @@ export class OscClient {
     options: CommandSendOptions
   ): Promise<void> {
     const address = mode === 'replace' ? NEW_COMMAND_REQUEST : COMMAND_REQUEST;
-    const args = this.buildCommandArgs(command, options.user);
+
+    if (typeof options.user === 'number' && Number.isFinite(options.user)) {
+      await this.send(
+        {
+          address: USER_REQUEST,
+          args: [{ type: 'i', value: Math.trunc(options.user) }]
+        },
+        options,
+        {
+          operation: `la selection de l'utilisateur OSC ${USER_REQUEST}`,
+          details: { user: Math.trunc(options.user) }
+        }
+      );
+    }
+
+    const args = this.buildCommandArgs(command);
 
     await this.send(
       {
@@ -1104,16 +1125,10 @@ export class OscClient {
     );
   }
 
-  private buildCommandArgs(command: string, user?: number): OscMessageArgument[] {
-    const args: OscMessageArgument[] = [
+  private buildCommandArgs(command: string): OscMessageArgument[] {
+    return [
       { type: 's', value: command }
     ];
-
-    if (typeof user === 'number' && Number.isFinite(user)) {
-      args.push({ type: 'i', value: Math.trunc(user) });
-    }
-
-    return args;
   }
 
   private async buildTimeoutConnectResult(options: ConnectOptions, errorMessage: string): Promise<ConnectResult> {

--- a/src/services/osc/mappings.ts
+++ b/src/services/osc/mappings.ts
@@ -211,7 +211,7 @@ export const oscMappings = {
   system: {
     getVersion: '/eos/get/version',
     getSetupDefaults: '/eos/get/setup_defaults',
-    setUserId: '/eos/set/user_id'
+    setUserId: '/eos/user'
   }
 } as const;
 

--- a/src/services/osc/officiality.ts
+++ b/src/services/osc/officiality.ts
@@ -140,7 +140,7 @@ export const OSC_ADDRESS_OFFICIALITY: readonly OscAddressOfficiality[] = [
   official('/eos/cuelist/{bank_index}/config/{cuelist_number}/{num_prev_cues}/{num_pending_cues}'),
   official('/eos/cuelist/{bank_index}/page/{delta}'),
   official('/eos/get/version'),
-  official('/eos/set/user_id', 'Equivalent MCP explicite de la commande officielle /eos/user.'),
+  official('/eos/user'),
   official('/eos/ping'),
   official('/eos/reset'),
   official('/eos/subscribe'),

--- a/src/tools/__tests__/__snapshots__/osc_contracts.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/osc_contracts.test.ts.snap
@@ -679,6 +679,15 @@ exports[`OSC tool contracts exported from src/tools/index.ts eos_set_pantilt_xy 
 ]
 `;
 
+exports[`OSC tool contracts exported from src/tools/index.ts eos_set_user_id sends the documented OSC address, payload, and target endpoint 1`] = `
+[
+  {
+    "type": "i",
+    "value": 7,
+  },
+]
+`;
+
 exports[`OSC tool contracts exported from src/tools/index.ts eos_set_xyz_position sends the documented OSC address, payload, and target endpoint 1`] = `
 [
   {
@@ -858,6 +867,7 @@ exports[`OSC tool contracts exported from src/tools/index.ts lists every exporte
   "eos_address_select",
   "eos_address_set_level",
   "eos_address_set_dmx",
+  "eos_set_user_id",
   "eos_cue_record",
   "eos_cue_update",
   "eos_cue_label_set",

--- a/src/tools/__tests__/osc_contracts.test.ts
+++ b/src/tools/__tests__/osc_contracts.test.ts
@@ -198,6 +198,7 @@ const SAMPLE_VALUES: Record<string, unknown> = {
   ticks: 3,
   timeoutMs: 50,
   user: 7,
+  user_id: 7,
   value: 45,
   values: [1, 50],
   verification_timeout_ms: 50,

--- a/src/tools/commands/__tests__/command_tools.test.ts
+++ b/src/tools/commands/__tests__/command_tools.test.ts
@@ -184,13 +184,14 @@ describe('command tools', () => {
   it('envoie une commande en respectant le terminateur', async () => {
     const result = await runTool(eosCommandTool, { command: 'Go To Cue 1', terminateWithEnter: true, user: 2 });
 
-    expect(service.sentMessages).toHaveLength(1);
+    expect(service.sentMessages).toHaveLength(2);
     expect(service.sentMessages[0]).toMatchObject({
+      address: '/eos/user',
+      args: [{ type: 'i', value: 2 }]
+    });
+    expect(service.sentMessages[1]).toMatchObject({
       address: '/eos/cmd',
-      args: [
-        { type: 's', value: 'Go To Cue 1#' },
-        { type: 'i', value: 2 }
-      ]
+      args: [{ type: 's', value: 'Go To Cue 1#' }]
     });
 
     expect(getStructuredContent(result)).toBeDefined();
@@ -316,13 +317,14 @@ describe('command tools', () => {
 
     await runTool(eosCommandTool, { command: 'Go', terminateWithEnter: true });
 
-    expect(service.sentMessages).toHaveLength(1);
+    expect(service.sentMessages).toHaveLength(2);
     expect(service.sentMessages[0]).toMatchObject({
+      address: '/eos/user',
+      args: [{ type: 'i', value: 6 }]
+    });
+    expect(service.sentMessages[1]).toMatchObject({
       address: '/eos/cmd',
-      args: [
-        { type: 's', value: 'Go#' },
-        { type: 'i', value: 6 }
-      ]
+      args: [{ type: 's', value: 'Go#' }]
     });
   });
 

--- a/src/tools/commands/command_tools.ts
+++ b/src/tools/commands/command_tools.ts
@@ -244,11 +244,18 @@ function applySubstitutions(template: string, values: SubstitutionValue[] = []):
 }
 
 function buildOscDescriptor(command: string, user?: number | null): Record<string, unknown> {
-  const args: Array<{ type: string; value: string | number }> = [{ type: 's', value: command }];
+  const descriptor: Record<string, unknown> = {
+    args: [{ type: 's', value: command }]
+  };
+
   if (typeof user === 'number' && Number.isFinite(user)) {
-    args.push({ type: 'i', value: Math.trunc(user) });
+    descriptor.user_selection = {
+      address: oscMappings.system.setUserId,
+      args: [{ type: 'i', value: Math.trunc(user) }]
+    };
   }
-  return { args };
+
+  return descriptor;
 }
 
 interface CommandVerificationResult {

--- a/src/tools/session/__tests__/session.test.ts
+++ b/src/tools/session/__tests__/session.test.ts
@@ -7,16 +7,40 @@ import {
   clearAllSessionContexts,
   configureSessionContextPersistence,
   getCurrentUserId,
+  eosSetUserIdTool,
   sessionGetCurrentUserTool,
   sessionSetCurrentUserTool
 } from '../index';
+import { setOscClient, type OscClient, type TargetOptions } from '../../../services/osc/client';
+import type { OscMessageArgument } from '../../../services/osc';
 import { getStructuredContent, runTool } from '../../__tests__/helpers/runTool';
 
+class MockOscClient {
+  public readonly calls: Array<{ address: string; args: OscMessageArgument[]; options: TargetOptions }> = [];
+
+  public async sendMessage(
+    address: string,
+    args: OscMessageArgument[] = [],
+    options: TargetOptions = {}
+  ): Promise<void> {
+    this.calls.push({ address, args, options });
+  }
+}
+
 describe('session tools', () => {
+  let oscClient: MockOscClient;
+
   beforeEach(async () => {
     configureSessionContextPersistence({ mode: 'memory' });
     clearCurrentUserId();
+    oscClient = new MockOscClient();
+    setOscClient(oscClient as unknown as OscClient);
     await clearAllSessionContexts();
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+    clearCurrentUserId();
   });
 
   it('stocke le numero utilisateur via le tool de configuration', async () => {
@@ -30,6 +54,31 @@ describe('session tools', () => {
     }
     expect(structuredContent).toMatchObject({ user: 7 });
     expect(structuredContent.suggested_next_actions).toBeDefined();
+  });
+
+  it('envoie /eos/user avec un argument OSC entier pour definir l utilisateur console', async () => {
+    const result = await runTool(eosSetUserIdTool, {
+      user_id: 4,
+      targetAddress: '192.0.2.10',
+      targetPort: 3032
+    });
+
+    expect(oscClient.calls).toEqual([
+      {
+        address: '/eos/user',
+        args: [{ type: 'i', value: 4 }],
+        options: { targetAddress: '192.0.2.10', targetPort: 3032 }
+      }
+    ]);
+    expect(getCurrentUserId()).toBe(4);
+    expect(getStructuredContent(result)).toMatchObject({
+      action: 'set_user_id',
+      user_id: 4,
+      osc: {
+        address: '/eos/user',
+        args: [{ type: 'i', value: 4 }]
+      }
+    });
   });
 
   it('renvoie null lorsqu aucun utilisateur nest defini', async () => {

--- a/src/tools/session/index.ts
+++ b/src/tools/session/index.ts
@@ -228,13 +228,6 @@ const extractTargetOptions = (options: { targetAddress?: string; targetPort?: nu
   return target;
 };
 
-const buildJsonArgs = (payload: Record<string, unknown>) => [
-  {
-    type: 's' as const,
-    value: JSON.stringify(payload)
-  }
-];
-
 /**
  * @tool session_set_current_user
  * @summary Definir utilisateur courant
@@ -319,16 +312,22 @@ export const eosSetUserIdTool: ToolDefinition<typeof setUserIdInputSchema> = {
   config: {
     title: 'Definir identifiant utilisateur EOS',
     description: "Definit l'identifiant utilisateur actif sur la console EOS via OSC.",
-    inputSchema: setUserIdInputSchema
+    inputSchema: setUserIdInputSchema,
+    annotations: {
+      mapping: {
+        osc: oscMappings.system.setUserId,
+        cli: 'user_id',
+        args: ['i:{user_id}']
+      }
+    }
   },
   handler: async (args) => {
     const schema = z.object(setUserIdInputSchema).strict();
     const options = schema.parse(args ?? {});
     const client = getOscClient();
-    const payload = { user_id: options.user_id };
-    const argsList = buildJsonArgs(payload);
+    const oscArgs = [{ type: 'i' as const, value: options.user_id }];
 
-    await client.sendMessage(oscMappings.system.setUserId, argsList, extractTargetOptions(options));
+    await client.sendMessage(oscMappings.system.setUserId, oscArgs, extractTargetOptions(options));
     setCurrentUserId(options.user_id);
 
     return {
@@ -344,7 +343,7 @@ export const eosSetUserIdTool: ToolDefinition<typeof setUserIdInputSchema> = {
         session_user: options.user_id,
         osc: {
           address: oscMappings.system.setUserId,
-          args: payload
+          args: oscArgs
         }
       }
     } as ToolExecutionResult;


### PR DESCRIPTION
### Motivation

- Align MCP behaviour with EOS ShowControl by using the official `/eos/user` OSC address for selecting the console user instead of a bespoke `/eos/set/user_id` mapping. 
- Ensure command-level user context is applied consistently and safely by selecting the user on the console first, then sending the command text without embedding a second user argument. 
- Update documentation, tooling annotations and tests to reflect the single, explicit OSC user-selection strategy.

### Description

- Replaced the mapping `oscMappings.system.setUserId` to point to `/eos/user` in `src/services/osc/mappings.ts` and marked `/eos/user` as official in `src/services/osc/officiality.ts`.
- Implemented explicit user selection in the OSC client: added `USER_REQUEST = '/eos/user'`, made `getSensitiveFamily` treat it as `command-line`, and updated `dispatchCommand` in `src/services/osc/client.ts` to send `/eos/user` with an OSC integer when `options.user` is provided, leaving `/eos/cmd` and `/eos/newcmd` arguments text-only; simplified `buildCommandArgs` accordingly.
- Changed `eos_set_user_id` tool in `src/tools/session/index.ts` to send the user id as an OSC integer argument (`i`) to `/eos/user`, added `config.annotations.mapping` for OSC/CLI and switched the tool payload to integer args.
- Updated command tooling descriptor in `src/tools/commands/command_tools.ts` so `buildOscDescriptor` can advertise a `user_selection` entry referencing `oscMappings.system.setUserId` (used by docs/tests to show the behaviour: select `/eos/user` then send command text).
- Updated tests and snapshots: adjusted `src/tools/commands/__tests__/command_tools.test.ts`, added expectations in `src/services/osc/__tests__/client.test.ts`, extended `src/tools/session/__tests__/session.test.ts` to assert `/eos/user` integer sends, and refreshed snapshots under `src/tools/__tests__/__snapshots__/osc_contracts.test.ts.snap`.
- Regenerated documentation examples and coverage tables: `docs/tools.md`, `docs/conformite-eos.md`, and `docs/osc-coverage.md` now document the `/eos/user` integer usage and the single user-selection strategy.

### Testing

- Ran unit tests for impacted suites: `npm run test:unit -- --runInBand src/tools/__tests__/osc_contracts.test.ts src/tools/commands/__tests__/command_tools.test.ts src/tools/session/__tests__/session.test.ts src/services/osc/__tests__/client.test.ts` and updated one snapshot; these suites passed after updates.
- Ran full test and conformance workflows: `npm test -- --runInBand` and `npm run test:conformance` (EOS conformance integration) and all test suites passed (final run: 58 passed, 58 total; conformance: 11/11 tests passed).
- Performed static checks: `npm run tsc`, `npm run docs:generate` / `npm run docs:check`, and `npm run lint`; these commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f9479a88832a98b4521b9d7bd19f)