### PR TITLE
Add EOS_READ_ONLY mode and read-only tool classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,25 @@ L'audit dédié est désactivé par défaut. Activez-le avec `EOS_AUDIT_ENABLED=
 
 Utilisation recommandée : conservez `logs/audit.log` hors du dépôt, faites-le collecter par votre système SIEM ou votre rotation de logs, et corrélez les entrées avec `correlationId`/`sessionId` lorsque la passerelle MCP les fournit. Les logs applicatifs restent configurés séparément via `LOG_DESTINATIONS` et `MCP_LOG_FILE`; l'audit ne s'active que par `EOS_AUDIT_ENABLED=true`.
 
+
+### Mode lecture seule EOS_READ_ONLY
+
+Définissez `EOS_READ_ONLY=true` pour démarrer le serveur en mode verrouillé. Dans ce mode, le registre MCP n'autorise que les outils classés comme lecture seule (`readOnly: true`) : lectures OSC/JSON, capacités, ping, diagnostics, contexte de session et autres vérifications qui ne modifient pas l'état de la console. Les outils qui envoient des commandes susceptibles de changer le show ou l'état live (`eos_command`, `eos_new_command`, `eos_cue_*` d'exécution/enregistrement, patch, macros, workflows d'écriture, faders/submasters, etc.) sont refusés même si le client fournit un profil `admin` et `confirm=true`.
+
+Chaque outil publié expose désormais les métadonnées de sécurité suivantes dans le catalogue MCP et dans les annotations de schéma :
+
+- `readOnly: true|false` indique si l'outil est autorisé lorsque `EOS_READ_ONLY=true` ;
+- `riskLevel: low|medium|high|critical` décrit l'impact potentiel côté console ;
+- `requiresConfirmation: true|false` indique si l'exécution réelle nécessite une confirmation opérateur (`confirm=true` ou `require_confirmation=true`).
+
+Exemple de démarrage sécurisé pour un assistant limité à l'observation et au diagnostic :
+
+```bash
+EOS_READ_ONLY=true npm run start:dev
+```
+
+Conservez `EOS_READ_ONLY=false` (valeur par défaut) uniquement lorsque des commandes d'exploitation ou de programmation doivent être possibles, puis combinez-le avec les profils de sécurité MCP (`EOS_MCP_ALLOWED_TOOL_PROFILE`) et les confirmations explicites déjà documentées.
+
 ## Configuration réseau et de la console Eos
 
 | Protocole | Port | Description |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -503,6 +503,7 @@ oscsend 127.0.0.1 8001 /eos/bp/fire s:'{"palette_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :** Aucun argument.
@@ -530,6 +531,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -568,7 +570,8 @@ oscsend 127.0.0.1 8001 /eos/get/channels s:'{"channels":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -605,7 +608,8 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'Chan 1'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -642,7 +646,8 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'Chan 1 At 1 DMX'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -680,7 +685,8 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'Chan 1 Sneak 1'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -863,6 +869,7 @@ oscsend 127.0.0.1 8001 /eos/cmd s:'{"template":"exemple"}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -897,6 +904,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -934,6 +942,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :** Aucun argument.
@@ -1100,7 +1109,8 @@ oscsend 127.0.0.1 8001 /eos/cue/{cuelist}/go s:'{"cuelist_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1183,7 +1193,8 @@ oscsend 127.0.0.1 8001 /eos/get/cuelist s:'{"cuelist_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1312,7 +1323,8 @@ oscsend 127.0.0.1 8001 /eos/cmd s:'Cue 1 Stop#'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1487,6 +1499,7 @@ oscsend 127.0.0.1 8001 /eos/get/cuelist/info s:'{"cuelist_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -1525,6 +1538,7 @@ oscsend 127.0.0.1 8001 /eos/get/curve s:'{"curve_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -1561,7 +1575,8 @@ oscsend 127.0.0.1 8001 /eos/curve/select s:'{"curve_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1601,7 +1616,8 @@ oscsend 127.0.0.1 8001 /eos/ds/{index}/config/{target}/{buttons}/{flexi}/{page} 
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1638,7 +1654,8 @@ oscsend 127.0.0.1 8001 /eos/ds/{index}/page/1 s:'{"bank_index":1,"delta":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1676,6 +1693,7 @@ oscsend 127.0.0.1 8001 /eos/ds/{index}/button/{page}/{button} f 1
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -1714,7 +1732,8 @@ oscsend 127.0.0.1 8001 /eos/get/effect s:'{"effect_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1750,7 +1769,8 @@ oscsend 127.0.0.1 8001 /eos/cmd s:'{"effect_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1786,6 +1806,7 @@ oscsend 127.0.0.1 8001 /eos/cmd s:'{"effect_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -1818,7 +1839,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1856,7 +1878,8 @@ oscsend 127.0.0.1 8001 /eos/fader/{index}/config/{faders}/{page} s:'{"bank_index
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1893,7 +1916,8 @@ oscsend 127.0.0.1 8001 /eos/fader/{bank}/{page}/{fader}/load s:'{"bank_index":1,
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1930,7 +1954,8 @@ oscsend 127.0.0.1 8001 /eos/fader/{index}/page/1 s:'{"bank_index":1,"delta":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -1968,7 +1993,8 @@ oscsend 127.0.0.1 8001 /eos/fader/{bank}/{page}/{fader} s:'{"bank_index":1,"fade
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -2005,6 +2031,7 @@ oscsend 127.0.0.1 8001 /eos/fader/{bank}/{page}/{fader}/unload s:'{"bank_index":
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -2085,6 +2112,7 @@ oscsend 127.0.0.1 8001 /eos/fp/fire s:'{"palette_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -2123,6 +2151,7 @@ oscsend 127.0.0.1 8001 /eos/get/fpe/point s:'{"set_number":1,"point_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -2159,6 +2188,7 @@ oscsend 127.0.0.1 8001 /eos/get/fpe/set/count s:'{"timeoutMs":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -2240,6 +2270,7 @@ oscsend 127.0.0.1 8001 /eos/get/active/cue s:'{"cuelist_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -2323,6 +2354,7 @@ oscsend 127.0.0.1 8001 /eos/get/cmd_line s:'{"user":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -2357,6 +2389,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :** Aucun argument.
@@ -2384,6 +2417,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -2502,6 +2536,7 @@ oscsend 127.0.0.1 8001 /eos/get/pending/cue s:'{"cuelist_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -2662,6 +2697,7 @@ oscsend 127.0.0.1 8001 /eos/get/cmd_line s:'{"user":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -2695,6 +2731,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -2732,6 +2769,7 @@ oscsend 127.0.0.1 8001 /eos/get/group s:'{"group_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -2768,7 +2806,8 @@ oscsend 127.0.0.1 8001 /eos/get/group/list s:'{"timeoutMs":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -2804,7 +2843,8 @@ oscsend 127.0.0.1 8001 /eos/group s:'{"group_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -3052,6 +3092,7 @@ oscsend 127.0.0.1 8001 /eos/macro s:'{"macro_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -3089,6 +3130,7 @@ oscsend 127.0.0.1 8001 /eos/get/magic_sheet s:'{"ms_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -3126,6 +3168,7 @@ oscsend 127.0.0.1 8001 /eos/ms s:'{"ms_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -3259,7 +3302,8 @@ oscsend 127.0.0.1 8001 /eos/get/palette s:'{"palette_type":"ip","palette_number"
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -3298,7 +3342,8 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'IP 1 Label "exemple"#'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -3474,7 +3519,8 @@ oscsend 127.0.0.1 8001 /eos/get/patch/chan_info s:'{"channel_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -3515,6 +3561,7 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'Patch Chan 1 Part 1 Address 1 Type "exempl
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -3553,6 +3600,7 @@ oscsend 127.0.0.1 8001 /eos/ping s:'{"message":"exemple"}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -3590,6 +3638,7 @@ oscsend 127.0.0.1 8001 /eos/get/pixmap s:'{"pixmap_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -3791,7 +3840,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -3826,7 +3876,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -3863,7 +3914,8 @@ oscsend 127.0.0.1 8001 /eos/param/color/hs s:'{"hue":1,"saturation":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -3981,7 +4033,8 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'{"format_string":"exemple"}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4018,7 +4071,8 @@ oscsend 127.0.0.1 8001 /eos/addr/{address}/DMX s:'{"addresses":1,"value":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4055,7 +4109,8 @@ oscsend 127.0.0.1 8001 /eos/param/position/xy s:'{"x":1,"y":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4095,7 +4150,8 @@ oscsend 127.0.0.1 8001 /eos/user i:1
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `medium` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4379,6 +4435,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -4417,7 +4474,8 @@ oscsend 127.0.0.1 8001 /eos/get/snapshot s:'{"snapshot_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4498,7 +4556,8 @@ oscsend 127.0.0.1 8001 /eos/softkey/1 s:'{"softkey_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4535,6 +4594,7 @@ oscsend 127.0.0.1 8001 /eos/sub/1/bump f 1
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -4572,7 +4632,8 @@ oscsend 127.0.0.1 8001 /eos/get/submaster s:'{"submaster_number":1}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4609,6 +4670,7 @@ oscsend 127.0.0.1 8001 /eos/sub/1 f 1
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -4646,7 +4708,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4722,7 +4785,8 @@ oscsend 127.0.0.1 8001 /eos/newcmd s:'{"targetAddress":"exemple"}'
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4760,7 +4824,8 @@ oscsend 127.0.0.1 8001 /eos/param/wheel/tick s:'{"parameter_name":"exemple","tic
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4802,7 +4867,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4841,7 +4907,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4880,7 +4947,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4922,7 +4990,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -4965,7 +5034,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -5014,7 +5084,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -5056,7 +5127,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -5099,7 +5171,8 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
-| Confirmation requise | Non |
+| Niveau de risque | `high` |
+| Confirmation requise | Oui |
 
 **Arguments :**
 
@@ -5141,6 +5214,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -5172,6 +5246,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -5206,6 +5281,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -5240,6 +5316,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :** Aucun argument.
@@ -5267,6 +5344,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**
@@ -5303,6 +5381,7 @@ _Pas de mapping OSC documenté._
 
 | Champ | Valeur |
 | --- | --- |
+| Niveau de risque | `low` |
 | Confirmation requise | Non |
 
 **Arguments :**

--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -13,8 +13,10 @@ import {
 } from '../../config/index';
 import {
   DEFAULT_ALLOWED_TOOL_PROFILE_ENV,
+  EOS_READ_ONLY_ENV,
   getDefaultAllowedToolProfile,
-  initialiseEnv
+  initialiseEnv,
+  isEosReadOnlyModeEnabled
 } from '../env';
 
 describe('tool safety profile environment', () => {
@@ -32,6 +34,22 @@ describe('tool safety profile environment', () => {
     expect(() =>
       getDefaultAllowedToolProfile({ [DEFAULT_ALLOWED_TOOL_PROFILE_ENV]: 'operator' } as NodeJS.ProcessEnv)
     ).toThrow(DEFAULT_ALLOWED_TOOL_PROFILE_ENV);
+  });
+});
+
+
+
+describe('EOS_READ_ONLY environment', () => {
+  it('desactive le mode lecture seule par defaut', () => {
+    expect(isEosReadOnlyModeEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it('active le mode lecture seule depuis EOS_READ_ONLY=true', () => {
+    expect(isEosReadOnlyModeEnabled({ [EOS_READ_ONLY_ENV]: 'true' } as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  it('rejette une valeur EOS_READ_ONLY invalide', () => {
+    expect(() => isEosReadOnlyModeEnabled({ [EOS_READ_ONLY_ENV]: 'maybe' } as NodeJS.ProcessEnv)).toThrow(EOS_READ_ONLY_ENV);
   });
 });
 
@@ -82,6 +100,9 @@ describe('configuration', () => {
           rateLimit: { windowMs: 60000, max: 60 }
         }
       },
+      runtime: {
+        readOnly: false
+      },
       cache: {
         defaultTtlMs: 1500,
         resourceTtls: {
@@ -130,7 +151,8 @@ describe('configuration', () => {
       CACHE_TTL_FIXTURES_MS: '600000',
       CACHE_TTL_SESSION_MS: '900000',
       EOS_AUDIT_ENABLED: 'true',
-      EOS_AUDIT_LOG_FILE: 'var/log/eos-audit.jsonl'
+      EOS_AUDIT_LOG_FILE: 'var/log/eos-audit.jsonl',
+      EOS_READ_ONLY: 'true'
     };
 
     const config = loadConfig(env);
@@ -166,6 +188,9 @@ describe('configuration', () => {
     });
     expect(config.httpGateway.publicUrl).toBe('https://public.example/mcp');
     expect(config.httpGateway.trustProxy).toBe(true);
+    expect(config.runtime).toEqual({
+      readOnly: true
+    });
     expect(config.cache).toEqual({
       defaultTtlMs: 2500,
       resourceTtls: {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -27,6 +27,8 @@ export const EOS_STRICT_MODE_ENV = 'EOS_STRICT_MODE';
 
 export const DEFAULT_ALLOWED_TOOL_PROFILE_ENV = 'EOS_MCP_ALLOWED_TOOL_PROFILE';
 
+export const EOS_READ_ONLY_ENV = 'EOS_READ_ONLY';
+
 export function getDefaultAllowedToolProfile(
   env: NodeJS.ProcessEnv = process.env
 ): ToolSafetyProfile {
@@ -43,4 +45,22 @@ export function getDefaultAllowedToolProfile(
   }
 
   return parsed.data;
+}
+
+
+export function isEosReadOnlyModeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[EOS_READ_ONLY_ENV];
+  if (raw === undefined || raw === null || raw.trim().length === 0) {
+    return false;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (['true', '1', 'yes'].includes(normalized)) {
+    return true;
+  }
+  if (['false', '0', 'no'].includes(normalized)) {
+    return false;
+  }
+
+  throw new Error(`Configuration invalide: ${EOS_READ_ONLY_ENV} doit être un booléen (true/false).`);
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -126,6 +126,10 @@ export interface AuditConfig {
   readonly logFile: string;
 }
 
+export interface RuntimeConfig {
+  readonly readOnly: boolean;
+}
+
 export interface CacheConfig {
   readonly defaultTtlMs: number;
   readonly resourceTtls: {
@@ -149,6 +153,7 @@ export interface AppConfig {
   readonly audit: AuditConfig;
   readonly httpGateway: HttpGatewayConfig;
   readonly cache: CacheConfig;
+  readonly runtime: RuntimeConfig;
 }
 
 interface PortSchemaOptions {
@@ -558,6 +563,7 @@ const configSchema = z
     logPretty: createOptionalBooleanSchema('LOG_PRETTY'),
     auditEnabled: createBooleanSchema('EOS_AUDIT_ENABLED', false),
     auditLogFile: createLogFileSchema('EOS_AUDIT_LOG_FILE', DEFAULT_AUDIT_LOG_FILE),
+    eosReadOnly: createBooleanSchema('EOS_READ_ONLY', false),
     httpApiKeys: createStringArraySchema('MCP_HTTP_API_KEYS', { defaultValue: [] }),
     httpMcpTokens: createStringArraySchema('MCP_HTTP_MCP_TOKENS', {
       defaultValue: [DEFAULT_HTTP_MCP_TOKEN]
@@ -677,6 +683,9 @@ const configSchema = z
           }
         }
       },
+      runtime: {
+        readOnly: values.eosReadOnly
+      },
       cache: {
         defaultTtlMs: values.cacheDefaultTtlMs,
         resourceTtls: {
@@ -719,6 +728,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
     logPretty: env.LOG_PRETTY,
     auditEnabled: env.EOS_AUDIT_ENABLED,
     auditLogFile: env.EOS_AUDIT_LOG_FILE,
+    eosReadOnly: env.EOS_READ_ONLY,
     httpApiKeys: env.MCP_HTTP_API_KEYS,
     httpMcpTokens: env.MCP_HTTP_MCP_TOKENS,
     httpIpAllowlist: env.MCP_HTTP_IP_ALLOWLIST,

--- a/src/server/__tests__/toolRegistry.test.ts
+++ b/src/server/__tests__/toolRegistry.test.ts
@@ -55,9 +55,20 @@ const createMockServer = (): McpServer & {
 };
 
 describe('ToolRegistry schema-less tools', () => {
+  const originalReadOnly = process.env.EOS_READ_ONLY;
+
   beforeEach(() => {
     mockLogger.info.mockClear();
     mockLogger.warn.mockClear();
+    delete process.env.EOS_READ_ONLY;
+  });
+
+  afterEach(() => {
+    if (originalReadOnly === undefined) {
+      delete process.env.EOS_READ_ONLY;
+    } else {
+      process.env.EOS_READ_ONLY = originalReadOnly;
+    }
   });
 
   it('invokes handlers with undefined args while preserving extra', async () => {
@@ -292,6 +303,66 @@ describe('ToolRegistry schema-less tools', () => {
     );
     expect(registry.getRegisteredSummaries()[0]?.config.metadata).toMatchObject({
       requiredRole: 'admin'
+    });
+  });
+
+
+
+  it('refuse les outils dangereux en mode EOS_READ_ONLY meme avec un role admin confirme', async () => {
+    process.env.EOS_READ_ONLY = 'true';
+    const server = createMockServer();
+    const registry = new ToolRegistry(server);
+    const handler = jest.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] }));
+
+    registry.register({
+      name: 'eos_new_command',
+      config: { inputSchema: { command: z.string(), confirm: z.boolean().optional() } },
+      metadata: { readOnly: false, riskLevel: 'high', requiresConfirmation: true },
+      handler
+    });
+
+    const [, , registeredHandler] = server.registerTool.mock.calls[0];
+
+    await expect(
+      (registeredHandler as RegisteredTestHandler)(
+        { command: 'Record Cue 1', confirm: true },
+        { requestId: 'read-only-denied', granted_role: 'admin' }
+      )
+    ).rejects.toThrow('EOS_READ_ONLY=true');
+
+    expect(handler).not.toHaveBeenCalled();
+    const [payload] = mockLogger.warn.mock.calls[0] as [Record<string, unknown>];
+    expect(payload).toMatchObject({
+      status: 'error',
+      read_only_mode: true,
+      tool_read_only: false
+    });
+  });
+
+  it('autorise les outils de diagnostic en mode EOS_READ_ONLY', async () => {
+    process.env.EOS_READ_ONLY = 'true';
+    const server = createMockServer();
+    const registry = new ToolRegistry(server);
+    const handler = jest.fn(async () => ({ content: [{ type: 'text', text: 'diagnostic ok' }] }));
+
+    registry.register({
+      name: 'eos_ping',
+      config: {},
+      metadata: { readOnly: true, riskLevel: 'low', requiresConfirmation: false },
+      handler
+    });
+
+    const [, , registeredHandler] = server.registerTool.mock.calls[0];
+    await expect(
+      (registeredHandler as RegisteredTestHandler)({ requestId: 'read-only-allowed' })
+    ).resolves.toBeDefined();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [payload] = mockLogger.info.mock.calls[0] as [Record<string, unknown>];
+    expect(payload).toMatchObject({
+      status: 'ok',
+      read_only_mode: true,
+      tool_read_only: true
     });
   });
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -7,12 +7,13 @@ import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { createLogger } from './logger';
 import { runWithRequestContext } from './requestContext';
-import { getDefaultAllowedToolProfile } from '../config/env';
+import { getDefaultAllowedToolProfile, isEosReadOnlyModeEnabled } from '../config/env';
 import {
   isToolSafetyProfileAllowed,
   toolSafetyProfileSchema,
   type ToolSafetyProfile
 } from '../tools/common/safety';
+import { classifyToolMetadata, resolveToolRequiredRole } from '../tools/common/classification';
 import type {
   ToolDefinition,
   ToolExecutionResult,
@@ -200,67 +201,9 @@ function resolveSafetyMode(args: unknown): 'strict' | 'standard' | 'off' {
 }
 
 
-const DEFAULT_TOOL_ROLE: ToolSafetyProfile = 'read_only';
-
-const EXACT_TOOL_ROLES: Readonly<Record<string, ToolSafetyProfile>> = {
-  eos_command: 'admin',
-  eos_new_command: 'admin',
-  eos_command_with_substitution: 'admin',
-  eos_cue_record: 'admin',
-  eos_cue_update: 'admin',
-  eos_cue_label_set: 'admin',
-  eos_cue_fire: 'live_playback',
-  eos_cue_go: 'live_playback',
-  eos_cue_stop_back: 'live_playback',
-  eos_patch_set_channel: 'admin',
-  eos_macro_fire: 'admin',
-  eos_macro_select: 'admin',
-  eos_snapshot_recall: 'admin',
-  eos_connect: 'read_only',
-  eos_configure: 'read_only',
-  eos_reset: 'admin',
-  eos_showfile_import: 'admin',
-  eos_set_cue_receive_string: 'admin',
-  eos_set_cue_send_string: 'admin'
-};
-
-const ROLE_PATTERNS: Array<{ pattern: RegExp; role: ToolSafetyProfile }> = [
-  { pattern: /^eos_workflow_/, role: 'admin' },
-  { pattern: /^eos_patch_.*(?:set|write|update|record|delete)/, role: 'admin' },
-  { pattern: /^eos_.*(?:record|update|delete|label_set)/, role: 'admin' },
-  { pattern: /^eos_.*(?:fire|go|stop_back|bump|set_level|load|unload|press|tick|continuous)/, role: 'live_playback' },
-  { pattern: /^eos_(?:channel|group|address|set_|palette|preset|effect|direct_select|fader|submaster)/, role: 'programming' }
-];
-
-const READ_ONLY_TOOL_PATTERNS = [
-  /^eos_.*(?:get|list|info|labels|name|state|active|pending|capabilities|ping)/,
-  /^eos_patch_get_/,
-  /^eos_get_/,
-  /^eos_readiness_check$/
-];
-
 const CONFIRMATION_ARGUMENT_KEYS = ['confirm', 'require_confirmation', 'safety_level'] as const;
 
 type ConfirmationState = 'confirmed' | 'missing' | 'not_required';
-
-function resolveToolRequiredRole(tool: ToolDefinition): ToolSafetyProfile {
-  const metadataRole = tool.metadata?.requiredRole;
-  if (metadataRole) {
-    return metadataRole;
-  }
-
-  const exactRole = EXACT_TOOL_ROLES[tool.name];
-  if (exactRole) {
-    return exactRole;
-  }
-
-  if (READ_ONLY_TOOL_PATTERNS.some((pattern) => pattern.test(tool.name))) {
-    return 'read_only';
-  }
-
-  const matched = ROLE_PATTERNS.find(({ pattern }) => pattern.test(tool.name));
-  return matched?.role ?? DEFAULT_TOOL_ROLE;
-}
 
 function resolveGrantedToolRole(extra: unknown): ToolSafetyProfile {
   const record = asObject(extra);
@@ -433,13 +376,12 @@ interface RegisteredToolSummary {
 
 
 function buildToolConfigForRegistration(tool: ToolDefinition): ToolDefinition['config'] {
-  const requiredRole = resolveToolRequiredRole(tool);
-  const requiresConfirmation = tool.metadata?.requiresConfirmation === true || requiredRole !== 'read_only';
+  const classification = classifyToolMetadata(tool);
+  const requiresConfirmation = classification.requiresConfirmation;
   const baseConfig = withConfirmationInputSchema(withGlobalConsoleTargetInputSchema(tool), requiresConfirmation);
   const metadata = {
     ...(tool.metadata ?? {}),
-    requiredRole,
-    requiresConfirmation
+    ...classification
   };
   const { annotations: metadataAnnotations, ...metadataFields } = metadata;
   return {
@@ -476,14 +418,13 @@ class ToolRegistry {
     }) as never;
 
     const config = buildToolConfigForRegistration(tool);
-    const requiredRole = resolveToolRequiredRole(tool);
+    const classification = classifyToolMetadata(tool);
     const registeredTool = {
       ...tool,
       config,
       metadata: {
         ...(tool.metadata ?? {}),
-        requiredRole,
-        requiresConfirmation: tool.metadata?.requiresConfirmation === true || requiredRole !== 'read_only'
+        ...classification
       }
     };
 
@@ -617,6 +558,15 @@ class ToolRegistry {
     const compatibilityStatus = evaluateToolCompatibility(toolName, compatibilityContext);
 
     try {
+      const classification = classifyToolMetadata(tool);
+      const readOnlyMode = isEosReadOnlyModeEnabled();
+
+      if (readOnlyMode && !classification.readOnly) {
+        throw new Error(
+          `Outil ${toolName} refuse: EOS_READ_ONLY=true autorise uniquement les outils de lecture ou de diagnostic.`
+        );
+      }
+
       if (!isToolSafetyProfileAllowed(grantedRole, requiredRole)) {
         throw new Error(
           `Outil ${toolName} refuse: profil requis ${requiredRole}, profil accorde ${grantedRole}.`
@@ -671,6 +621,8 @@ class ToolRegistry {
         required_role: requiredRole,
         granted_role: grantedRole,
         confirmation_state: confirmationState,
+        read_only_mode: isEosReadOnlyModeEnabled(),
+        tool_read_only: classifyToolMetadata(tool).readOnly,
         compatibility: compatibilityStatus,
         durationMs: Date.now() - startedAt,
         status: 'ok'
@@ -712,6 +664,8 @@ class ToolRegistry {
         required_role: requiredRole,
         granted_role: grantedRole,
         confirmation_state: confirmationState,
+        read_only_mode: isEosReadOnlyModeEnabled(),
+        tool_read_only: classifyToolMetadata(tool).readOnly,
         compatibility: compatibilityStatus,
         durationMs: Date.now() - startedAt,
         status: 'error'

--- a/src/tools/__tests__/read_only_catalog.test.ts
+++ b/src/tools/__tests__/read_only_catalog.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { toolDefinitions } from '../index';
+
+describe('tool catalog read-only classification', () => {
+  it('classifie chaque outil avec readOnly, riskLevel et requiresConfirmation', () => {
+    for (const tool of toolDefinitions) {
+      expect(tool.metadata).toEqual(expect.objectContaining({
+        readOnly: expect.any(Boolean),
+        riskLevel: expect.stringMatching(/^(low|medium|high|critical)$/),
+        requiresConfirmation: expect.any(Boolean)
+      }));
+      expect(tool.config.annotations).toEqual(expect.objectContaining({
+        readOnly: tool.metadata?.readOnly,
+        riskLevel: tool.metadata?.riskLevel,
+        requiresConfirmation: tool.metadata?.requiresConfirmation
+      }));
+    }
+  });
+
+  it('marque les outils de commande console comme non lecture seule', () => {
+    const dangerousNames = ['eos_command', 'eos_new_command', 'eos_cue_go', 'eos_patch_set_channel'];
+
+    for (const toolName of dangerousNames) {
+      const tool = toolDefinitions.find((candidate) => candidate.name === toolName);
+      expect(tool?.metadata).toEqual(expect.objectContaining({ readOnly: false }));
+    }
+  });
+});

--- a/src/tools/common/classification.ts
+++ b/src/tools/common/classification.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Florian Ribes (NairolfConcept)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { ToolDefinition, ToolMetadata, ToolRiskLevel } from '../types';
+import { resolveRiskLevelForSafetyProfile, type ToolSafetyProfile } from './safety';
+
+const DEFAULT_TOOL_ROLE: ToolSafetyProfile = 'read_only';
+
+const EXACT_TOOL_ROLES: Readonly<Record<string, ToolSafetyProfile>> = {
+  eos_command: 'admin',
+  eos_new_command: 'admin',
+  eos_command_with_substitution: 'admin',
+  eos_cue_record: 'admin',
+  eos_cue_update: 'admin',
+  eos_cue_label_set: 'admin',
+  eos_cue_fire: 'live_playback',
+  eos_cue_go: 'live_playback',
+  eos_cue_stop_back: 'live_playback',
+  eos_patch_set_channel: 'admin',
+  eos_macro_fire: 'admin',
+  eos_macro_select: 'admin',
+  eos_snapshot_recall: 'admin',
+  eos_connect: 'read_only',
+  eos_configure: 'read_only',
+  eos_reset: 'admin',
+  eos_showfile_import: 'admin',
+  eos_set_cue_receive_string: 'admin',
+  eos_set_cue_send_string: 'admin'
+};
+
+const ROLE_PATTERNS: Array<{ pattern: RegExp; role: ToolSafetyProfile }> = [
+  { pattern: /^eos_workflow_/, role: 'admin' },
+  { pattern: /^eos_patch_.*(?:set|write|update|record|delete)/, role: 'admin' },
+  { pattern: /^eos_.*(?:record|update|delete|label_set)/, role: 'admin' },
+  { pattern: /^eos_.*(?:fire|go|stop_back|bump|set_level|load|unload|press|tick|continuous)/, role: 'live_playback' },
+  { pattern: /^eos_(?:channel|group|address|set_|palette|preset|effect|direct_select|fader|submaster)/, role: 'programming' }
+];
+
+const READ_ONLY_TOOL_PATTERNS = [
+  /^eos_.*(?:get|list|info|labels|name|state|active|pending|capabilities|ping)/,
+  /^eos_patch_get_/,
+  /^eos_get_/,
+  /^eos_readiness_check$/
+];
+
+export function resolveToolRequiredRole(tool: Pick<ToolDefinition, 'name' | 'metadata'>): ToolSafetyProfile {
+  const metadataRole = tool.metadata?.requiredRole;
+  if (metadataRole) {
+    return metadataRole;
+  }
+
+  const exactRole = EXACT_TOOL_ROLES[tool.name];
+  if (exactRole) {
+    return exactRole;
+  }
+
+  if (READ_ONLY_TOOL_PATTERNS.some((pattern) => pattern.test(tool.name))) {
+    return 'read_only';
+  }
+
+  const matched = ROLE_PATTERNS.find(({ pattern }) => pattern.test(tool.name));
+  return matched?.role ?? DEFAULT_TOOL_ROLE;
+}
+
+export function classifyToolMetadata(tool: ToolDefinition): Required<Pick<ToolMetadata, 'readOnly' | 'riskLevel' | 'requiresConfirmation' | 'requiredRole'>> {
+  const requiredRole = resolveToolRequiredRole(tool);
+  const readOnly = tool.metadata?.readOnly ?? requiredRole === 'read_only';
+  const existingRiskLevel = tool.metadata?.riskLevel;
+  const riskLevel: ToolRiskLevel = existingRiskLevel ?? resolveRiskLevelForSafetyProfile(requiredRole, {
+    critical: existingRiskLevel === 'critical'
+  });
+  const requiresConfirmation = tool.metadata?.requiresConfirmation ?? !readOnly;
+
+  return {
+    readOnly,
+    riskLevel,
+    requiresConfirmation,
+    requiredRole
+  };
+}

--- a/src/tools/common/safety.ts
+++ b/src/tools/common/safety.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { z, type ZodRawShape } from 'zod';
-import { buildToolResult, type ToolExecutionResult } from '../types';
+import { buildToolResult, type ToolExecutionResult, type ToolRiskLevel } from '../types';
 
 export const safetyLevelSchema = z.enum(['strict', 'standard', 'off']);
 
@@ -26,6 +26,27 @@ export function isToolSafetyProfileAllowed(
   requiredProfile: ToolSafetyProfile
 ): boolean {
   return compareToolSafetyProfiles(grantedProfile, requiredProfile) >= 0;
+}
+
+
+export function resolveRiskLevelForSafetyProfile(
+  requiredProfile: ToolSafetyProfile,
+  options: { critical?: boolean } = {}
+): ToolRiskLevel {
+  if (options.critical) {
+    return 'critical';
+  }
+
+  switch (requiredProfile) {
+    case 'read_only':
+      return 'low';
+    case 'programming':
+      return 'medium';
+    case 'live_playback':
+      return 'high';
+    case 'admin':
+      return 'high';
+  }
 }
 
 export const safetyOptionsSchema = {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -38,6 +38,7 @@ import sessionTools from './session/index';
 import programmingTools from './programming/index';
 import workflowTools from './workflows/index';
 import { buildOscToolStrictModePolicy } from '../services/osc/messageBuilders';
+import { classifyToolMetadata } from './common/classification';
 import type { ToolDefinition } from './types';
 
 const rawDefinitions = [
@@ -91,13 +92,23 @@ function collectOscAddresses(value: unknown): string[] {
   return [];
 }
 
-function withStrictOscPolicy(tool: ToolDefinition): ToolDefinition {
+function withCatalogMetadata(tool: ToolDefinition): ToolDefinition {
+  const classification = classifyToolMetadata(tool);
   const mapping = tool.config.annotations?.mapping as { osc?: unknown } | undefined;
-  const requiresConfirmation = tool.metadata?.requiresConfirmation === true;
+  const requiresConfirmation = classification.requiresConfirmation;
   const policy = buildOscToolStrictModePolicy({
     oscAddresses: collectOscAddresses(mapping?.osc),
     requiresConfirmation
   });
+  const metadata = {
+    ...(tool.metadata ?? {}),
+    ...classification,
+    nativeOscPreferred: policy.nativeOscPreferred,
+    cmdFallbackAllowed: policy.cmdFallbackAllowed,
+    requiresConfirmation: policy.requiresConfirmation,
+    strictModeBehavior: policy.strictModeBehavior
+  };
+  const { annotations: metadataAnnotations, ...annotationMetadata } = metadata;
 
   return {
     ...tool,
@@ -105,24 +116,16 @@ function withStrictOscPolicy(tool: ToolDefinition): ToolDefinition {
       ...tool.config,
       annotations: {
         ...(tool.config.annotations ?? {}),
-        nativeOscPreferred: policy.nativeOscPreferred,
-        cmdFallbackAllowed: policy.cmdFallbackAllowed,
-        requiresConfirmation: policy.requiresConfirmation,
-        strictModeBehavior: policy.strictModeBehavior,
+        ...(metadataAnnotations ?? {}),
+        ...annotationMetadata,
         oscStrictModePolicy: policy
       }
     },
-    metadata: {
-      ...(tool.metadata ?? {}),
-      nativeOscPreferred: policy.nativeOscPreferred,
-      cmdFallbackAllowed: policy.cmdFallbackAllowed,
-      requiresConfirmation: policy.requiresConfirmation,
-      strictModeBehavior: policy.strictModeBehavior
-    }
+    metadata
   };
 }
 
-const definitions = rawDefinitions.map((tool) => withStrictOscPolicy(tool as ToolDefinition));
+const definitions = rawDefinitions.map((tool) => withCatalogMetadata(tool as ToolDefinition));
 
 export const toolDefinitions = definitions as ToolDefinition[];
 

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -184,6 +184,7 @@ export type ToolRiskLevel = 'low' | 'medium' | 'high' | 'critical';
 
 export interface ToolMetadata {
   annotations?: Record<string, unknown>;
+  readOnly?: boolean;
   category?: string;
   synonyms?: string[];
   riskLevel?: ToolRiskLevel;


### PR DESCRIPTION
### Motivation
- Introduce a global read-only runtime mode (`EOS_READ_ONLY`) that restricts the MCP to observation/diagnostic tools when enabled.
- Ensure each MCP tool carries explicit safety metadata (`readOnly`, `riskLevel`, `requiresConfirmation`) so the registry and clients can decide what to allow in read-only or constrained environments.

### Description
- Add `EOS_READ_ONLY` parsing helper and runtime exposure (`runtime.readOnly`) in configuration (`src/config/env.ts`, `src/config/index.ts`).
- Centralize tool safety classification in a new module `src/tools/common/classification.ts` which derives `requiredRole`, `readOnly`, `riskLevel` and `requiresConfirmation`; wire that classification into the catalog generation in `src/tools/index.ts` and into `ToolMetadata` shape (`src/tools/types.ts`).
- Enforce read-only mode in the tool registry (`src/server/toolRegistry.ts`): when `EOS_READ_ONLY=true` any tool classified as non-read-only is refused (even with an admin grant or explicit confirmation), and audit logs include `read_only_mode` and `tool_read_only` flags.
- Add a small helper to resolve sensible default `riskLevel` from tool roles (`src/tools/common/safety.ts`) and propagate security annotations into generated tool catalog entries and schemas (`docs/tools.md` regenerated).
- Tests and docs: add unit tests `src/tools/__tests__/read_only_catalog.test.ts` and update `src/server/__tests__/toolRegistry.test.ts` to cover enforcement behavior; document the mode in `README.md` and regenerate `docs/tools.md`.

### Testing
- Ran TypeScript compilation with `npm run tsc` which succeeded. (OK)
- Executed focused Jest suites with `npx jest --passWithNoTests src/server/__tests__/toolRegistry.test.ts src/config/__tests__/config.test.ts src/tools/__tests__/read_only_catalog.test.ts` which all passed. (OK)
- Regenerated docs with `npm run docs:generate` and verified with `npm run docs:check`; documentation check passed after generation. (OK)
- Ran linter and manifest validation (`npm run lint`, `npm run lint:manifest`) during the rollout and fixed issues; lint and manifest checks passed. (OK)
- Executed full test matrix with `npm test -- --runInBand` which ran the unit and conformance suites; all test suites passed (62 suites, 639 tests in total) and the EOS conformance integration passed. (OK)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2441cad6bc832aa1373aa1edb53e51)