### PR TITLE
Ajout d'un audit des commandes MCP/OSC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,9 @@ MCP_HTTP_ALLOWED_ORIGINS=
 # Fenêtre du rate-limit (en millisecondes) et nombre maximal de requêtes par IP.
 MCP_HTTP_RATE_LIMIT_WINDOW=60000
 MCP_HTTP_RATE_LIMIT_MAX=60
+
+# Audit des commandes MCP/OSC
+# Active l'écriture d'un journal JSONL dédié pour les commandes dry-run et les envois OSC réels.
+EOS_AUDIT_ENABLED=false
+# Emplacement du journal d'audit lorsque EOS_AUDIT_ENABLED=true.
+EOS_AUDIT_LOG_FILE=logs/audit.log

--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ npx ts-node src/server/index.ts --verbose --json-logs --stats-interval 30s
 
 Le protocole MCP utilise exclusivement STDOUT pour échanger avec les clients. Pour éviter toute interférence, l'intégralité des logs applicatifs est désormais routée vers STDERR (ou vers les fichiers/transports configurés). Même si la destination héritée `stdout` reste acceptée dans les variables d'environnement pour des raisons de compatibilité, elle est automatiquement redirigée vers STDERR par le serveur. Consultez vos journaux via STDERR ou en configurant `LOG_DESTINATIONS=file`/`transport` selon vos besoins.
 
+### Audit des commandes MCP/OSC
+
+L'audit dédié est désactivé par défaut. Activez-le avec `EOS_AUDIT_ENABLED=true`; le serveur écrit alors un journal JSON Lines dans `EOS_AUDIT_LOG_FILE` (par défaut `logs/audit.log`, relatif à la racine du projet si le chemin n'est pas absolu). Chaque ligne correspond à une commande dry-run ou à un envoi OSC réel et contient notamment :
+
+- `timestamp` : horodatage ISO de l'événement ;
+- `toolName` : nom de l'outil MCP ou, à défaut, identifiant OSC utilisé ;
+- `oscAddress` et `args` : adresse OSC et arguments, avec masquage des champs sensibles (`token`, `password`, `secret`, `authorization`, `apiKey`, etc.) ;
+- `eosUser` : utilisateur Eos résolu depuis les arguments ou le contexte MCP lorsqu'il est connu ;
+- `mode` : `strict` si `EOS_STRICT_MODE=true`, sinon `compatibility` ;
+- `delivery` : `dry_run` pour les previews ou `sent` pour les envois réels ;
+- `status`, `result` ou `error` : issue de l'opération, également nettoyée des secrets.
+
+Utilisation recommandée : conservez `logs/audit.log` hors du dépôt, faites-le collecter par votre système SIEM ou votre rotation de logs, et corrélez les entrées avec `correlationId`/`sessionId` lorsque la passerelle MCP les fournit. Les logs applicatifs restent configurés séparément via `LOG_DESTINATIONS` et `MCP_LOG_FILE`; l'audit ne s'active que par `EOS_AUDIT_ENABLED=true`.
+
 ## Configuration réseau et de la console Eos
 
 | Protocole | Port | Description |

--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -67,6 +67,10 @@ describe('configuration', () => {
           }
         ]
       },
+      audit: {
+        enabled: false,
+        logFile: resolve(process.cwd(), 'logs/audit.log')
+      },
       httpGateway: {
         publicUrl: undefined,
         trustProxy: false,
@@ -124,7 +128,9 @@ describe('configuration', () => {
       CACHE_TTL_GROUPS_MS: '2000',
       CACHE_TTL_PALETTES_MS: '2200',
       CACHE_TTL_FIXTURES_MS: '600000',
-      CACHE_TTL_SESSION_MS: '900000'
+      CACHE_TTL_SESSION_MS: '900000',
+      EOS_AUDIT_ENABLED: 'true',
+      EOS_AUDIT_LOG_FILE: 'var/log/eos-audit.jsonl'
     };
 
     const config = loadConfig(env);
@@ -147,6 +153,10 @@ describe('configuration', () => {
       { type: 'stderr' },
       { type: 'file', path: resolve(process.cwd(), 'var/log/eos-mcp.log') }
     ]);
+    expect(config.audit).toEqual({
+      enabled: true,
+      logFile: resolve(process.cwd(), 'var/log/eos-audit.jsonl')
+    });
     expect(config.httpGateway.security).toEqual({
       apiKeys: ['admin-key'],
       mcpTokens: ['token-one', 'token-two'],

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,6 +6,7 @@ import { resolve } from 'node:path';
 import { z } from 'zod';
 
 const DEFAULT_LOG_FILE = 'logs/mcp-server.log';
+const DEFAULT_AUDIT_LOG_FILE = 'logs/audit.log';
 const DEFAULT_LOG_DESTINATIONS = ['file'] as const;
 const DEFAULT_OSC_REMOTE_ADDRESS = '127.0.0.1';
 const DEFAULT_OSC_LOCAL_ADDRESS = '0.0.0.0';
@@ -120,6 +121,11 @@ export interface HttpGatewayConfig {
   readonly security: HttpGatewaySecurityConfig;
 }
 
+export interface AuditConfig {
+  readonly enabled: boolean;
+  readonly logFile: string;
+}
+
 export interface CacheConfig {
   readonly defaultTtlMs: number;
   readonly resourceTtls: {
@@ -140,6 +146,7 @@ export interface AppConfig {
   readonly mcp: McpConfig;
   readonly osc: OscConfig;
   readonly logging: LoggingConfig;
+  readonly audit: AuditConfig;
   readonly httpGateway: HttpGatewayConfig;
   readonly cache: CacheConfig;
 }
@@ -549,6 +556,8 @@ const configSchema = z
     logTransportTarget: createTransportTargetSchema('LOG_TRANSPORT_TARGET'),
     logTransportOptions: createTransportOptionsSchema('LOG_TRANSPORT_OPTIONS'),
     logPretty: createOptionalBooleanSchema('LOG_PRETTY'),
+    auditEnabled: createBooleanSchema('EOS_AUDIT_ENABLED', false),
+    auditLogFile: createLogFileSchema('EOS_AUDIT_LOG_FILE', DEFAULT_AUDIT_LOG_FILE),
     httpApiKeys: createStringArraySchema('MCP_HTTP_API_KEYS', { defaultValue: [] }),
     httpMcpTokens: createStringArraySchema('MCP_HTTP_MCP_TOKENS', {
       defaultValue: [DEFAULT_HTTP_MCP_TOKEN]
@@ -650,6 +659,10 @@ const configSchema = z
         format: prettyEnabled ? 'pretty' : 'json',
         destinations
       },
+      audit: {
+        enabled: values.auditEnabled,
+        logFile: values.auditLogFile
+      },
       httpGateway: {
         publicUrl: values.httpPublicUrl,
         trustProxy: values.httpTrustProxy ?? false,
@@ -704,6 +717,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
     logTransportTarget: env.LOG_TRANSPORT_TARGET,
     logTransportOptions: env.LOG_TRANSPORT_OPTIONS,
     logPretty: env.LOG_PRETTY,
+    auditEnabled: env.EOS_AUDIT_ENABLED,
+    auditLogFile: env.EOS_AUDIT_LOG_FILE,
     httpApiKeys: env.MCP_HTTP_API_KEYS,
     httpMcpTokens: env.MCP_HTTP_MCP_TOKENS,
     httpIpAllowlist: env.MCP_HTTP_IP_ALLOWLIST,

--- a/src/server/requestContext.ts
+++ b/src/server/requestContext.ts
@@ -8,6 +8,7 @@ export interface RequestContext {
   correlationId: string;
   sessionId?: string;
   userId?: number;
+  toolName?: string;
 }
 
 const requestContextStorage = new AsyncLocalStorage<RequestContext>();

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -26,6 +26,7 @@ import {
   resolveCompatibilityContext
 } from '../services/osc/compatibilityMatrix';
 import { resolveConsoleTarget, type ConsoleTargetResolution } from '../services/consoleTargets';
+import { resolveAuditMode, writeCommandAudit } from '../services/audit';
 
 const logger = createLogger('tool-registry');
 
@@ -322,6 +323,65 @@ function normalizeConfirmationArgsForTool(args: unknown, inputSchema?: ToolDefin
   return record;
 }
 
+
+function extractOscAuditEntries(result: ToolExecutionResult, args: unknown): Array<{ address: string | null; args: unknown }> {
+  const structured = asObject(result.structuredContent);
+  const osc = asObject(structured.osc);
+  const entries: Array<{ address: string | null; args: unknown }> = [];
+
+  if (typeof osc.address === 'string') {
+    entries.push({ address: osc.address, args: osc.args ?? [] });
+  }
+
+  const previews = Array.isArray(structured.commands_preview) ? structured.commands_preview : [];
+  for (const preview of previews) {
+    if (typeof preview === 'string') {
+      entries.push({ address: '/eos/cmd', args: [{ type: 's', value: preview }] });
+    }
+  }
+
+  if (entries.length === 0) {
+    entries.push({ address: null, args });
+  }
+
+  return entries;
+}
+
+function auditDryRunToolResult(params: {
+  toolName: string;
+  args: unknown;
+  result: ToolExecutionResult;
+  correlationId: string;
+  sessionId?: string;
+  userId?: number;
+  targetConsole: { name?: string; address: string; port: number };
+}): void {
+  const structured = asObject(params.result.structuredContent);
+  if (structured.dry_run !== true) {
+    return;
+  }
+
+  for (const entry of extractOscAuditEntries(params.result, params.args)) {
+    writeCommandAudit({
+      toolName: params.toolName,
+      oscAddress: entry.address,
+      args: entry.args,
+      eosUser: typeof params.userId === 'number' ? params.userId : null,
+      mode: resolveAuditMode(),
+      delivery: 'dry_run',
+      status: 'ok',
+      result: params.result,
+      correlationId: params.correlationId,
+      sessionId: params.sessionId,
+      target: {
+        ...(params.targetConsole.name ? { console: params.targetConsole.name } : {}),
+        address: params.targetConsole.address,
+        port: params.targetConsole.port
+      }
+    });
+  }
+}
+
 function isSensitiveAction(args: unknown): boolean {
   const record = asObject(args);
   if (hasExplicitConfirmation(args)) {
@@ -580,11 +640,22 @@ class ToolRegistry {
         {
           correlationId,
           ...(sessionId ? { sessionId } : {}),
-          ...(typeof userId === 'number' ? { userId } : {})
+          ...(typeof userId === 'number' ? { userId } : {}),
+          toolName
         },
         () => execute(executionArgs)
       );
       const result = addConsoleTargetToResult(executionResult, targetResolution);
+
+      auditDryRunToolResult({
+        toolName,
+        args,
+        result,
+        correlationId,
+        sessionId,
+        userId,
+        targetConsole
+      });
 
       logger.info({
         event: 'tool_execution_audit',
@@ -607,6 +678,26 @@ class ToolRegistry {
 
       return result;
     } catch (error) {
+      if (asObject(args).dry_run === true) {
+        writeCommandAudit({
+          toolName,
+          oscAddress: null,
+          args,
+          eosUser: typeof userId === 'number' ? userId : null,
+          mode: resolveAuditMode(),
+          delivery: 'dry_run',
+          status: 'error',
+          error: error instanceof Error ? { name: error.name, message: error.message } : error,
+          correlationId,
+          sessionId,
+          target: {
+            ...(targetConsole.name ? { console: targetConsole.name } : {}),
+            address: targetConsole.address,
+            port: targetConsole.port
+          }
+        });
+      }
+
       logger.warn({
         event: 'tool_execution_audit',
         toolName,

--- a/src/services/audit/__tests__/audit.test.ts
+++ b/src/services/audit/__tests__/audit.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveAuditMode, sanitizeAuditValue, writeCommandAudit } from '../index';
+
+describe('command audit', () => {
+  it('masque les champs et fragments sensibles', () => {
+    expect(sanitizeAuditValue({
+      apiKey: 'abc123',
+      nested: { authorization: 'Bearer secret-token', text: 'token=visible-secret Chan 1' }
+    })).toEqual({
+      apiKey: '[REDACTED]',
+      nested: { authorization: '[REDACTED]', text: 'token=[REDACTED] Chan 1' }
+    });
+  });
+
+  it('ecrit une ligne JSONL lorsque l audit est active', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'eos-mcp-audit-test-'));
+    const logFile = join(tempDir, 'audit.log');
+
+    try {
+      writeCommandAudit({
+        timestamp: '2026-06-06T00:00:00.000Z',
+        toolName: 'eos_command',
+        oscAddress: '/eos/cmd',
+        args: [{ type: 's', value: 'Chan 1 At 50 token=abc' }],
+        eosUser: 3,
+        mode: 'strict',
+        delivery: 'sent',
+        status: 'ok',
+        result: { password: 'hidden' }
+      }, { enabled: true, logFile });
+
+      const [line] = readFileSync(logFile, 'utf8').trim().split('\n');
+      expect(JSON.parse(line!)).toMatchObject({
+        timestamp: '2026-06-06T00:00:00.000Z',
+        toolName: 'eos_command',
+        oscAddress: '/eos/cmd',
+        eosUser: 3,
+        mode: 'strict',
+        delivery: 'sent',
+        status: 'ok',
+        result: { password: '[REDACTED]' }
+      });
+      expect(line).toContain('token=[REDACTED]');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('derive le mode depuis EOS_STRICT_MODE', () => {
+    expect(resolveAuditMode({ EOS_STRICT_MODE: 'true' } as NodeJS.ProcessEnv)).toBe('strict');
+    expect(resolveAuditMode({ EOS_STRICT_MODE: 'false' } as NodeJS.ProcessEnv)).toBe('compatibility');
+  });
+});

--- a/src/services/audit/index.ts
+++ b/src/services/audit/index.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { getConfig } from '../../config/index';
+
+const SENSITIVE_FIELD_PATTERN = /(token|password|secret|authorization|api[-_]?key|cookie|credential|passphrase)/i;
+const SENSITIVE_STRING_PATTERN = /(bearer\s+)[A-Za-z0-9._~+\-/=]+|((?:token|password|secret|api[-_]?key)=)[^\s&]+/gi;
+
+export type AuditMode = 'strict' | 'compatibility';
+export type AuditDelivery = 'dry_run' | 'sent';
+export type AuditStatus = 'ok' | 'error';
+
+export interface AuditConfig {
+  enabled: boolean;
+  logFile: string;
+}
+
+export interface CommandAuditRecord {
+  timestamp?: string;
+  toolName: string;
+  oscAddress: string | null;
+  args: unknown;
+  eosUser: number | null;
+  mode: AuditMode;
+  delivery: AuditDelivery;
+  status: AuditStatus;
+  result?: unknown;
+  error?: unknown;
+  correlationId?: string;
+  sessionId?: string;
+  target?: {
+    console?: string;
+    address?: string;
+    port?: number;
+  };
+}
+
+export function sanitizeAuditValue(value: unknown, depth = 0): unknown {
+  if (depth > 6) {
+    return '[MaxDepth]';
+  }
+
+  if (typeof value === 'string') {
+    return value.replace(SENSITIVE_STRING_PATTERN, (_match, bearerPrefix, keyPrefix) => `${bearerPrefix ?? keyPrefix}[REDACTED]`);
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 100).map((entry) => sanitizeAuditValue(entry, depth + 1));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).slice(0, 100).map(([key, entryValue]) => {
+        if (SENSITIVE_FIELD_PATTERN.test(key)) {
+          return [key, '[REDACTED]'];
+        }
+        return [key, sanitizeAuditValue(entryValue, depth + 1)];
+      })
+    );
+  }
+
+  return value;
+}
+
+export function resolveAuditMode(env: NodeJS.ProcessEnv = process.env): AuditMode {
+  const raw = env.EOS_STRICT_MODE;
+  return raw === 'true' || raw === '1' || raw === 'yes' ? 'strict' : 'compatibility';
+}
+
+export function getAuditConfig(): AuditConfig {
+  return getConfig().audit;
+}
+
+export function writeCommandAudit(record: CommandAuditRecord, config: AuditConfig = getAuditConfig()): void {
+  if (!config.enabled) {
+    return;
+  }
+
+  const logFile = resolve(process.cwd(), config.logFile);
+  mkdirSync(dirname(logFile), { recursive: true });
+  const payload = {
+    ...record,
+    timestamp: record.timestamp ?? new Date().toISOString(),
+    args: sanitizeAuditValue(record.args),
+    result: sanitizeAuditValue(record.result),
+    error: sanitizeAuditValue(record.error)
+  };
+
+  appendFileSync(logFile, `${JSON.stringify(payload)}\n`, 'utf8');
+}

--- a/src/services/osc/client.ts
+++ b/src/services/osc/client.ts
@@ -27,6 +27,7 @@ import { getResourceCache } from '../cache/index';
 import { resolveConsoleTarget } from '../consoleTargets';
 import { RequestQueue, type RequestQueueDiagnostics, type RequestQueueRunOptions } from './requestQueue';
 import { getRequestContext } from '../../server/requestContext';
+import { resolveAuditMode, writeCommandAudit } from '../audit';
 import { assertOscAddressStrictModeAllowed } from './officiality';
 import {
   extractJsonPayloadFromMessage,
@@ -1109,22 +1110,70 @@ export class OscClient {
     const queuePolicy = this.buildQueuePolicy(message.address, gatewayOptions);
 
     let transportType: TransportType | null = null;
-
-    await this.requestQueue.run(
-      operation,
-      () => this.gateway.send(message, gatewayOptions).then((sentTransport) => {
-        transportType = sentTransport ?? this.gateway.getActiveTransport?.(gatewayOptions.toolId ?? message.address) ?? null;
-      }),
-      {
-        timeoutMs,
-        timeoutMessage: queueOptions.timeoutMessage,
-        details,
-        targetKey: queuePolicy.targetKey,
-        familyKey: queueOptions.familyKey ?? queuePolicy.familyKey
+    const requestContext = getRequestContext();
+    const auditBase = {
+      toolName: requestContext?.toolName ?? gatewayOptions.toolId ?? message.address,
+      oscAddress: message.address,
+      args: message.args ?? [],
+      eosUser: typeof requestContext?.userId === 'number' ? requestContext.userId : this.extractUserFromMessage(message, queueOptions.details),
+      mode: resolveAuditMode(),
+      delivery: 'sent' as const,
+      correlationId: requestContext?.correlationId,
+      sessionId: requestContext?.sessionId,
+      target: {
+        ...(gatewayOptions.targetConsole ? { console: gatewayOptions.targetConsole } : {}),
+        ...(gatewayOptions.targetAddress ? { address: gatewayOptions.targetAddress } : {}),
+        ...(typeof gatewayOptions.targetPort === 'number' ? { port: gatewayOptions.targetPort } : {})
       }
-    );
+    };
 
-    return transportType ?? this.gateway.getActiveTransport?.(gatewayOptions.toolId ?? message.address) ?? null;
+    try {
+      await this.requestQueue.run(
+        operation,
+        () => this.gateway.send(message, gatewayOptions).then((sentTransport) => {
+          transportType = sentTransport ?? this.gateway.getActiveTransport?.(gatewayOptions.toolId ?? message.address) ?? null;
+        }),
+        {
+          timeoutMs,
+          timeoutMessage: queueOptions.timeoutMessage,
+          details,
+          targetKey: queuePolicy.targetKey,
+          familyKey: queueOptions.familyKey ?? queuePolicy.familyKey
+        }
+      );
+
+      const finalTransport = transportType ?? this.gateway.getActiveTransport?.(gatewayOptions.toolId ?? message.address) ?? null;
+      writeCommandAudit({
+        ...auditBase,
+        status: 'ok',
+        result: { transport: finalTransport }
+      });
+      return finalTransport;
+    } catch (error) {
+      writeCommandAudit({
+        ...auditBase,
+        status: 'error',
+        error: error instanceof Error ? { name: error.name, message: error.message } : error
+      });
+      throw error;
+    }
+  }
+
+
+  private extractUserFromMessage(message: OscMessage, details?: Record<string, unknown>): number | null {
+    const detailUser = details?.user;
+    if (typeof detailUser === 'number' && Number.isFinite(detailUser)) {
+      return Math.trunc(detailUser);
+    }
+
+    if (message.address === USER_REQUEST) {
+      const argUser = message.args?.[0]?.value;
+      if (typeof argUser === 'number' && Number.isFinite(argUser)) {
+        return Math.trunc(argUser);
+      }
+    }
+
+    return null;
   }
 
   private buildQueuePolicy(address: string, options: OscGatewaySendOptions): OscQueuePolicy {


### PR DESCRIPTION
### Motivation

- Ajouter un mécanisme d'audit centralisé pour tracer les envois OSC et les previews (dry-run) afin de disposer d'un journal exploitable (horodatage, outil MCP, adresse OSC, arguments, utilisateur Eos, mode strict/compatibilité, dry-run vs envoi réel, résultat/erreur) tout en masquant les secrets.

### Description

- Nouveau module `src/services/audit/index.ts` qui écrit des entrées JSON Lines configurables et applique un masquage récursif des champs et fragments sensibles (`token`, `password`, `secret`, `authorization`, `apiKey`, etc.).
- Raccordement de l'audit aux envois OSC réels dans `src/services/osc/client.ts` : capture du contexte de requête, cible OSC, transport final et erreurs, et écriture d'un enregistrement `sent` ou `error`.
- Propagation du `toolName` dans le `RequestContext` (`src/server/requestContext.ts`) et enregistrement des previews `dry_run` dans le registre d'outils (`src/server/toolRegistry.ts`), y compris extraction des commandes prévisualisées et gestion des erreurs de dry-run.
- Ajout de la configuration `EOS_AUDIT_ENABLED` / `EOS_AUDIT_LOG_FILE` (avec valeurs par défaut) dans `src/config/index.ts` et `.env.example`, et documentation de l'emplacement/usage du journal dans `README.md`.
- Tests unitaires pour le masquage et l'écriture JSONL ajoutés dans `src/services/audit/__tests__/audit.test.ts` et ajustements des tests de configuration.

### Testing

- Compilation TypeScript via `npm run tsc` réussie (OK).
- Lint via `npm run lint` exécuté sans erreurs (OK).
- Suites de tests exécutées via `npm test` (unitaires + conformance ciblées) et `npx jest` pour les nouveaux tests; tous les tests lancés ont passé avec succès (tous verts).
- Commandes de test utilisées : `npm run tsc`, `npm run lint`, `npm test -- --runTestsByPath src/config/__tests__/config.test.ts src/services/osc/__tests__/client.test.ts src/server/__tests__/toolRegistry.test.ts` et `npx jest --passWithNoTests src/services/audit/__tests__/audit.test.ts src/config/__tests__/config.test.ts`, toutes réussies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a243afa7f30832abbbcbb44cb2a398c)