### PR TITLE
Add strict OSC routing policy metadata

### DIFF
--- a/src/services/osc/messageBuilders.ts
+++ b/src/services/osc/messageBuilders.ts
@@ -5,6 +5,7 @@
 import { z } from 'zod';
 import { buildDmxAddressDmxAddress, buildDmxAddressLevelAddress, oscMappings } from './mappings';
 import type { OscMessage, OscMessageArgument } from './index';
+import { getOscAddressOfficiality } from './officiality';
 
 const jsonArgumentSchema = z.object({
   type: z.literal('s'),
@@ -20,6 +21,71 @@ const intArgumentSchema = z.object({
   type: z.literal('i'),
   value: z.number().int()
 });
+
+export type StrictModeBehavior =
+  | 'native_official_required'
+  | 'validated_cmd_fallback'
+  | 'blocked_without_validated_cmd_fallback'
+  | 'no_osc_transport';
+
+export interface OscToolStrictModePolicy {
+  nativeOscPreferred: boolean;
+  cmdFallbackAllowed: boolean;
+  requiresConfirmation: boolean;
+  strictModeBehavior: StrictModeBehavior;
+  officialOscAddresses: string[];
+  blockedOscAddresses: string[];
+}
+
+export interface BuildOscToolStrictModePolicyOptions {
+  oscAddresses?: readonly string[];
+  requiresConfirmation?: boolean;
+}
+
+const VALIDATED_COMMAND_FALLBACK_ADDRESSES = new Set<string>([
+  oscMappings.commands.command,
+  oscMappings.commands.newCommand
+]);
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return Array.from(new Set(values.filter((value) => value.length > 0)));
+}
+
+/**
+ * Central policy used by MCP tools to expose how strict OSC mode must handle
+ * native ETC OSC endpoints versus validated Eos command-line text.
+ */
+export function buildOscToolStrictModePolicy(
+  options: BuildOscToolStrictModePolicyOptions = {}
+): OscToolStrictModePolicy {
+  const addresses = uniqueStrings(options.oscAddresses ?? []);
+  const officialOscAddresses = addresses.filter((address) => getOscAddressOfficiality(address)?.strictModeAllowed === true);
+  const blockedOscAddresses = addresses.filter((address) => getOscAddressOfficiality(address)?.strictModeAllowed !== true);
+  const hasNativeOfficialAddress = officialOscAddresses.some((address) => !VALIDATED_COMMAND_FALLBACK_ADDRESSES.has(address));
+  const hasCommandFallback = addresses.some((address) => VALIDATED_COMMAND_FALLBACK_ADDRESSES.has(address));
+
+  let strictModeBehavior: StrictModeBehavior = 'no_osc_transport';
+  if (hasNativeOfficialAddress) {
+    strictModeBehavior = blockedOscAddresses.length > 0
+      ? 'blocked_without_validated_cmd_fallback'
+      : 'native_official_required';
+  } else if (hasCommandFallback) {
+    strictModeBehavior = blockedOscAddresses.length > 0
+      ? 'blocked_without_validated_cmd_fallback'
+      : 'validated_cmd_fallback';
+  } else if (blockedOscAddresses.length > 0) {
+    strictModeBehavior = 'blocked_without_validated_cmd_fallback';
+  }
+
+  return {
+    nativeOscPreferred: blockedOscAddresses.length === 0 && hasNativeOfficialAddress,
+    cmdFallbackAllowed: blockedOscAddresses.length === 0 && !hasNativeOfficialAddress && hasCommandFallback,
+    requiresConfirmation: options.requiresConfirmation === true,
+    strictModeBehavior,
+    officialOscAddresses,
+    blockedOscAddresses
+  };
+}
 
 export interface OscWireContract {
   address: string;

--- a/src/tools/__tests__/osc_contracts.test.ts
+++ b/src/tools/__tests__/osc_contracts.test.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import type { OscMessage, OscMessageArgument } from '../../services/osc/index';
 import { setOscClient, type OscClient, type OscJsonResponse, type TargetOptions } from '../../services/osc/client';
 import { oscResponseMappings, toEosOutResponseAddress } from '../../services/osc/mappings';
+import { getOscAddressOfficiality } from '../../services/osc/officiality';
 import type { BuiltOscWireMessage } from '../../services/osc/messageBuilders';
 import toolDefinitions from '../index';
 import type { ToolDefinition } from '../types';
@@ -367,6 +368,46 @@ describe('OSC tool contracts exported from src/tools/index.ts', () => {
       }
       expect(addresses).toContain(requestAddress);
       expect(addresses).toContain(toEosOutResponseAddress(requestAddress));
+    }
+  });
+
+
+  it('defines strict OSC routing policy metadata for every tool', () => {
+    for (const tool of toolDefinitions) {
+      expect(typeof tool.metadata?.nativeOscPreferred).toBe('boolean');
+      expect(typeof tool.metadata?.cmdFallbackAllowed).toBe('boolean');
+      expect(typeof tool.metadata?.requiresConfirmation).toBe('boolean');
+      expect(tool.metadata?.strictModeBehavior).toMatch(/^(native_official_required|validated_cmd_fallback|blocked_without_validated_cmd_fallback|no_osc_transport)$/);
+      expect(tool.config.annotations).toMatchObject({
+        nativeOscPreferred: tool.metadata?.nativeOscPreferred,
+        cmdFallbackAllowed: tool.metadata?.cmdFallbackAllowed,
+        requiresConfirmation: tool.metadata?.requiresConfirmation,
+        strictModeBehavior: tool.metadata?.strictModeBehavior
+      });
+    }
+  });
+
+  it('does not mark unofficial OSC aliases as native strict-mode targets', () => {
+    for (const tool of oscTools) {
+      const policy = tool.config.annotations?.oscStrictModePolicy as {
+        nativeOscPreferred: boolean;
+        cmdFallbackAllowed: boolean;
+        strictModeBehavior: string;
+        officialOscAddresses: string[];
+        blockedOscAddresses: string[];
+      };
+      expect(policy).toBeDefined();
+      for (const address of policy.officialOscAddresses) {
+        expect(getOscAddressOfficiality(address)?.strictModeAllowed).toBe(true);
+      }
+      for (const address of policy.blockedOscAddresses) {
+        expect(getOscAddressOfficiality(address)?.strictModeAllowed).not.toBe(true);
+      }
+      if (policy.blockedOscAddresses.length > 0) {
+        expect(policy.strictModeBehavior).toBe('blocked_without_validated_cmd_fallback');
+        expect(policy.nativeOscPreferred).toBe(false);
+        expect(policy.cmdFallbackAllowed).toBe(false);
+      }
     }
   });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -37,9 +37,10 @@ import dmxTools from './dmx/index';
 import sessionTools from './session/index';
 import programmingTools from './programming/index';
 import workflowTools from './workflows/index';
+import { buildOscToolStrictModePolicy } from '../services/osc/messageBuilders';
 import type { ToolDefinition } from './types';
 
-const definitions = [
+const rawDefinitions = [
   eosCapabilitiesGetTool,
   pingTool,
   eosConnectTool,
@@ -76,6 +77,52 @@ const definitions = [
   ...sessionTools,
   ...programmingTools
 ];
+
+function collectOscAddresses(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectOscAddresses(entry));
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).flatMap((entry) => collectOscAddresses(entry));
+  }
+  return [];
+}
+
+function withStrictOscPolicy(tool: ToolDefinition): ToolDefinition {
+  const mapping = tool.config.annotations?.mapping as { osc?: unknown } | undefined;
+  const requiresConfirmation = tool.metadata?.requiresConfirmation === true;
+  const policy = buildOscToolStrictModePolicy({
+    oscAddresses: collectOscAddresses(mapping?.osc),
+    requiresConfirmation
+  });
+
+  return {
+    ...tool,
+    config: {
+      ...tool.config,
+      annotations: {
+        ...(tool.config.annotations ?? {}),
+        nativeOscPreferred: policy.nativeOscPreferred,
+        cmdFallbackAllowed: policy.cmdFallbackAllowed,
+        requiresConfirmation: policy.requiresConfirmation,
+        strictModeBehavior: policy.strictModeBehavior,
+        oscStrictModePolicy: policy
+      }
+    },
+    metadata: {
+      ...(tool.metadata ?? {}),
+      nativeOscPreferred: policy.nativeOscPreferred,
+      cmdFallbackAllowed: policy.cmdFallbackAllowed,
+      requiresConfirmation: policy.requiresConfirmation,
+      strictModeBehavior: policy.strictModeBehavior
+    }
+  };
+}
+
+const definitions = rawDefinitions.map((tool) => withStrictOscPolicy(tool as ToolDefinition));
 
 export const toolDefinitions = definitions as ToolDefinition[];
 

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { ZodRawShape } from 'zod';
+import type { StrictModeBehavior } from '../services/osc/messageBuilders';
 import type { ToolSafetyProfile } from './common/safety';
 
 export interface ToolResultContent {
@@ -187,6 +188,9 @@ export interface ToolMetadata {
   synonyms?: string[];
   riskLevel?: ToolRiskLevel;
   requiresConfirmation?: boolean;
+  nativeOscPreferred?: boolean;
+  cmdFallbackAllowed?: boolean;
+  strictModeBehavior?: StrictModeBehavior;
   preferredWorkflow?: string | string[];
   requiredRole?: ToolSafetyProfile;
 }


### PR DESCRIPTION
### Motivation
- Centraliser une politique expliquant comment les outils MCP doivent se comporter en `EOS_STRICT_MODE` (préférer les endpoints OSC natifs officiels, autoriser/autoriser pas le fallback commande texte, exiger la confirmation, ou bloquer les aliases non officiels). 
- Éviter que des alias OSC non officiels soient traités silencieusement comme cibles natives en mode strict. 
- Fournir des métadonnées exploitables par la registry d'outils pour guider le routage et l'affichage des outils. 

### Description
- Ajout d'un builder central `buildOscToolStrictModePolicy` dans `src/services/osc/messageBuilders.ts` qui calcule `nativeOscPreferred`, `cmdFallbackAllowed`, `requiresConfirmation`, `strictModeBehavior`, `officialOscAddresses` et `blockedOscAddresses`. 
- Étendue du type `ToolMetadata` dans `src/tools/types.ts` pour exposer `nativeOscPreferred`, `cmdFallbackAllowed` et `strictModeBehavior`. 
- Application automatique de la politique à chaque outil exporté dans `src/tools/index.ts`, la rendant disponible à la fois dans `tool.metadata` et `tool.config.annotations` (`oscStrictModePolicy`). 
- Ajout de tests de contrat dans `src/tools/__tests__/osc_contracts.test.ts` vérifiant que chaque outil publie la politique stricte et que les aliases non officiels ne sont pas marqués comme cibles natives en mode strict. 

### Testing
- Exécution ciblée des tests de contrat et d'officialité avec `npm test -- --runTestsByPath src/tools/__tests__/osc_contracts.test.ts src/services/osc/__tests__/officiality.test.ts` qui sont passés (`Test Suites: 3 passed, 3 total` puis plus globalement `58 passed, 58 total`). 
- Compilation TypeScript vérifiée avec `npm run tsc` qui a réussi. 
- Lint réussi via `npm run lint` sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22ffc8704c832a99e1908c14c86322)