### PR TITLE
docs: add live safety checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Formats à utiliser selon le langage :
 - [Guide agent LLM](docs/llm-agent-guide.md) : règles de conduite pour assistants IA, exemples dry-run/confirmation et table d’orientation outil par intention utilisateur.
 - [Dépannage OSC Eos](docs/troubleshooting-osc-eos.md) : checklist réseau/OSC et règles de fallback showfile lorsque les lectures live ne sont pas fiables.
 - [Configuration réseau Eos MCP](docs/network-setup.md) : topologie Wi-Fi Internet + Ethernet console Eos sans bridge, sans partage Internet et avec sous-réseaux séparés.
+- [Checklist de sécurité live](docs/live-safety-checklist.md) : contrôles obligatoires avant connexion à une console de production et liste des commandes dangereuses à confirmer.
 - [Architecture technique](docs/architecture.md) : diagrammes du flux MCP → OSC, composants internes et guide “où modifier quoi” pour contribuer.
 - [`docs/tools.md`](docs/tools.md) : référence exhaustive générée automatiquement pour chaque outil MCP.
 - [Ajouter un outil MCP](docs/adding-a-tool.md) : procédure contributeur pour créer une famille d’outils, déclarer les mappings OSC, écrire les schémas Zod, tester et régénérer la référence.

--- a/docs/live-safety-checklist.md
+++ b/docs/live-safety-checklist.md
@@ -1,0 +1,32 @@
+# Checklist de sécurité live
+
+Cette checklist doit être relue avant toute connexion d'Eos MCP à une console Eos de production ou à un réseau lumière utilisé en répétition, balance, filage ou représentation.
+
+## Avant toute commande live
+
+- [ ] Tester d'abord le scénario avec **Eos Nomad** ou en mode **offline**, sans console de production connectée.
+- [ ] Vérifier l'adresse IP de la console et confirmer que `OSC_REMOTE_ADDRESS` pointe vers la bonne machine.
+- [ ] Vérifier les ports OSC côté Eos et côté Eos MCP (`OSC_UDP_OUT_PORT`, `OSC_UDP_IN_PORT`) ainsi que les règles firewall UDP associées.
+- [ ] Activer le **mode strict** afin de bloquer les commandes ambiguës, incomplètes ou non conformes à la politique d'exploitation.
+- [ ] Activer les **confirmations** pour empêcher toute exécution réelle sans validation explicite.
+- [ ] Utiliser `dry_run` pour tous les workflows avant exécution, puis comparer la prévisualisation avec l'intention opérateur.
+- [ ] Ne pas exposer le serveur MCP publiquement sur Internet ou sur un réseau non maîtrisé.
+- [ ] Ne pas créer de bridge entre Wi-Fi et Ethernet, et ne pas activer le partage Internet entre le réseau bureautique et le réseau lumière.
+- [ ] Sauvegarder le show avant les tests afin de pouvoir revenir rapidement à l'état précédent.
+- [ ] Prévenir l'opérateur console avant toute commande live et attendre son accord explicite.
+
+## Commandes dangereuses
+
+Les commandes suivantes sont considérées comme **dangereuses en live**. Elles doivent toujours respecter le pattern **Plan → dry-run → confirmation → exécution**, avec validation par l'opérateur console :
+
+- **Go** : déclenchement de cue ou d'état scénique visible.
+- **Record** : écriture ou remplacement de données du show.
+- **Update** : modification de cues, presets, palettes ou états enregistrés.
+- **Delete** : suppression d'éléments du show.
+- **Patch** : modification du patch, des adresses, des types de projecteurs ou des affectations.
+- **Macro Fire** : déclenchement de macro pouvant chaîner plusieurs actions.
+- **Submaster** : changement de niveau, flash ou contrôle de submaster.
+- **Park** : forçage ou libération d'états parkés.
+- **Commande texte libre** : toute commande envoyée sous forme textuelle non spécialisée, car son effet dépend directement de l'interpréteur Eos.
+
+En cas de doute sur l'effet d'une commande, rester en `dry_run`, demander une confirmation humaine et ne jamais exécuter pendant un moment critique du show.


### PR DESCRIPTION
### Motivation
- Formaliser et centraliser les contrôles de sécurité à effectuer avant toute connexion d'Eos MCP à une console en production ou en répétition. 
- Rappeler et expliciter les commandes considérées dangereuses en live afin d'imposer le pattern de sécurité `Plan → dry-run → confirmation → exécution`.

### Description
- Ajout du fichier `docs/live-safety-checklist.md` contenant la checklist pré-live (Eos Nomad/offline, vérification IP, ports OSC, mode strict, confirmations, `dry_run`, non-exposition publique, pas de bridge Wi‑Fi/Ethernet, sauvegarde du show, coordination opérateur). 
- Ajout d'une section listant les commandes dangereuses en live : `Go`, `Record`, `Update`, `Delete`, `Patch`, `Macro Fire`, `Submaster`, `Park` et « commande texte libre ». 
- Lien ajouté dans le sommaire de la documentation du `README.md` vers `docs/live-safety-checklist.md`.

### Testing
- Vérification automatique par recherche que les entrées attendues sont présentes avec `rg -n "live-safety|Checklist de sécurité live|Go|Commande texte libre" README.md docs/live-safety-checklist.md`, qui a retourné les correspondances attendues. 
- Vérification que les fichiers modifiés ont été ajoutés et commités (tracked) via `git status --short` and commit created successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a246706fa5c832a91e37ed1eed03834)