### PR TITLE
test: add priority OSC tool coverage

### DIFF
--- a/docs/osc-coverage.md
+++ b/docs/osc-coverage.md
@@ -94,6 +94,30 @@ Toutes les adresses `/eos/get/` declarees par les services OSC, les outils MCP, 
 
 Les contrats centralisés sont vérifiés dans `src/tools/__tests__/osc_contracts.test.ts` : adresse OSC, arguments OSC (snapshots), propagation `targetAddress` / `targetPort`, transformation d'erreur OSC en résultat MCP stable et rejet des paramètres inconnus pour les schémas stricts. Les tests de famille sous `src/tools/**/__tests__` conservent les scénarios métier détaillés.
 
+
+## Suite OSC prioritaire (ajout 2026-06-06)
+
+La suite dédiée `src/tools/__tests__/osc_priority_tools.test.ts` couvre maintenant les outils demandés en priorité avec des assertions explicites sur :
+
+- l'adresse OSC générée et les arguments envoyés ;
+- le comportement strict déclaré (`native_official_required` ou blocage de l'extension `/eos/get/cmd_line`) ;
+- le comportement de compatibilité des cues `fire`, `go` et `select` via le repli `/eos/cmd` ;
+- le rejet des entrées invalides et des paramètres inconnus ;
+- le comportement `dry_run`, sans émission OSC, pour les outils prioritaires.
+
+| Outil prioritaire | Couverture additionnelle obtenue |
+| --- | --- |
+| `eos_channel_set_parameter` | Frames natives par canal, tri/dédoublonnage des canaux, argument float, politique stricte native, rejet des canaux invalides, `dry_run` sans envoi. |
+| `eos_address_select` | Adresse `/eos/addr`, argument adresse normalisée, politique stricte native, rejet des adresses libres dangereuses, `dry_run` sans envoi. |
+| `eos_address_set_level` | Adresse `/eos/addr/{address}`, argument float de niveau, politique stricte native, rejet niveau hors plage, `dry_run` sans envoi. |
+| `eos_address_set_dmx` | Adresse `/eos/addr/{address}/DMX`, argument entier DMX, politique stricte native, rejet DMX hors plage, `dry_run` sans envoi. |
+| `eos_softkey_press` | Adresse `/eos/softkey/{index}`, argument d'état, politique stricte native, rejet index hors plage, `dry_run` sans envoi. |
+| `eos_set_user_id` | Adresse `/eos/user`, argument entier utilisateur, politique stricte native, rejet utilisateur invalide, `dry_run` sans mutation de session ni envoi. |
+| `eos_get_command_line` | Payload utilisateur sur `/eos/get/cmd_line`, blocage strict documenté de l'extension non officielle, rejet utilisateur invalide, `dry_run` sans lecture. |
+| `eos_cue_fire` | Mode strict natif `/eos/cue/{cue}/fire`, mode compatibilité `/eos/cmd`, rejet cue invalide, `dry_run` sans envoi. |
+| `eos_cue_go` | Mode strict natif `/eos/cue/{cuelist}/go`, mode compatibilité `/eos/cmd`, rejet paire cue/part invalide, `dry_run` sans envoi. |
+| `eos_cue_select` | Mode strict natif `/eos/cue/{cue}`, mode compatibilité `/eos/cmd`, rejet paramètres inconnus, `dry_run` sans envoi. |
+
 | Famille | Outil MCP exporté | Commande OSC | Test associé |
 | --- | --- | --- | --- |
 | capabilities | `eos_capabilities_get` | — | — (outil non OSC ou orchestrateur) |
@@ -115,13 +139,13 @@ Les contrats centralisés sont vérifiés dans `src/tools/__tests__/osc_contract
 | commands | `eos_command` | `/eos/cmd` | `src/tools/__tests__/osc_contracts.test.ts` |
 | commands | `eos_new_command` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
 | commands | `eos_command_with_substitution` | `/eos/cmd` | `src/tools/__tests__/osc_contracts.test.ts` |
-| commands | `eos_get_command_line` | `/eos/get/cmd_line` | `src/tools/__tests__/osc_contracts.test.ts` |
+| commands | `eos_get_command_line` | `/eos/get/cmd_line` | `src/tools/__tests__/osc_contracts.test.ts`; `src/tools/__tests__/osc_priority_tools.test.ts` |
 | commands | `eos_get_user_command_line` | `/eos/get/cmd_line` | `src/tools/__tests__/osc_contracts.test.ts` |
 | channels | `eos_channel_select` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
 | channels | `eos_channel_set_level` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
 | channels | `eos_channel_set_dmx` | `/eos/newcmd` | `src/tools/__tests__/osc_contracts.test.ts` |
 | programming | `eos_set_dmx` | `/eos/addr/{address}/DMX` | `src/tools/__tests__/osc_contracts.test.ts` |
-| channels | `eos_channel_set_parameter` | `/eos/chan/{channel}/param/{parameter}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| channels | `eos_channel_set_parameter` | `/eos/chan/{channel}/param/{parameter}` | `src/tools/__tests__/osc_contracts.test.ts`; `src/tools/__tests__/osc_priority_tools.test.ts` |
 | channels | `eos_channel_get_info` | `/eos/get/channels` | `src/tools/__tests__/osc_contracts.test.ts` |
 | groups | `eos_group_select` | `/eos/group` | `src/tools/__tests__/osc_contracts.test.ts` |
 | groups | `eos_group_set_level` | `/eos/group/{group}/level` | `src/tools/__tests__/osc_contracts.test.ts` |
@@ -133,10 +157,10 @@ Les contrats centralisés sont vérifiés dans `src/tools/__tests__/osc_contract
 | diagnostics | `eos_console_targets` | — | — (outil non OSC ou orchestrateur) |
 | diagnostics | `eos_get_version` | — | — (outil non OSC ou orchestrateur) |
 | diagnostics | `eos_get_setup_defaults` | — | — (outil non OSC ou orchestrateur) |
-| cues | `eos_cue_fire` | `/eos/cue/{cuelist}/{cue}/fire` (fallback `/eos/cmd`) | `src/tools/__tests__/osc_contracts.test.ts` |
-| cues | `eos_cue_go` | `/eos/cue/{cuelist}/go` (fallback `/eos/cmd`) | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cue_fire` | `/eos/cue/{cuelist}/{cue}/fire` (fallback `/eos/cmd`) | `src/tools/__tests__/osc_contracts.test.ts`; `src/tools/__tests__/osc_priority_tools.test.ts` |
+| cues | `eos_cue_go` | `/eos/cue/{cuelist}/go` (fallback `/eos/cmd`) | `src/tools/__tests__/osc_contracts.test.ts`; `src/tools/__tests__/osc_priority_tools.test.ts` |
 | cues | `eos_cue_stop_back` | `/eos/cmd` | `src/tools/__tests__/osc_contracts.test.ts` |
-| cues | `eos_cue_select` | `/eos/cue/{cue}` (fallback `/eos/cmd`) | `src/tools/__tests__/osc_contracts.test.ts` |
+| cues | `eos_cue_select` | `/eos/cue/{cue}` (fallback `/eos/cmd`) | `src/tools/__tests__/osc_contracts.test.ts`; `src/tools/__tests__/osc_priority_tools.test.ts` |
 | cues | `eos_cue_get_info` | `/eos/get/cue` | `src/tools/__tests__/osc_contracts.test.ts` |
 | cues | `eos_cue_list_all` | `/eos/get/cuelist` | `src/tools/__tests__/osc_contracts.test.ts` |
 | cues | `eos_cuelist_get_info` | `/eos/get/cuelist/info` | `src/tools/__tests__/osc_contracts.test.ts` |
@@ -174,7 +198,7 @@ Les contrats centralisés sont vérifiés dans `src/tools/__tests__/osc_contract
 | programming | `eos_set_xyz_position` | `/eos/param/position/xyz` | `src/tools/__tests__/osc_contracts.test.ts` |
 | queries | `eos_get_active_wheels` | `/eos/get/active/wheels` | `src/tools/__tests__/osc_contracts.test.ts` |
 | keys | `eos_key_press` | `/eos/key/{key}` | `src/tools/__tests__/osc_contracts.test.ts` |
-| keys | `eos_softkey_press` | `/eos/softkey/{index}` | `src/tools/__tests__/osc_contracts.test.ts` |
+| keys | `eos_softkey_press` | `/eos/softkey/{index}` | `src/tools/__tests__/osc_contracts.test.ts`; `src/tools/__tests__/osc_priority_tools.test.ts` |
 | keys | `eos_get_softkey_labels` | `/eos/get/softkey_labels` | `src/tools/__tests__/osc_contracts.test.ts` |
 | directSelects | `eos_direct_select_bank_create` | `/eos/ds/{index}/config/{target}/{buttons}/{flexi}/{page}` | `src/tools/__tests__/osc_contracts.test.ts` |
 | directSelects | `eos_direct_select_press` | `/eos/ds/{index}/button/{page}/{button}` | `src/tools/__tests__/osc_contracts.test.ts` |
@@ -209,10 +233,10 @@ Les contrats centralisés sont vérifiés dans `src/tools/__tests__/osc_contract
 | fpe | `eos_fpe_get_set_count` | `/eos/get/fpe/set/count` | `src/tools/__tests__/osc_contracts.test.ts` |
 | fpe | `eos_fpe_get_set_info` | `/eos/get/fpe/set` | `src/tools/__tests__/osc_contracts.test.ts` |
 | fpe | `eos_fpe_get_point_info` | `/eos/get/fpe/point` | `src/tools/__tests__/osc_contracts.test.ts` |
-| dmx | `eos_address_select` | `/eos/addr` | `src/tools/__tests__/osc_contracts.test.ts` |
-| dmx | `eos_address_set_level` | `/eos/addr/{address}` | `src/tools/__tests__/osc_contracts.test.ts` |
-| dmx | `eos_address_set_dmx` | `/eos/addr/{address}/DMX` | `src/tools/__tests__/osc_contracts.test.ts` |
-| programming | `eos_set_user_id` | `/eos/user` | `src/tools/session/__tests__/session.test.ts` |
+| dmx | `eos_address_select` | `/eos/addr` | `src/tools/__tests__/osc_contracts.test.ts`; `src/tools/__tests__/osc_priority_tools.test.ts` |
+| dmx | `eos_address_set_level` | `/eos/addr/{address}` | `src/tools/__tests__/osc_contracts.test.ts`; `src/tools/__tests__/osc_priority_tools.test.ts` |
+| dmx | `eos_address_set_dmx` | `/eos/addr/{address}/DMX` | `src/tools/__tests__/osc_contracts.test.ts`; `src/tools/__tests__/osc_priority_tools.test.ts` |
+| programming | `eos_set_user_id` | `/eos/user` | `src/tools/session/__tests__/session.test.ts`; `src/tools/__tests__/osc_priority_tools.test.ts` |
 | session | `session_set_current_user` | — | — (outil non OSC ou orchestrateur) |
 | session | `session_get_current_user` | — | — (outil non OSC ou orchestrateur) |
 | session | `session_set_context` | — | — (outil non OSC ou orchestrateur) |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -336,6 +336,10 @@ Catégories documentées : `commands`, `cues`, `diagnostics`, `dmx`, `keys`, `ma
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `address_number` | number \| string | Oui | Adresse DMX au format 'univers/adresse' ou numero absolu. |
+| `confirm` | boolean | Non | — |
+| `dry_run` | boolean | Non | — |
+| `require_confirmation` | boolean | Non | — |
+| `safety_level` | enum(strict, standard, off) | Non | — |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 
@@ -376,7 +380,11 @@ oscsend 127.0.0.1 8001 /eos/addr s:'{"address_number":1}'
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `address_number` | number \| string | Oui | Adresse DMX au format 'univers/adresse' ou numero absolu. |
+| `confirm` | boolean | Non | — |
 | `dmx_value` | number \| enum(full, Full, FULL, out, Out, OUT) \| string | Oui | — |
+| `dry_run` | boolean | Non | — |
+| `require_confirmation` | boolean | Non | — |
+| `safety_level` | enum(strict, standard, off) | Non | — |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 
@@ -417,7 +425,11 @@ oscsend 127.0.0.1 8001 /eos/addr/{address}/DMX s:'{"address_number":1,"dmx_value
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `address_number` | number \| string | Oui | Adresse DMX au format 'univers/adresse' ou numero absolu. |
+| `confirm` | boolean | Non | — |
+| `dry_run` | boolean | Non | — |
 | `level` | number \| enum(full, Full, FULL, out, Out, OUT) \| string | Oui | — |
+| `require_confirmation` | boolean | Non | — |
+| `safety_level` | enum(strict, standard, off) | Non | — |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 
@@ -675,7 +687,11 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'Chan 1 Sneak 1'
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
 | `channels` | number \| array<number> \| string | Oui | Un numero de canal ou une liste de canaux |
+| `confirm` | boolean | Non | — |
+| `dry_run` | boolean | Non | — |
 | `parameter` | string | Oui | — |
+| `require_confirmation` | boolean | Non | — |
+| `safety_level` | enum(strict, standard, off) | Non | — |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `value` | number \| string | Oui | — |
@@ -2880,7 +2896,11 @@ oscsend 127.0.0.1 8001 /eos/ip/fire s:'{"palette_number":1}'
 
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
+| `confirm` | boolean | Non | — |
+| `dry_run` | boolean | Non | — |
 | `key_name` | string | Oui | — |
+| `require_confirmation` | boolean | Non | — |
+| `safety_level` | enum(strict, standard, off) | Non | — |
 | `state` | number \| boolean | Non | — |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
@@ -4041,6 +4061,10 @@ oscsend 127.0.0.1 8001 /eos/param/position/xy s:'{"x":1,"y":1}'
 
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
+| `confirm` | boolean | Non | — |
+| `dry_run` | boolean | Non | — |
+| `require_confirmation` | boolean | Non | — |
+| `safety_level` | enum(strict, standard, off) | Non | — |
 | `targetAddress` | string | Non | — |
 | `targetPort` | number | Non | — |
 | `user_id` | number | Oui | — |
@@ -4439,6 +4463,10 @@ oscsend 127.0.0.1 8001 /eos/snap s:'{"snapshot_number":1}'
 
 | Nom | Type | Requis | Description |
 | --- | --- | --- | --- |
+| `confirm` | boolean | Non | — |
+| `dry_run` | boolean | Non | — |
+| `require_confirmation` | boolean | Non | — |
+| `safety_level` | enum(strict, standard, off) | Non | — |
 | `softkey_number` | number | Oui | — |
 | `state` | number \| boolean | Non | — |
 | `targetAddress` | string | Non | — |

--- a/src/tools/__tests__/osc_priority_tools.test.ts
+++ b/src/tools/__tests__/osc_priority_tools.test.ts
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { z } from 'zod';
+import type { OscMessageArgument } from '../../services/osc/index';
+import { setOscClient, type OscClient, type TargetOptions } from '../../services/osc/client';
+import toolDefinitions from '../index';
+import type { ToolDefinition, ToolExecutionResult } from '../types';
+import { runTool, getStructuredContent } from './helpers/runTool';
+
+type CapturedCall = {
+  address: string;
+  args: OscMessageArgument[];
+  options: TargetOptions;
+};
+
+class PriorityOscClient {
+  public readonly calls: CapturedCall[] = [];
+
+  public async sendMessage(address: string, args: OscMessageArgument[] = [], options: TargetOptions = {}): Promise<void> {
+    this.calls.push({ address, args, options });
+  }
+
+  public async getCommandLine(options: TargetOptions & { user?: number } = {}): Promise<Record<string, unknown>> {
+    const payload: Record<string, unknown> = {};
+    if (typeof options.user === 'number') {
+      payload.user = options.user;
+    }
+    this.calls.push({
+      address: '/eos/get/cmd_line',
+      args: [{ type: 's', value: JSON.stringify(payload) }],
+      options
+    });
+    return {
+      status: 'ok',
+      text: 'Chan 1 At Full',
+      user: options.user ?? null,
+      payload,
+      source: 'mcp_extension_get_cmd_line'
+    };
+  }
+}
+
+function priorityTool(name: string): ToolDefinition {
+  const tool = toolDefinitions.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error(`Missing priority tool ${name}`);
+  }
+  return tool;
+}
+
+function parseStrictSchema(tool: ToolDefinition, args: Record<string, unknown>): void {
+  if (tool.config.inputSchema) {
+    z.object(tool.config.inputSchema).strict().parse(args);
+  }
+}
+
+function structured(result: ToolExecutionResult): Record<string, unknown> {
+  const content = getStructuredContent(result);
+  if (!content) {
+    throw new Error('Expected structured content');
+  }
+  return content;
+}
+
+const nonCueCases = [
+  {
+    name: 'eos_channel_set_parameter',
+    args: { channels: [2, 1], parameter: 'pan', value: '45', targetAddress: '192.0.2.10', targetPort: 3032 },
+    expectedCalls: [
+      { address: '/eos/chan/1/param/pan', args: [{ type: 'f', value: 45 }] },
+      { address: '/eos/chan/2/param/pan', args: [{ type: 'f', value: 45 }] }
+    ],
+    invalidArgs: { channels: [], parameter: 'pan', value: 45 },
+    dryRunOscAddress: '/eos/chan/1/param/pan'
+  },
+  {
+    name: 'eos_address_select',
+    args: { address_number: '2/41', targetAddress: '192.0.2.10', targetPort: 3032 },
+    expectedCalls: [{ address: '/eos/addr', args: [{ type: 's', value: '2/041' }] }],
+    invalidArgs: { address_number: '1 Delete Cue 2' },
+    dryRunOscAddress: '/eos/addr'
+  },
+  {
+    name: 'eos_address_set_level',
+    args: { address_number: '1/001', level: '37.5%', targetAddress: '192.0.2.10', targetPort: 3032 },
+    expectedCalls: [{ address: '/eos/addr/1%2F001', args: [{ type: 'f', value: 37.5 }] }],
+    invalidArgs: { address_number: '1/001', level: 101 },
+    dryRunOscAddress: '/eos/addr/1%2F001'
+  },
+  {
+    name: 'eos_address_set_dmx',
+    args: { address_number: '1/120', dmx_value: 'full', targetAddress: '192.0.2.10', targetPort: 3032 },
+    expectedCalls: [{ address: '/eos/addr/1%2F120/DMX', args: [{ type: 'i', value: 255 }] }],
+    invalidArgs: { address_number: '1/120', dmx_value: 300 },
+    dryRunOscAddress: '/eos/addr/1%2F120/DMX'
+  },
+  {
+    name: 'eos_softkey_press',
+    args: { softkey_number: 3, state: false, targetAddress: '192.0.2.10', targetPort: 3032 },
+    expectedCalls: [{ address: '/eos/softkey/3', args: [{ type: 'f', value: 0 }] }],
+    invalidArgs: { softkey_number: 13 },
+    dryRunOscAddress: '/eos/softkey/3'
+  },
+  {
+    name: 'eos_set_user_id',
+    args: { user_id: 7, targetAddress: '192.0.2.10', targetPort: 3032 },
+    expectedCalls: [{ address: '/eos/user', args: [{ type: 'i', value: 7 }] }],
+    invalidArgs: { user_id: -1 },
+    dryRunOscAddress: '/eos/user'
+  }
+] as const;
+
+describe('suite OSC prioritaire', () => {
+  let client: PriorityOscClient;
+
+  beforeEach(() => {
+    client = new PriorityOscClient();
+    setOscClient(client as unknown as OscClient);
+  });
+
+  afterEach(() => {
+    setOscClient(null);
+  });
+
+  it.each(nonCueCases)('$name genere les adresses et arguments OSC attendus', async (testCase) => {
+    const tool = priorityTool(testCase.name);
+    parseStrictSchema(tool, testCase.args);
+
+    await runTool(tool, testCase.args);
+
+    expect(client.calls).toEqual(testCase.expectedCalls.map((call) => ({
+      ...call,
+      options: expect.objectContaining({ targetAddress: '192.0.2.10', targetPort: 3032 })
+    })));
+  });
+
+  it.each(nonCueCases)('$name declare un comportement strict natif et aucun alias de compatibilite non strict', (testCase) => {
+    const tool = priorityTool(testCase.name);
+
+    expect(tool.metadata?.strictModeBehavior).toBe('native_official_required');
+    expect(tool.metadata?.nativeOscPreferred).toBe(true);
+    expect(tool.metadata?.cmdFallbackAllowed).toBe(false);
+    expect(tool.config.annotations?.oscStrictModePolicy).toMatchObject({
+      blockedOscAddresses: [],
+      strictModeBehavior: 'native_official_required'
+    });
+  });
+
+  it.each(nonCueCases)('$name rejette les entrees invalides et les parametres inconnus', async (testCase) => {
+    const tool = priorityTool(testCase.name);
+
+    await expect(runTool(tool, testCase.invalidArgs)).rejects.toThrow();
+    await expect(runTool(tool, { ...testCase.args, unexpected_parameter: true })).rejects.toThrow();
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it.each(nonCueCases)('$name expose un dry_run sans emission OSC', async (testCase) => {
+    const tool = priorityTool(testCase.name);
+
+    const result = await runTool(tool, { ...testCase.args, dry_run: true });
+    const content = structured(result);
+
+    expect(client.calls).toHaveLength(0);
+    expect(content).toMatchObject({ status: 'dry_run', dry_run: true });
+    expect(content.osc).toMatchObject({ address: testCase.dryRunOscAddress });
+  });
+
+  it('eos_get_command_line lit la ligne de commande avec payload utilisateur et cible OSC', async () => {
+    const tool = priorityTool('eos_get_command_line');
+    const args = { user: 7, targetAddress: '192.0.2.10', targetPort: 3032, timeoutMs: 50 };
+    parseStrictSchema(tool, args);
+
+    const result = await runTool(tool, args);
+
+    expect(client.calls).toEqual([
+      {
+        address: '/eos/get/cmd_line',
+        args: [{ type: 's', value: JSON.stringify({ user: 7 }) }],
+        options: expect.objectContaining({ user: 7, targetAddress: '192.0.2.10', targetPort: 3032, timeoutMs: 50 })
+      }
+    ]);
+    expect(structured(result)).toMatchObject({ status: 'ok', text: 'Chan 1 At Full', user: 7 });
+  });
+
+  it('eos_get_command_line documente le blocage strict de son endpoint extension et simule le dry_run', async () => {
+    const tool = priorityTool('eos_get_command_line');
+
+    expect(tool.metadata?.strictModeBehavior).toBe('blocked_without_validated_cmd_fallback');
+    expect(tool.metadata?.nativeOscPreferred).toBe(false);
+    expect(tool.config.annotations?.oscStrictModePolicy).toMatchObject({
+      blockedOscAddresses: ['/eos/get/cmd_line']
+    });
+
+    await expect(runTool(tool, { user: -1 })).rejects.toThrow();
+
+    const result = await runTool(tool, { user: 7, dry_run: true });
+    expect(client.calls).toHaveLength(0);
+    expect(structured(result)).toMatchObject({
+      status: 'dry_run',
+      dry_run: true,
+      osc: { address: '/eos/get/cmd_line', args: { user: 7 } }
+    });
+  });
+
+  it('cues fire/go/select utilisent les endpoints natifs en mode strict', async () => {
+    await runTool(priorityTool('eos_cue_fire'), { cue_number: 2, confirm: true }, { cueOscMode: 'strict' });
+    await runTool(priorityTool('eos_cue_go'), { cuelist_number: 1 }, { cueOscMode: 'strict' });
+    await runTool(priorityTool('eos_cue_select'), { cue_number: 2 }, { cueOscMode: 'strict' });
+
+    expect(client.calls).toEqual([
+      { address: '/eos/cue/2/fire', args: [], options: expect.objectContaining({ wireContract: expect.objectContaining({ family: 'cue' }) }) },
+      { address: '/eos/cue/1/go', args: [], options: expect.objectContaining({ wireContract: expect.objectContaining({ family: 'cue' }) }) },
+      { address: '/eos/cue/2', args: [], options: expect.objectContaining({ wireContract: expect.objectContaining({ family: 'cue' }) }) }
+    ]);
+  });
+
+  it('cues fire/go/select basculent vers /eos/cmd en mode compatibilite', async () => {
+    await runTool(priorityTool('eos_cue_fire'), { cuelist_number: 3, cue_number: 2, confirm: true }, { cueOscMode: 'compatibility' });
+    await runTool(priorityTool('eos_cue_go'), { cuelist_number: 1 }, { cueOscMode: 'compatibility' });
+    await runTool(priorityTool('eos_cue_select'), { cue_number: 2 }, { cueOscMode: 'compatibility' });
+
+    expect(client.calls).toEqual([
+      { address: '/eos/cmd', args: [{ type: 's', value: 'Cue 2 CueList 3 Fire' }], options: expect.objectContaining({ wireContract: expect.objectContaining({ family: 'cue' }) }) },
+      { address: '/eos/cmd', args: [{ type: 's', value: 'CueList 1 Go' }], options: expect.objectContaining({ wireContract: expect.objectContaining({ family: 'cue' }) }) },
+      { address: '/eos/cmd', args: [{ type: 's', value: 'Cue 2' }], options: expect.objectContaining({ wireContract: expect.objectContaining({ family: 'cue' }) }) }
+    ]);
+  });
+
+  it('cues fire/go/select rejettent les entrees invalides et les parametres inconnus', async () => {
+    await expect(runTool(priorityTool('eos_cue_fire'), { cue_number: 0, confirm: true })).rejects.toThrow();
+    await expect(runTool(priorityTool('eos_cue_go'), { cuelist_number: 1, cue_part: 1 })).rejects.toThrow();
+    await expect(runTool(priorityTool('eos_cue_select'), { cue_number: 1, unexpected_parameter: true })).rejects.toThrow();
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it('cues fire/go/select exposent le dry_run sans emission OSC', async () => {
+    const fire = structured(await runTool(priorityTool('eos_cue_fire'), { cue_number: 2, dry_run: true }));
+    const go = structured(await runTool(priorityTool('eos_cue_go'), { cuelist_number: 1, dry_run: true }));
+    const select = structured(await runTool(priorityTool('eos_cue_select'), { cue_number: 2, dry_run: true }));
+
+    expect(client.calls).toHaveLength(0);
+    expect(fire).toMatchObject({ status: 'dry_run', dry_run: true, osc: { address: '/eos/cue/2/fire', args: [] } });
+    expect(go).toMatchObject({ status: 'dry_run', dry_run: true, osc: { address: '/eos/cue/1/go', args: [] } });
+    expect(select).toMatchObject({ status: 'dry_run', dry_run: true, osc: { address: '/eos/cue/2', args: [] } });
+  });
+});

--- a/src/tools/channels/index.ts
+++ b/src/tools/channels/index.ts
@@ -14,6 +14,7 @@ import { getOscClient, type OscJsonResponse, type StepStatus } from '../../servi
 import type { OscMessageArgument } from '../../services/osc/index';
 import { buildChannelParameterAddress, oscMappings } from '../../services/osc/mappings';
 import { buildDmxAddressDmxMessage } from '../../services/osc/messageBuilders';
+import { createDryRunResult, resolveSafetyOptions, safetyOptionsSchema } from '../common/safety';
 import { sendDeterministicCommand } from '../commands/command_tools';
 import type { ToolDefinition, ToolExecutionResult } from '../types';
 
@@ -371,7 +372,8 @@ const setParameterSchema = {
   channels: channelListSchema,
   parameter: z.string().min(1),
   value: parameterValueSchema,
-  ...targetOptionsSchema
+  ...targetOptionsSchema,
+  ...safetyOptionsSchema
 } satisfies ZodRawShape;
 
 const getInfoSchema = {
@@ -605,6 +607,22 @@ export const eosChannelSetParameterTool: ToolDefinition<typeof setParameterSchem
       address: buildChannelParameterAddress(channel, options.parameter),
       args: oscArgs
     }));
+
+    if (resolveSafetyOptions(options).dryRun) {
+      return createDryRunResult({
+        text: `Reglage du parametre ${options.parameter} simule pour les canaux ${channels.join(', ')}`,
+        action: 'set_parameter',
+        request: { channels, parameter: options.parameter, value },
+        oscAddress: frames[0]?.address ?? '/eos/chan/{channel}/param/{parameter}',
+        oscArgs: oscArgs,
+        extra: {
+          channels,
+          parameter: options.parameter,
+          value,
+          frames
+        }
+      });
+    }
 
     for (const frame of frames) {
       await client.sendMessage(frame.address, frame.args, targetOptions);

--- a/src/tools/cues/select.ts
+++ b/src/tools/cues/select.ts
@@ -5,6 +5,7 @@
 import { z, type ZodRawShape } from 'zod';
 import { getOscClient } from '../../services/osc/client';
 import { oscMappings } from '../../services/osc/mappings';
+import { createDryRunResult, resolveSafetyOptions } from '../common/safety';
 import type { ToolDefinition } from '../types';
 import {
   buildCueSelectCommand,
@@ -58,6 +59,18 @@ export const eosCueSelectTool: ToolDefinition<typeof selectInputSchema> = {
     const payload = buildCueCommandPayload(identifier, { defaultPart: 0 });
     const command = buildCueSelectCommand(identifier);
     const oscRequest = buildCueSelectOscRequest(identifier, command, resolveCueOscMode(extra));
+    const safety = resolveSafetyOptions(options);
+
+    if (safety.dryRun) {
+      return createDryRunResult({
+        text: `Selection simulee de ${formatCueDescription(identifier)}`,
+        action: 'cue_select',
+        request: payload,
+        oscAddress: oscRequest.message.address,
+        oscArgs: oscRequest.message.args ?? [],
+        cli: oscRequest.command ? { text: oscRequest.command } : undefined
+      });
+    }
 
     await client.sendMessage(oscRequest.message.address, oscRequest.message.args ?? [], {
       ...extractTargetOptions(options),

--- a/src/tools/dmx/index.ts
+++ b/src/tools/dmx/index.ts
@@ -11,11 +11,13 @@ import {
   buildDmxAddressLevelMessage,
   buildDmxAddressSelectMessage
 } from '../../services/osc/messageBuilders';
+import { createDryRunResult, resolveSafetyOptions, safetyOptionsSchema } from '../common/safety';
 import { buildToolResult, withToolMetadata, type ToolDefinition, type ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
-  targetPort: z.coerce.number().int().min(1).max(65535).optional()
+  targetPort: z.coerce.number().int().min(1).max(65535).optional(),
+  ...safetyOptionsSchema
 } satisfies ZodRawShape;
 
 const LEVEL_KEYWORDS: Record<string, number> = {
@@ -196,6 +198,16 @@ export const eosAddressSelectTool: ToolDefinition<typeof addressSelectInputSchem
     const address = normaliseAddress(options.address_number);
     const request = buildDmxAddressSelectMessage(address);
 
+    if (resolveSafetyOptions(options).dryRun) {
+      return createDryRunResult({
+        text: `Selection d'adresse DMX ${address} simulee`,
+        action: 'address_select',
+        request: { address },
+        oscAddress: request.message.address,
+        oscArgs: request.message.args ?? []
+      });
+    }
+
     await client.sendMessage(request.message.address, request.message.args ?? [], {
       ...extractTargetOptions(options),
       wireContract: request.contract
@@ -236,6 +248,16 @@ export const eosAddressSetLevelTool: ToolDefinition<typeof addressSetLevelInputS
     const address = normaliseAddress(options.address_number);
     const level = resolveLevelValue(options.level);
     const request = buildDmxAddressLevelMessage(address, level);
+
+    if (resolveSafetyOptions(options).dryRun) {
+      return createDryRunResult({
+        text: `Reglage de niveau DMX ${level}% simule pour ${address}`,
+        action: 'address_set_level',
+        request: { address, level },
+        oscAddress: request.message.address,
+        oscArgs: request.message.args ?? []
+      });
+    }
 
     await client.sendMessage(request.message.address, request.message.args ?? [], {
       ...extractTargetOptions(options),
@@ -278,6 +300,16 @@ export const eosAddressSetDmxTool: ToolDefinition<typeof addressSetDmxInputSchem
     const address = normaliseAddress(options.address_number);
     const value = resolveDmxValue(options.dmx_value);
     const request = buildDmxAddressDmxMessage(address, value);
+
+    if (resolveSafetyOptions(options).dryRun) {
+      return createDryRunResult({
+        text: `Reglage DMX brut ${value} simule pour ${address}`,
+        action: 'address_set_dmx',
+        request: { address, value },
+        oscAddress: request.message.address,
+        oscArgs: request.message.args ?? []
+      });
+    }
 
     await client.sendMessage(request.message.address, request.message.args ?? [], {
       ...extractTargetOptions(options),

--- a/src/tools/keys/index.ts
+++ b/src/tools/keys/index.ts
@@ -7,11 +7,17 @@ import { getOscClient, type OscJsonResponse } from '../../services/osc/client';
 import type { OscMessageArgument } from '../../services/osc/index';
 import { buildSoftkeyAddress, oscMappings } from '../../services/osc/mappings';
 import { softkeyIndexSchema } from '../../utils/validators';
+import { createDryRunResult, resolveSafetyOptions, safetyOptionsSchema } from '../common/safety';
 import { withToolMetadata, type ToolDefinition, type ToolExecutionResult } from '../types';
 
 const targetOptionsSchema = {
   targetAddress: z.string().min(1).optional(),
   targetPort: z.coerce.number().int().min(1).max(65535).optional()
+} satisfies ZodRawShape;
+
+const keyActionOptionsSchema = {
+  ...targetOptionsSchema,
+  ...safetyOptionsSchema
 } satisfies ZodRawShape;
 
 const buttonStateSchema = z.union([z.coerce.number().int().min(0).max(1), z.boolean()]).optional();
@@ -88,13 +94,13 @@ function createOscArgs(state: 0 | 1): OscMessageArgument[] {
 const keyPressInputSchema = {
   key_name: keyNameSchema,
   state: buttonStateSchema,
-  ...targetOptionsSchema
+  ...keyActionOptionsSchema
 } satisfies ZodRawShape;
 
 const softkeyPressInputSchema = {
   softkey_number: softkeyIndexSchema,
   state: buttonStateSchema,
-  ...targetOptionsSchema
+  ...keyActionOptionsSchema
 } satisfies ZodRawShape;
 
 const softkeyLabelsInputSchema = {
@@ -212,8 +218,19 @@ export const eosKeyPressTool: ToolDefinition<typeof keyPressInputSchema> = {
     const identifier = resolveKeyIdentifier(keyName);
     const address = `${oscMappings.keys.base}/${identifier}`;
     const client = getOscClient();
+    const oscArgs = createOscArgs(state);
 
-    await client.sendMessage(address, createOscArgs(state), {
+    if (resolveSafetyOptions(options).dryRun) {
+      return createDryRunResult({
+        text: `Appui touche ${keyName} simule`,
+        action: 'key_press',
+        request: { key_name: keyName, osc_identifier: identifier, state },
+        oscAddress: address,
+        oscArgs
+      });
+    }
+
+    await client.sendMessage(address, oscArgs, {
       targetAddress: options.targetAddress,
       targetPort: options.targetPort
     });
@@ -225,7 +242,7 @@ export const eosKeyPressTool: ToolDefinition<typeof keyPressInputSchema> = {
       state,
       osc: {
         address,
-        args: createOscArgs(state)
+        args: oscArgs
       }
     });
   }
@@ -259,8 +276,19 @@ export const eosSoftkeyPressTool: ToolDefinition<typeof softkeyPressInputSchema>
     const softkeyNumber = options.softkey_number;
     const address = buildSoftkeyAddress(softkeyNumber);
     const client = getOscClient();
+    const oscArgs = createOscArgs(state);
 
-    await client.sendMessage(address, createOscArgs(state), {
+    if (resolveSafetyOptions(options).dryRun) {
+      return createDryRunResult({
+        text: `Appui softkey ${softkeyNumber} simule`,
+        action: 'softkey_press',
+        request: { softkey_number: softkeyNumber, state },
+        oscAddress: address,
+        oscArgs
+      });
+    }
+
+    await client.sendMessage(address, oscArgs, {
       targetAddress: options.targetAddress,
       targetPort: options.targetPort
     });
@@ -271,7 +299,7 @@ export const eosSoftkeyPressTool: ToolDefinition<typeof softkeyPressInputSchema>
       state,
       osc: {
         address,
-        args: createOscArgs(state)
+        args: oscArgs
       }
     });
   }

--- a/src/tools/session/index.ts
+++ b/src/tools/session/index.ts
@@ -12,6 +12,7 @@ import {
 import { getOscClient } from '../../services/osc/client';
 import { oscMappings } from '../../services/osc/mappings';
 import { channelNumberSchema, userIdSchema } from '../../utils/validators';
+import { createDryRunResult, resolveSafetyOptions, safetyOptionsSchema } from '../common/safety';
 import type { ToolDefinition, ToolExecutionResult } from '../types';
 
 let currentUserId: number | null = null;
@@ -215,7 +216,8 @@ const targetOptionsSchema = {
 
 const setUserIdInputSchema = {
   user_id: userIdSchema,
-  ...targetOptionsSchema
+  ...targetOptionsSchema,
+  ...safetyOptionsSchema
 };
 
 const extractTargetOptions = (options: { targetAddress?: string; targetPort?: number }) => {
@@ -327,6 +329,17 @@ export const eosSetUserIdTool: ToolDefinition<typeof setUserIdInputSchema> = {
     const options = schema.parse(args ?? {});
     const client = getOscClient();
     const oscArgs = [{ type: 'i' as const, value: options.user_id }];
+
+    if (resolveSafetyOptions(options).dryRun) {
+      return createDryRunResult({
+        text: `Changement d'identifiant utilisateur EOS simule vers ${options.user_id}`,
+        action: 'set_user_id',
+        request: { user_id: options.user_id },
+        oscAddress: oscMappings.system.setUserId,
+        oscArgs,
+        extra: { user_id: options.user_id, session_user: currentUserId }
+      });
+    }
 
     await client.sendMessage(oscMappings.system.setUserId, oscArgs, extractTargetOptions(options));
     setCurrentUserId(options.user_id);


### PR DESCRIPTION
### Motivation
- Provide a focused, reproducible test suite for high-priority OSC tools to validate generated OSC addresses, arguments, strict/compat behavior, invalid-input handling and `dry_run` behavior.
- Make `dry_run` available for the priority tools so LLM-driven runs can preview OSC frames without sending them.

### Description
- Add a new prioritized test suite `src/tools/__tests__/osc_priority_tools.test.ts` that asserts OSC address/argument generation, strict-mode metadata, cue compatibility fallbacks, invalid-input rejection and `dry_run` semantics for selected tools.
- Implement `dry_run` support and safety-schema integration for the following tools: `eos_channel_set_parameter`, DMX tools (`eos_address_select`, `eos_address_set_level`, `eos_address_set_dmx`), key/softkey tools (`eos_key_press`, `eos_softkey_press`), `eos_set_user_id`, and `eos_cue_select`; this includes small handler changes to return a simulated `ToolExecutionResult` instead of sending OSC when `dry_run` is true.
- Update input schemas where needed to expose `dry_run`/confirmation/safety arguments (`safetyOptionsSchema`) and centralize use of prepared OSC args variables for clarity.
- Update documentation: `docs/osc-coverage.md` (add priority coverage matrix section) and `docs/tools.md` (document `dry_run`/`confirm`/`require_confirmation`/`safety_level` fields in relevant tool argument tables).

### Testing
- Ran linter: `npm run lint` (passed).
- Typecheck: `npm run tsc -- --noEmit` (passed).
- Regenerated and validated tool docs: `npm run docs:generate` + `npm run docs:check` (docs regenerated and check passed).
- Unit tests: ran `npm run test:unit` for the new priority suite and related tool tests (including `src/tools/__tests__/osc_priority_tools.test.ts`, `src/tools/__tests__/osc_contracts.test.ts`, `src/tools/dmx/__tests__/dmx.test.ts`, `src/tools/keys/__tests__/keys.test.ts`, `src/tools/session/__tests__/session.test.ts`, `src/tools/cues/__tests__/cues.test.ts`) and observed all tests passing.
- Full test run: `npm test` (unit + conformance) completed successfully; all test suites passed including the conformance integration (final run: 59 test suites, 620 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a236a196c20832abfa3c8e879ea0417)