### PR TITLE
Support official OSC command-line state and prefer /eos/out over /eos/get/cmd_line

### DIFF
--- a/docs/conformite-eos.md
+++ b/docs/conformite-eos.md
@@ -23,7 +23,7 @@ Plusieurs outils MCP n'envoient pas l'adresse OSC specialisee equivalente; ils e
 
 ### Extensions MCP
 
-Les extensions MCP sont des endpoints crees pour offrir une lecture ou une ergonomie non exposee comme adresse OSC ETC documentee. Elles sont marquees `official=false`; lorsqu'elles pilotent une adresse non documentee, elles sont marquees `strictModeAllowed=false`. Exemples: `/eos/get/patch/chan_pos`, `/eos/get/patch/chan_beam` et certains endpoints JSON de diagnostic/setup.
+Les extensions MCP sont des endpoints crees pour offrir une lecture ou une ergonomie non exposee comme adresse OSC ETC documentee. Elles sont marquees `official=false`; lorsqu'elles pilotent une adresse non documentee, elles sont marquees `strictModeAllowed=false`. Exemples: `/eos/get/cmd_line` (repli MCP/compatibilite simulateur de la ligne de commande), `/eos/get/patch/chan_pos`, `/eos/get/patch/chan_beam` et certains endpoints JSON de diagnostic/setup.
 
 Les adresses de runtime MCP (`/eos/handshake`, `/eos/protocol/select` et replies associees) ne sont pas des commandes pupitre ETC, mais restent `strictModeAllowed=true` car elles sont necessaires a la negociation du transport MCP et ne modifient pas le show.
 
@@ -37,7 +37,7 @@ Les endpoints non documentes sont les adresses observees ou introduites pour com
 | --- | --- | --- | --- | --- | --- | --- |
 | `eos_command`, `eos_command_with_substitution`, `eos_channel_select`, `eos_channel_set_level`, `eos_channel_set_dmx`, `eos_set_dmx`, `eos_cue_stop_back` | `/eos/cmd` | `/eos/cmd` | Chaine de commande (optionnellement terminee par `#`, substitutions `%1..%n`) | v3.0.0 | ShowControl > OSC > Ligne de commande (p. 614) | Utilise pour envoyer des commandes type `Chan`, `Address`, `Cue Stop/Back`. |
 | `eos_new_command`, `eos_cue_record`, `eos_cue_update`, `eos_cue_label_set`, `eos_palette_record`, `eos_palette_label_set`, `eos_patch_set_channel`, `eos_workflow_create_look`, `eos_workflow_patch_fixture`, `eos_workflow_rehearsal_go_safe` | `/eos/newcmd` | `/eos/newcmd` | Chaine de commande (efface la ligne avant l'envoi) | v3.0.0 | ShowControl > OSC > Ligne de commande (p. 614) | Utilise pour les commandes deterministes avec reset de ligne. |
-| `eos_get_command_line`, `eos_get_user_command_line`, `eos_workflow_rehearsal_go_safe` (precheck) | `/eos/get/cmd_line` | _Non documente dans le manuel v3.0.0_ | Requete sans argument, reponse texte ligne de commande | n/a | n/a | Extension MCP pour lecture de ligne de commande. |
+| `eos_get_command_line`, `eos_get_user_command_line`, `eos_workflow_rehearsal_go_safe` (precheck) | Reception memorisee de `/eos/out/cmd` et `/eos/out/user/<number>/cmd`; repli `/eos/get/cmd_line` | `/eos/out/cmd`, `/eos/out/user/<number>/cmd` pour le mode officiel; `/eos/get/cmd_line` est _non documente dans le manuel v3.0.0_ | Sortie OSC implicite de la ligne de commande; repli MCP JSON `{}` ou `{ "user": <id> }` | v3.0.0 pour `/eos/out/...`; n/a pour `/eos/get/cmd_line` | ShowControl > OSC > Sortie OSC implicite (p. 616-617) | Le client OSC memorise la derniere ligne recue depuis `/eos/out/...` et les outils indiquent `source=official_osc_out`. `/eos/get/cmd_line` reste uniquement une extension MCP/compatibilite simulateur (`strictModeAllowed=false`) et donne `source=mcp_extension_get_cmd_line`. |
 
 ## Connexion & ping
 
@@ -182,7 +182,7 @@ Les endpoints non documentes sont les adresses observees ou introduites pour com
 
 ## Strategie utilisateur OSC
 
-La strategie retenue est unique: le serveur selectionne l'utilisateur courant de la console avec `/eos/user` et un argument OSC entier avant les commandes qui precisent explicitement `user`. Les commandes `/eos/cmd` et `/eos/newcmd` restent envoyees avec leur seul argument texte EOS; l'identifiant utilisateur n'est pas ajoute comme second argument a ces commandes. Les prefixes `/eos/user/<number>/...` ne sont pas utilises dans les mappings MCP actuels, et les arguments utilisateur JSON restent limites aux lectures qui documentent explicitement ce contrat MCP, par exemple `/eos/get/cmd_line`.
+La strategie retenue est unique: le serveur selectionne l'utilisateur courant de la console avec `/eos/user` et un argument OSC entier avant les commandes qui precisent explicitement `user`. Les commandes `/eos/cmd` et `/eos/newcmd` restent envoyees avec leur seul argument texte EOS; l'identifiant utilisateur n'est pas ajoute comme second argument a ces commandes. Les prefixes d'envoi `/eos/user/<number>/...` ne sont pas utilises dans les mappings MCP actuels. En reception, `/eos/out/user/<number>/cmd` est en revanche la source officielle memorisee pour la ligne de commande utilisateur. Les arguments utilisateur JSON restent limites au repli d'extension MCP `/eos/get/cmd_line`, bloque en mode strict.
 
 ## Systeme & diagnostics
 

--- a/src/services/osc/__tests__/client.test.ts
+++ b/src/services/osc/__tests__/client.test.ts
@@ -507,6 +507,56 @@ describe('OscClient', () => {
     });
   });
 
+  it('memorise les lignes de commande officielles /eos/out et evite le repli extension', async () => {
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    service.emit({
+      address: '/eos/out/user/3/cmd',
+      args: [{ type: 's', value: 'Chan 3 At 70' }]
+    });
+
+    const result = await client.getCommandLine({ user: 3 });
+
+    expect(result).toMatchObject({
+      status: 'ok',
+      text: 'Chan 3 At 70',
+      user: 3,
+      source: 'official_osc_out'
+    });
+    expect(service.sentMessages).toHaveLength(0);
+  });
+
+  it('decode les messages globaux /eos/out/cmd avec utilisateur et texte', async () => {
+    const service = new FakeOscService();
+    const client = new OscClient(service);
+
+    service.emit({
+      address: '/eos/out/cmd',
+      args: [
+        { type: 's', value: 'User 4' },
+        { type: 's', value: 'Chan 4 At Full' }
+      ]
+    });
+
+    const result = await client.getCommandLine({ user: 4 });
+    const latestResult = await client.getCommandLine();
+
+    expect(result).toMatchObject({
+      status: 'ok',
+      text: 'Chan 4 At Full',
+      user: 4,
+      source: 'official_osc_out'
+    });
+    expect(latestResult).toMatchObject({
+      status: 'ok',
+      text: 'Chan 4 At Full',
+      user: 4,
+      source: 'official_osc_out'
+    });
+    expect(service.sentMessages).toHaveLength(0);
+  });
+
   it('retourne un mode degrade lorsque le handshake expire mais que le ping repond et la lecture timeout', async () => {
     const service = new FakeOscService();
     const client = new OscClient(service);

--- a/src/services/osc/__tests__/officiality.test.ts
+++ b/src/services/osc/__tests__/officiality.test.ts
@@ -27,12 +27,19 @@ describe('OSC address officiality classification', () => {
     expect(getOscAddressOfficiality('/eos/fader/1/2/3')?.strictModeAllowed).toBe(true);
     expect(getOscAddressOfficiality('/eos/group/4/level')?.official).toBe(true);
     expect(getOscAddressOfficiality('/eos/key/go_0')?.official).toBe(true);
+    expect(getOscAddressOfficiality('/eos/out/user/3/cmd')).toMatchObject({ official: true, strictModeAllowed: true });
   });
 
   it('identifie les extensions MCP bloquees en mode strict', () => {
     const extension = getOscAddressOfficiality('/eos/get/patch/chan_pos');
     expect(extension).toMatchObject({ official: false, strictModeAllowed: false, source: 'MCP extension' });
+    expect(getOscAddressOfficiality('/eos/get/cmd_line')).toMatchObject({
+      official: false,
+      strictModeAllowed: false,
+      source: 'MCP extension'
+    });
     expect(() => assertOscAddressStrictModeAllowed('/eos/get/patch/chan_pos', strictEnv)).toThrow(/EOS_STRICT_MODE bloque/);
+    expect(() => assertOscAddressStrictModeAllowed('/eos/get/cmd_line', strictEnv)).toThrow(/EOS_STRICT_MODE bloque/);
   });
 
   it('autorise /eos/cmd et les commandes runtime necessaires en mode strict', () => {

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -51,6 +51,8 @@ const NEW_COMMAND_REQUEST = '/eos/newcmd';
 const USER_REQUEST = '/eos/user';
 const COMMAND_LINE_GET_REQUEST = '/eos/get/cmd_line';
 const COMMAND_LINE_GET_REPLY = '/eos/get/cmd_line';
+const COMMAND_LINE_OUT_GLOBAL = '/eos/out/cmd';
+const COMMAND_LINE_OUT_USER_PATTERN = /^\/eos\/out\/user\/(-?\d+)\/cmd$/;
 const JSON_STATUS_REQUIRED_ENDPOINTS = new Set<string>([
   '/eos/get/cue'
 ]);
@@ -209,11 +211,14 @@ export interface CommandLineRequestOptions extends TargetOptions {
   timeoutMs?: number;
 }
 
+export type CommandLineSource = 'official_osc_out' | 'mcp_extension_get_cmd_line';
+
 export interface CommandLineState extends Record<string, unknown> {
   status: StepStatus;
   text: string;
   user: number | null;
   payload: unknown;
+  source: CommandLineSource | null;
   error?: string;
 }
 
@@ -292,10 +297,17 @@ export class OscClient {
 
   private readJsonCapabilityChecked = false;
 
+  private readonly commandLineState = new Map<string, CommandLineState>();
+
+  private readonly disposeCommandLineStateListener: () => void;
+
   constructor(private readonly gateway: OscGateway, private readonly config: OscClientConfig = {}) {
     this.requestQueue = new RequestQueue({ concurrency: config.requestConcurrency });
     this.requestQueueTimeoutMs =
       config.queueTimeoutMs ?? config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS;
+    this.disposeCommandLineStateListener = this.gateway.onMessage((message) => {
+      this.rememberCommandLineMessage(message);
+    });
   }
 
   public getRuntimeCapabilities(): OscRuntimeCapabilities {
@@ -913,11 +925,19 @@ export class OscClient {
   }
 
   public async getCommandLine(options: CommandLineRequestOptions = {}): Promise<CommandLineState> {
+    const requestedUser = typeof options.user === 'number' && Number.isFinite(options.user)
+      ? Math.trunc(options.user)
+      : null;
+    const cached = this.getRememberedCommandLine(requestedUser);
+    if (cached) {
+      return cached;
+    }
+
     const timeoutMs = options.timeoutMs ?? this.config.defaultTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS;
     const requestPayload: Record<string, unknown> = {};
 
-    if (typeof options.user === 'number' && Number.isFinite(options.user)) {
-      requestPayload.user = Math.trunc(options.user);
+    if (requestedUser !== null) {
+      requestPayload.user = requestedUser;
     }
 
     const operation = 'la lecture de la ligne de commande OSC';
@@ -964,7 +984,8 @@ export class OscClient {
         status: 'ok',
         text: decoded.text,
         user: decoded.user,
-        payload
+        payload,
+        source: 'mcp_extension_get_cmd_line'
       };
     } catch (error) {
       const timeoutError = this.asAppError(error, ErrorCode.OSC_TIMEOUT);
@@ -974,6 +995,7 @@ export class OscClient {
           text: '',
           user: null,
           payload: null,
+          source: null,
           error: timeoutError.message
         };
       }
@@ -985,12 +1007,65 @@ export class OscClient {
           text: '',
           user: null,
           payload: null,
+          source: null,
           error: connectionLostError.message
         };
       }
 
       throw error;
     }
+  }
+
+  private rememberCommandLineMessage(message: OscMessage): void {
+    const decoded = this.decodeCommandLineOutMessage(message);
+    if (!decoded) {
+      return;
+    }
+
+    const state: CommandLineState = {
+      status: 'ok',
+      text: decoded.text,
+      user: decoded.user,
+      payload: message,
+      source: 'official_osc_out'
+    };
+
+    this.commandLineState.set(this.commandLineStateKey(decoded.user), state);
+    this.commandLineState.set(this.commandLineStateKey(null), state);
+  }
+
+  private getRememberedCommandLine(user: number | null): CommandLineState | null {
+    const state = this.commandLineState.get(this.commandLineStateKey(user));
+    return state ? { ...state } : null;
+  }
+
+  private commandLineStateKey(user: number | null): string {
+    return user === null ? 'global' : `user:${user}`;
+  }
+
+  private decodeCommandLineOutMessage(message: OscMessage): { text: string; user: number | null } | null {
+    if (message.address === COMMAND_LINE_OUT_GLOBAL) {
+      const first = message.args?.[0]?.value;
+      const second = message.args?.[1]?.value;
+      if (typeof first === 'number' && second !== undefined) {
+        return { text: String(second ?? ''), user: Math.trunc(first) };
+      }
+      if (typeof first === 'string' && second !== undefined) {
+        const decodedUser = this.decodeUser(first);
+        return decodedUser !== null
+          ? { text: String(second ?? ''), user: decodedUser }
+          : { text: [first, second].map((value) => String(value ?? '')).join(' '), user: null };
+      }
+      return { text: first == null ? '' : String(first), user: null };
+    }
+
+    const userMatch = message.address.match(COMMAND_LINE_OUT_USER_PATTERN);
+    if (userMatch) {
+      const first = message.args?.[0]?.value;
+      return { text: first == null ? '' : String(first), user: Number.parseInt(userMatch[1] ?? '', 10) };
+    }
+
+    return null;
   }
 
   private async send(

--- a/src/services/osc/officiality.ts
+++ b/src/services/osc/officiality.ts
@@ -48,7 +48,9 @@ function undocumented(address: string): OscAddressOfficiality {
 export const OSC_ADDRESS_OFFICIALITY: readonly OscAddressOfficiality[] = [
   command('/eos/cmd'),
   command('/eos/newcmd'),
-  official('/eos/get/cmd_line'),
+  extension('/eos/get/cmd_line'),
+  official('/eos/out/cmd'),
+  official('/eos/out/user/{number}/cmd'),
   official('/eos/key'),
   official('/eos/key/{key}'),
   official('/eos/softkey/{index}'),

--- a/src/tools/__tests__/osc_contracts.test.ts
+++ b/src/tools/__tests__/osc_contracts.test.ts
@@ -87,7 +87,7 @@ class MockOscClient {
       args: [{ type: 's', value: JSON.stringify(payload) }],
       options
     });
-    return { status: 'ok', text: 'Chan 1', user: options.user ?? null, payload };
+    return { status: 'ok', text: 'Chan 1', user: options.user ?? null, payload, source: 'mcp_extension_get_cmd_line' };
   }
 
   private captureCommand(address: string, command: string, options: TargetOptions & { user?: number }): void {

--- a/src/tools/commands/__tests__/command_tools.test.ts
+++ b/src/tools/commands/__tests__/command_tools.test.ts
@@ -306,10 +306,33 @@ describe('command tools', () => {
     expect(structuredContent).toMatchObject({
       status: 'ok',
       text: 'Chan 1 At 50',
-      user: 4
+      user: 4,
+      source: 'mcp_extension_get_cmd_line',
+      source_description: 'source extension MCP/simulateur /eos/get/cmd_line'
     });
 
+    expect(result.content?.[0]?.text).toContain('source extension MCP/simulateur /eos/get/cmd_line');
     expect(service.sentMessages[0]).toMatchObject({ address: '/eos/get/cmd_line' });
+  });
+
+  it('indique la source officielle lorsque la ligne de commande vient de /eos/out/user/<number>/cmd', async () => {
+    service.emit({
+      address: '/eos/out/user/4/cmd',
+      args: [{ type: 's', value: 'Chan 4 At 80' }]
+    });
+
+    const result = await runTool(eosGetCommandLineTool, { user: 4 });
+    const structuredContent = getStructuredContent(result);
+
+    expect(structuredContent).toMatchObject({
+      status: 'ok',
+      text: 'Chan 4 At 80',
+      user: 4,
+      source: 'official_osc_out',
+      source_description: 'source officielle /eos/out/cmd ou /eos/out/user/<number>/cmd'
+    });
+    expect(result.content?.[0]?.text).toContain('source officielle /eos/out/cmd ou /eos/out/user/<number>/cmd');
+    expect(service.sentMessages).toHaveLength(0);
   });
 
   it('utilise le numero utilisateur stocke lorsquaucun identifiant nest fourni', async () => {

--- a/src/tools/commands/command_tools.ts
+++ b/src/tools/commands/command_tools.ts
@@ -502,15 +502,20 @@ function formatSendResult(
 }
 
 function formatCommandLineState(result: CommandLineState): ToolExecutionResult {
+  const sourceLabel = result.source === 'official_osc_out'
+    ? 'source officielle /eos/out/cmd ou /eos/out/user/<number>/cmd'
+    : result.source === 'mcp_extension_get_cmd_line'
+      ? 'source extension MCP/simulateur /eos/get/cmd_line'
+      : 'source inconnue';
   const text = result.status === 'ok'
-    ? `Ligne de commande utilisateur ${result.user ?? 'global'}: ${result.text}`
-    : `Lecture de la ligne de commande indisponible (${result.status})`;
+    ? `Ligne de commande utilisateur ${result.user ?? 'global'} (${sourceLabel}): ${result.text}`
+    : `Lecture de la ligne de commande indisponible (${result.status}, ${sourceLabel})`;
   return buildToolResult({
     text,
     status: result.status,
     summary: text,
     warnings: result.status === 'ok' ? [] : [text],
-    structuredContent: { ...result }
+    structuredContent: { ...result, source_description: sourceLabel }
   });
 }
 
@@ -803,7 +808,7 @@ const userCommandLineInputSchema = {
 /**
  * @tool eos_get_command_line
  * @summary Lecture de la ligne de commande EOS
- * @description Recupere le contenu courant de la ligne de commande via OSC Get.
+ * @description Recupere le contenu courant depuis les messages officiels /eos/out/... memorises, avec repli extension MCP /eos/get/cmd_line.
  * @arguments Voir docs/tools.md#eos-get-command-line pour le schema complet.
  * @returns ToolExecutionResult avec contenu texte et objet.
  * @example CLI Consultez docs/tools.md#eos-get-command-line pour un exemple CLI.
@@ -813,7 +818,7 @@ export const eosGetCommandLineTool: ToolDefinition<typeof commandLineInputSchema
   name: 'eos_get_command_line',
   config: {
     title: 'Lecture de la ligne de commande EOS',
-    description: 'Recupere le contenu courant de la ligne de commande via OSC Get.',
+    description: 'Recupere le contenu courant depuis les messages officiels /eos/out/... memorises, avec repli extension MCP /eos/get/cmd_line.',
     inputSchema: commandLineInputSchema,
     annotations: mappingAnnotations(oscMappings.commands.getCommandLine, 'command_line_query')
   },
@@ -846,7 +851,7 @@ export const eosGetCommandLineTool: ToolDefinition<typeof commandLineInputSchema
 /**
  * @tool eos_get_user_command_line
  * @summary Lecture de la ligne de commande utilisateur
- * @description Recupere la ligne de commande pour un utilisateur specifique.
+ * @description Recupere la ligne de commande utilisateur depuis /eos/out/user/<number>/cmd memorise, avec repli extension MCP /eos/get/cmd_line.
  * @arguments Voir docs/tools.md#eos-get-user-command-line pour le schema complet.
  * @returns ToolExecutionResult avec contenu texte et objet.
  * @example CLI Consultez docs/tools.md#eos-get-user-command-line pour un exemple CLI.
@@ -856,7 +861,7 @@ export const eosGetUserCommandLineTool: ToolDefinition<typeof userCommandLineInp
   name: 'eos_get_user_command_line',
   config: {
     title: 'Lecture de la ligne de commande utilisateur',
-    description: 'Recupere la ligne de commande pour un utilisateur specifique.',
+    description: 'Recupere la ligne de commande utilisateur depuis /eos/out/user/<number>/cmd memorise, avec repli extension MCP /eos/get/cmd_line.',
     inputSchema: userCommandLineInputSchema,
     annotations: mappingAnnotations(oscMappings.commands.getCommandLine, 'user_command_line_query')
   },


### PR DESCRIPTION
### Motivation
- Distinguish official EOS command-line events from the MCP/simulator JSON fallback and prefer the official messages when available.  
- Keep `/eos/get/cmd_line` only as an MCP extension compatibility fallback and block it in strict mode.  
- Make the tools clearly report which source provided the command-line (official `/eos/out/...` vs MCP extension).  
- Provide the OSC client with an in-memory state so readers can obtain the most-recent official command-line without forcing a fallback request.

### Description
- Added constants and parsing for official command-line outputs (`COMMAND_LINE_OUT_GLOBAL = '/eos/out/cmd'` and `COMMAND_LINE_OUT_USER_PATTERN`) in `src/services/osc/client.ts`.  
- Added `CommandLineSource` and a `source` field to `CommandLineState`, and implemented an in-memory cache that listens to gateway messages (`gateway.onMessage`) and remembers the last `/eos/out/cmd` and `/eos/out/user/<n>/cmd` lines; `getCommandLine` returns the cached official value if present before issuing a `/eos/get/cmd_line` request.  
- Kept `/eos/get/cmd_line` as an MCP extension (fallback) and annotated returned states from that path with `source: 'mcp_extension_get_cmd_line'`.  
- Reclassified addresses in `src/services/osc/officiality.ts` so `/eos/get/cmd_line` is an MCP `extension` (`strictModeAllowed=false`) and added official entries for `/eos/out/cmd` and `/eos/out/user/{number}/cmd`.  
- Updated `src/tools/commands/command_tools.ts` to include a human-readable `source_description` in `structuredContent` and to display the source in tool text output, and adjusted tool JSDoc descriptions to document the official `/eos/out/...` reception with `/eos/get/cmd_line` as fallback.  
- Updated mocks and tests (`src/services/osc/__tests__/client.test.ts`, `src/services/osc/__tests__/officiality.test.ts`, `src/tools/commands/__tests__/command_tools.test.ts`, `src/tools/__tests__/osc_contracts.test.ts`) to assert source distinctions and behaviour, and modified the mock client to return `source` where appropriate.  
- Updated documentation `docs/conformite-eos.md` to describe the official `/eos/out/...` reception behavior and the MCP fallback semantics.

### Testing
- Ran the full unit/conformance test suite with `npm test -- --runInBand` and targeted Jest runs; all tests passed.  
- Type-checked with `npm run tsc` (successful).  
- Linted with `npm run lint` (successful).  
- Ran targeted test commands used during development (`npx jest` on modified test files) and observed all related suites passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22fb8e76e0832aaf18f20bf7775645)